### PR TITLE
#8853: mod editor pane metadata e2e tests

### DIFF
--- a/end-to-end-tests/tests/pageEditor/modEditorPane.spec.ts-snapshots/mod-editor-pane-behavior/updated-metadata.diff
+++ b/end-to-end-tests/tests/pageEditor/modEditorPane.spec.ts-snapshots/mod-editor-pane-behavior/updated-metadata.diff
@@ -1,0 +1,60 @@
+Index: updated-metadata
+===================================================================
+--- updated-metadata
++++ updated-metadata
+@@ -23,52 +23,52 @@
+       body:
+         - config:
+             body:
+               - children:
+                   - children:
+                       - children:
+                           - config:
+                               heading: h1
+                               title: !nunjucks Simple Sidebar Panel
+                             type: header
+                         config: {}
+                         type: column
+                     config: {}
+                     type: row
+                   - children:
+                       - children:
+                           - config:
+                               enableMarkdown: true
+                               text: !nunjucks >-
+                                 Simple sidebar panel for testing sidepanel
+                                 open/close behavior
+                             type: text
+                         config: {}
+                         type: column
+                     config: {}
+                     type: row
+                 config: {}
+                 type: container
+           id: '@pixiebrix/document'
+           root: null
+           rootMode: document
+       heading: Simple Sidebar Panel
+     id: extensionPoint
+     label: Simple Sidebar Panel
+     permissions:
+       origins: []
+       permissions: []
+     services: {}
+ kind: recipe
+ metadata:
+-  description: Created with the PixieBrix Page Editor
++  description: Created with the PixieBrix Page Editor (updated)
+   id: >-
+     @extension-e2e-test-unaffiliated/simple-sidebar-panel-00000000-0000-0000-0000-000000000000
+-  name: Simple Sidebar Panel
+-  version: 1.0.0
++  name: Simple Sidebar Panel (Updated)
++  version: 1.0.2
+ options:
+   schema:
+     properties: {}
+     type: object
+   uiSchema:
+     ui:order:
+       - '*'


### PR DESCRIPTION
## What does this PR do?

- Part of #8853
- This PR introduces a new end-to-end test for the mod editor pane behavior in the page editor. The test checks the visibility of the mod editor pane, and the modification of mod metadata. The test also verifies the updated mod metadata against a snapshot.

## Future Work

- Editing the mod input options