### PR TITLE
Rename `BLOCK_ID` to `BRICK_ID` and exclude `scripts/bin` from IDE search

### DIFF
--- a/pixiebrix-extension.iml
+++ b/pixiebrix-extension.iml
@@ -7,6 +7,7 @@
       <excludeFolder url="file://$MODULE_DIR$/dist" />
       <excludeFolder url="file://$MODULE_DIR$/coverage" />
       <excludeFolder url="file://$MODULE_DIR$/storybook-static" />
+      <excludeFolder url="file://$MODULE_DIR$/scripts/bin" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/src/analysis/analysisVisitors/conditionAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/conditionAnalysis.test.ts
@@ -27,7 +27,7 @@ describe("conditionAnalysis", () => {
   it("no warning for unset field", async () => {
     const formState = triggerFormStateFactory({}, [
       {
-        id: ContextBrick.BLOCK_ID,
+        id: ContextBrick.BRICK_ID,
         config: {},
         outputKey: validateOutputKey("foo"),
       },
@@ -42,7 +42,7 @@ describe("conditionAnalysis", () => {
   it("warning for blank value", async () => {
     const formState = triggerFormStateFactory({}, [
       {
-        id: ContextBrick.BLOCK_ID,
+        id: ContextBrick.BRICK_ID,
         config: {},
         if: toExpression("nunjucks", " "),
         outputKey: validateOutputKey("foo"),
@@ -69,7 +69,7 @@ describe("conditionAnalysis", () => {
   it.each([true, false])("info for boolean literal", async (value) => {
     const formState = triggerFormStateFactory({}, [
       {
-        id: ContextBrick.BLOCK_ID,
+        id: ContextBrick.BRICK_ID,
         config: {},
         if: value,
         outputKey: validateOutputKey("foo"),
@@ -89,7 +89,7 @@ describe("conditionAnalysis", () => {
   it.each(["y", "f"])("info for template literal", async (value) => {
     const formState = triggerFormStateFactory({}, [
       {
-        id: ContextBrick.BLOCK_ID,
+        id: ContextBrick.BRICK_ID,
         config: {},
         if: toExpression("nunjucks", value),
         outputKey: validateOutputKey("foo"),

--- a/src/analysis/analysisVisitors/httpRequestAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/httpRequestAnalysis.test.ts
@@ -33,7 +33,7 @@ describe("httpRequestAnalysis", () => {
     analysis.visitBrick(
       position,
       {
-        id: RemoteMethod.BLOCK_ID,
+        id: RemoteMethod.BRICK_ID,
         config: {
           method: "get",
           url: "https://example.com/?foo=42",
@@ -59,7 +59,7 @@ describe("httpRequestAnalysis", () => {
     analysis.visitBrick(
       position,
       {
-        id: RemoteMethod.BLOCK_ID,
+        id: RemoteMethod.BRICK_ID,
         config: {
           method: "get",
           url: toExpression("nunjucks", "https://example.com/?foo={{ @foo }}"),
@@ -76,7 +76,7 @@ describe("httpRequestAnalysis", () => {
     analysis.visitBrick(
       position,
       {
-        id: RemoteMethod.BLOCK_ID,
+        id: RemoteMethod.BRICK_ID,
         config: {
           method: "get",
           url: "https://example.com",
@@ -105,7 +105,7 @@ describe("httpRequestAnalysis", () => {
     analysis.visitBrick(
       position,
       {
-        id: RemoteMethod.BLOCK_ID,
+        id: RemoteMethod.BRICK_ID,
         config: {
           method: "post",
           url: "https://example.com",
@@ -137,7 +137,7 @@ describe("httpRequestAnalysis", () => {
     analysis.visitBrick(
       position,
       {
-        id: RemoteMethod.BLOCK_ID,
+        id: RemoteMethod.BRICK_ID,
         config: {
           method: "post",
           url: "https://example.com",
@@ -160,7 +160,7 @@ describe("httpRequestAnalysis", () => {
     analysis.visitBrick(
       position,
       {
-        id: RemoteMethod.BLOCK_ID,
+        id: RemoteMethod.BRICK_ID,
         config: {
           method: "get",
           url: "https://example.com",
@@ -189,7 +189,7 @@ describe("httpRequestAnalysis", () => {
     analysis.visitBrick(
       position,
       {
-        id: RemoteMethod.BLOCK_ID,
+        id: RemoteMethod.BRICK_ID,
         config: {
           method: "get",
           url: "https://example.com",
@@ -209,7 +209,7 @@ describe("httpRequestAnalysis", () => {
     analysis.visitBrick(
       position,
       {
-        id: RemoteMethod.BLOCK_ID,
+        id: RemoteMethod.BRICK_ID,
         config: {
           method: "post",
           url: "https://example.com",

--- a/src/analysis/analysisVisitors/httpRequestAnalysis.ts
+++ b/src/analysis/analysisVisitors/httpRequestAnalysis.ts
@@ -53,7 +53,7 @@ class HttpRequestAnalysis extends AnalysisVisitorABC {
   ) {
     super.visitBrick(position, blockConfig, extra);
 
-    if (blockConfig.id !== RemoteMethod.BLOCK_ID) {
+    if (blockConfig.id !== RemoteMethod.BRICK_ID) {
       return;
     }
 

--- a/src/analysis/analysisVisitors/outputKeyAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/outputKeyAnalysis.test.ts
@@ -26,7 +26,7 @@ describe("outputKeyAnalysis", () => {
   it("no warning", async () => {
     const formState = triggerFormStateFactory({}, [
       {
-        id: ContextBrick.BLOCK_ID,
+        id: ContextBrick.BRICK_ID,
         config: {},
         outputKey: validateOutputKey("foo"),
       },
@@ -42,7 +42,7 @@ describe("outputKeyAnalysis", () => {
     const formState = triggerFormStateFactory({}, [
       // Syntactically it's a valid output key
       {
-        id: ContextBrick.BLOCK_ID,
+        id: ContextBrick.BRICK_ID,
         config: {},
         outputKey: validateOutputKey(name),
       },

--- a/src/analysis/analysisVisitors/requestPermissionAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/requestPermissionAnalysis.test.ts
@@ -29,7 +29,7 @@ function brickModComponentFactory(url: string) {
   const formState = triggerFormStateFactory();
   formState.modComponent.brickPipeline = [
     brickConfigFactory({
-      id: RemoteMethod.BLOCK_ID,
+      id: RemoteMethod.BRICK_ID,
       config: {
         url: toExpression("nunjucks", url),
       },

--- a/src/analysis/analysisVisitors/requestPermissionAnalysis.ts
+++ b/src/analysis/analysisVisitors/requestPermissionAnalysis.ts
@@ -55,7 +55,7 @@ class RequestPermissionAnalysis extends AnalysisVisitorABC {
     // Analyze the known blocks that make external HTTP request
     if (
       !(
-        blockConfig.id === RemoteMethod.BLOCK_ID ||
+        blockConfig.id === RemoteMethod.BRICK_ID ||
         blockConfig.id === GetAPITransformer.BRICK_ID
       ) ||
       blockConfig.config.service != null

--- a/src/analysis/analysisVisitors/templateAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/templateAnalysis.test.ts
@@ -31,7 +31,7 @@ function httpBrickModComponentFactory(expression: Expression<unknown>) {
   const formState = triggerFormStateFactory();
   formState.modComponent.brickPipeline = [
     brickConfigFactory({
-      id: RemoteMethod.BLOCK_ID,
+      id: RemoteMethod.BRICK_ID,
       config: {
         url: expression,
       },

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -1181,7 +1181,7 @@ describe("Invalid template", () => {
 
   beforeEach(() => {
     const invalidEchoBlock = {
-      id: EchoBrick.BLOCK_ID,
+      id: EchoBrick.BRICK_ID,
       config: {
         message: toExpression(
           "nunjucks",
@@ -1190,7 +1190,7 @@ describe("Invalid template", () => {
       },
     };
     const validEchoBlock = {
-      id: EchoBrick.BLOCK_ID,
+      id: EchoBrick.BRICK_ID,
       config: {
         message: toExpression(
           "nunjucks",
@@ -1230,7 +1230,7 @@ describe("var expression annotations", () => {
           outputKey: validateOutputKey("foo"),
         }),
         {
-          id: EchoBrick.BLOCK_ID,
+          id: EchoBrick.BRICK_ID,
           config: {
             message: toExpression("var", "@foo"),
           },
@@ -1248,7 +1248,7 @@ describe("var expression annotations", () => {
     const formState = formStateFactory({
       brickPipeline: [
         {
-          id: EchoBrick.BLOCK_ID,
+          id: EchoBrick.BRICK_ID,
           config: {
             message: toExpression("var", ""),
           },
@@ -1266,7 +1266,7 @@ describe("var expression annotations", () => {
     const formState = formStateFactory({
       brickPipeline: [
         {
-          id: EchoBrick.BLOCK_ID,
+          id: EchoBrick.BRICK_ID,
           config: {
             message: toExpression("var", "foo"),
           },
@@ -1288,7 +1288,7 @@ describe("var expression annotations", () => {
     const formState = formStateFactory({
       brickPipeline: [
         {
-          id: EchoBrick.BLOCK_ID,
+          id: EchoBrick.BRICK_ID,
           config: {
             message: toExpression("var", "  "),
           },
@@ -1308,7 +1308,7 @@ describe("var expression annotations", () => {
     const formState = formStateFactory({
       brickPipeline: [
         {
-          id: EchoBrick.BLOCK_ID,
+          id: EchoBrick.BRICK_ID,
           config: {
             message: toExpression("var", "@"),
           },
@@ -1329,7 +1329,7 @@ describe("var analysis integration tests", () => {
   it("should handle trigger event", async () => {
     const formState = triggerFormStateFactory(undefined, [
       {
-        id: EchoBrick.BLOCK_ID,
+        id: EchoBrick.BRICK_ID,
         config: {
           message: toExpression(
             "nunjucks",
@@ -1351,7 +1351,7 @@ describe("var analysis integration tests", () => {
   it("should handle trigger custom event", async () => {
     const formState = triggerFormStateFactory(undefined, [
       {
-        id: EchoBrick.BLOCK_ID,
+        id: EchoBrick.BRICK_ID,
         config: {
           message: toExpression(
             "nunjucks",
@@ -1373,7 +1373,7 @@ describe("var analysis integration tests", () => {
   it("should handle trigger selectionchange event", async () => {
     const formState = triggerFormStateFactory(undefined, [
       {
-        id: EchoBrick.BLOCK_ID,
+        id: EchoBrick.BRICK_ID,
         config: {
           message: toExpression(
             "nunjucks",

--- a/src/bricks/effects/AddQuickBarAction.tsx
+++ b/src/bricks/effects/AddQuickBarAction.tsx
@@ -68,11 +68,11 @@ const DEFAULT_PRIORITY = 1;
  * @see QuickBarProviderExtensionPoint
  */
 class AddQuickBarAction extends EffectABC {
-  static BLOCK_ID = validateRegistryId("@pixiebrix/quickbar/add");
+  static BRICK_ID = validateRegistryId("@pixiebrix/quickbar/add");
 
   constructor() {
     super(
-      AddQuickBarAction.BLOCK_ID,
+      AddQuickBarAction.BRICK_ID,
       "Add Quick Bar Action",
       "Add an action to the PixieBrix Quick Bar",
     );

--- a/src/bricks/effects/tourEffect.ts
+++ b/src/bricks/effects/tourEffect.ts
@@ -38,10 +38,10 @@ type Step = {
 };
 
 export class TourEffect extends EffectABC {
-  static readonly BLOCK_ID = validateRegistryId("@pixiebrix/tour");
+  static readonly BRICK_ID = validateRegistryId("@pixiebrix/tour");
 
   constructor() {
-    super(TourEffect.BLOCK_ID, "Show Tour", "Show step-by-step tour");
+    super(TourEffect.BRICK_ID, "Show Tour", "Show step-by-step tour");
   }
 
   override async isRootAware(): Promise<boolean> {

--- a/src/bricks/transformers/remoteMethod.ts
+++ b/src/bricks/transformers/remoteMethod.ts
@@ -65,11 +65,11 @@ export const inputProperties: Record<string, Schema> = {
 };
 
 export class RemoteMethod extends TransformerABC {
-  static BLOCK_ID = validateRegistryId("@pixiebrix/http");
+  static BRICK_ID = validateRegistryId("@pixiebrix/http");
 
   constructor() {
     super(
-      RemoteMethod.BLOCK_ID,
+      RemoteMethod.BRICK_ID,
       "HTTP Request",
       "Send an RESTful HTTP request, i.e., GET, PUT, POST, PATCH, DELETE",
     );

--- a/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
+++ b/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
@@ -333,7 +333,7 @@ describe("DisplayTemporaryInfo", () => {
       config: {
         title: "Test Temp Panel",
         body: toExpression("pipeline", [
-          { id: ContextBrick.BLOCK_ID, config: {} },
+          { id: ContextBrick.BRICK_ID, config: {} },
           { id: renderer.id, config },
         ]),
         location: "panel",

--- a/src/components/form/makeFieldActionForAnnotationAction.test.tsx
+++ b/src/components/form/makeFieldActionForAnnotationAction.test.tsx
@@ -33,7 +33,7 @@ describe("makeFieldActionForAnnotationAction", () => {
 
     const formState = triggerFormStateFactory(undefined, [
       {
-        id: ContextBrick.BLOCK_ID,
+        id: ContextBrick.BRICK_ID,
         config: {},
         if: toExpression("nunjucks", " "),
         outputKey: validateOutputKey("foo"),

--- a/src/pageEditor/tabs/editTab/editHelpers.test.ts
+++ b/src/pageEditor/tabs/editTab/editHelpers.test.ts
@@ -152,9 +152,9 @@ describe("generateFreshOutputKey", () => {
 
   it("should default to output for transformer", async () => {
     class TransformerBrick extends TransformerABC {
-      static BLOCK_ID = validateRegistryId("test/transformer");
+      static BRICK_ID = validateRegistryId("test/transformer");
       constructor() {
-        super(TransformerBrick.BLOCK_ID, "Transformer Brick");
+        super(TransformerBrick.BRICK_ID, "Transformer Brick");
       }
 
       inputSchema = {};
@@ -192,9 +192,9 @@ describe("generateFreshOutputKey", () => {
 
   it("should return undefined for effect", async () => {
     class EffectBrick extends EffectABC {
-      static BLOCK_ID = validateRegistryId("test/effect");
+      static BRICK_ID = validateRegistryId("test/effect");
       constructor() {
-        super(EffectBrick.BLOCK_ID, "Effect Brick");
+        super(EffectBrick.BRICK_ID, "Effect Brick");
       }
 
       inputSchema = {};

--- a/src/runtime/pipelineTests/pipelineTestHelpers.ts
+++ b/src/runtime/pipelineTests/pipelineTestHelpers.ts
@@ -20,12 +20,12 @@ import { propertiesToSchema } from "@/utils/schemaUtils";
  * A test helper brick that returns and stores the BrickOptions.context.
  */
 export class ContextBrick extends BrickABC {
-  static BLOCK_ID = validateRegistryId("test/context");
+  static BRICK_ID = validateRegistryId("test/context");
 
   static contexts: UnknownObject[] = [];
 
   constructor() {
-    super(ContextBrick.BLOCK_ID, "Return Context");
+    super(ContextBrick.BRICK_ID, "Return Context");
   }
 
   static clearContexts() {
@@ -44,12 +44,12 @@ export class ContextBrick extends BrickABC {
  * A test helper brick that returns and stores the brick options it was called with.
  */
 export class OptionsBrick extends BrickABC {
-  static BLOCK_ID = validateRegistryId("test/options");
+  static BRICK_ID = validateRegistryId("test/options");
 
   static options: BrickOptions[] = [];
 
   constructor() {
-    super(OptionsBrick.BLOCK_ID, "Return Options");
+    super(OptionsBrick.BRICK_ID, "Return Options");
   }
 
   static clearOptions() {
@@ -68,9 +68,9 @@ export class OptionsBrick extends BrickABC {
  * A test helper brick that echos a message.
  */
 export class EchoBrick extends BrickABC {
-  static BLOCK_ID = validateRegistryId("test/echo");
+  static BRICK_ID = validateRegistryId("test/echo");
   constructor() {
-    super(EchoBrick.BLOCK_ID, "Echo Brick");
+    super(EchoBrick.BRICK_ID, "Echo Brick");
   }
 
   inputSchema = propertiesToSchema(
@@ -88,10 +88,10 @@ export class EchoBrick extends BrickABC {
 }
 
 export class DeferredEchoBrick extends BrickABC {
-  static BLOCK_ID = validateRegistryId("test/deferred");
+  static BRICK_ID = validateRegistryId("test/deferred");
   readonly promiseOrFactory: Promise<unknown> | (() => Promise<unknown>);
   constructor(promiseOrFactory: Promise<unknown> | (() => Promise<unknown>)) {
-    super(DeferredEchoBrick.BLOCK_ID, "Deferred Brick");
+    super(DeferredEchoBrick.BRICK_ID, "Deferred Brick");
     this.promiseOrFactory = promiseOrFactory;
   }
 

--- a/src/testUtils/factories/traceFactories.ts
+++ b/src/testUtils/factories/traceFactories.ts
@@ -26,7 +26,7 @@ import { type RenderedArgs } from "@/types/runtimeTypes";
 import { type BrickConfig } from "@/bricks/types";
 import { validateRegistryId } from "@/types/helpers";
 
-const TEST_BLOCK_ID = validateRegistryId("testing/block-id");
+const TEST_BRICK_ID = validateRegistryId("testing/block-id");
 
 export const traceRecordFactory = define<TraceRecord>({
   timestamp: timestampFactory,
@@ -38,7 +38,7 @@ export const traceRecordFactory = define<TraceRecord>({
   // XXX: callId should be derived from branches
   callId: objectHash([]),
   brickInstanceId: uuidSequence,
-  brickId: TEST_BLOCK_ID,
+  brickId: TEST_BRICK_ID,
   templateContext(): TraceRecord["templateContext"] {
     return {};
   },
@@ -48,7 +48,7 @@ export const traceRecordFactory = define<TraceRecord>({
   renderError: null,
   brickConfig(): BrickConfig {
     return {
-      id: TEST_BLOCK_ID,
+      id: TEST_BRICK_ID,
       config: {},
     };
   },


### PR DESCRIPTION
## What does this PR do?

- Rename BLOCK_ID to BRICK_ID
- Exclude `scripts/bin` from search

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
