### PR TITLE
Pass mod component ref via `BrickOptions.meta` instead of logger

### DIFF
--- a/src/bricks/effects/AddDynamicTextSnippet.test.ts
+++ b/src/bricks/effects/AddDynamicTextSnippet.test.ts
@@ -68,7 +68,7 @@ describe("AddDynamicTextSnippet", () => {
           // Preview is optional
           preview: undefined,
           handler: expect.toBeFunction(),
-          componentId: reduceOptions.modComponentId,
+          componentId: reduceOptions.modComponentRef.modComponentId,
           context: {
             ...reduceOptions.logger.context,
             brickId: brick.id,
@@ -109,7 +109,7 @@ describe("AddDynamicTextSnippet", () => {
           title: "Echo",
           preview,
           handler: expect.toBeFunction(),
-          componentId: reduceOptions.modComponentId,
+          componentId: reduceOptions.modComponentRef.modComponentId,
           context: {
             ...reduceOptions.logger.context,
             brickId: brick.id,

--- a/src/bricks/effects/AddDynamicTextSnippet.test.ts
+++ b/src/bricks/effects/AddDynamicTextSnippet.test.ts
@@ -56,9 +56,7 @@ describe("AddDynamicTextSnippet", () => {
         },
       };
 
-      await reducePipeline(pipeline, simpleInput({}), {
-        ...reduceOptions,
-      });
+      await reducePipeline(pipeline, simpleInput({}), reduceOptions);
 
       expect(snippetRegistry.snippetShortcuts).toStrictEqual([
         {

--- a/src/bricks/effects/AddDynamicTextSnippet.ts
+++ b/src/bricks/effects/AddDynamicTextSnippet.ts
@@ -30,6 +30,7 @@ import { validateOutputKey } from "@/runtime/runtimeTypes";
 import type { PlatformCapability } from "@/platform/capabilities";
 import { propertiesToSchema } from "@/utils/schemaUtils";
 import { normalizeShortcut } from "@/bricks/effects/AddTextSnippets";
+import { assertNotNullish } from "@/utils/nullishUtils";
 
 type SnippetArgs = {
   /**
@@ -107,22 +108,28 @@ class AddDynamicTextSnippet extends EffectABC {
       preview,
       generate: generatePipeline,
     }: BrickArgs<SnippetArgs>,
-    { logger, runPipeline, platform, abortSignal }: BrickOptions,
+    {
+      logger,
+      runPipeline,
+      platform,
+      abortSignal,
+      meta: { modComponentRef },
+    }: BrickOptions,
   ): Promise<void> {
     // The runtime checks the abortSignal for each brick. But check here too to avoid flickering in the menu
     if (abortSignal?.aborted) {
       return;
     }
 
-    if (logger.context.modComponentId == null) {
-      throw new Error("Must be run in the context of a mod");
-    }
+    const { modComponentId } = modComponentRef;
+
+    assertNotNullish(modComponentId, "Must be run in the context of a mod");
 
     // Counter to keep track of the action run number for tracing
     let counter = 0;
 
     platform.snippetShortcutMenu.register({
-      componentId: logger.context.modComponentId,
+      componentId: modComponentId,
       context: logger.context,
       // Trim leading command key in shortcut to be resilient to user input
       shortcut: normalizeShortcut(shortcut),

--- a/src/bricks/effects/AddQuickBarAction.test.ts
+++ b/src/bricks/effects/AddQuickBarAction.test.ts
@@ -17,12 +17,12 @@
 
 import AddQuickBarAction from "@/bricks/effects/AddQuickBarAction";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import ConsoleLogger from "@/utils/ConsoleLogger";
-import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
+import {
+  brickOptionsFactory,
+  runMetadataFactory,
+} from "@/testUtils/factories/runtimeFactories";
 import { platformMock } from "@/testUtils/platformMock";
 import { modComponentRefFactory } from "@/testUtils/factories/modComponentFactories";
-
-import { mapModComponentRefToMessageContext } from "@/utils/modUtils";
 
 const brick = new AddQuickBarAction();
 
@@ -50,9 +50,7 @@ describe("AddQuickBarAction", () => {
       unsafeAssumeValidArg({ title: "test" }),
       brickOptionsFactory({
         platform,
-        logger: new ConsoleLogger(
-          mapModComponentRefToMessageContext(modComponentRef),
-        ),
+        meta: runMetadataFactory({ modComponentRef }),
         abortSignal: abortController.signal,
       }),
     );

--- a/src/bricks/effects/AddQuickBarAction.tsx
+++ b/src/bricks/effects/AddQuickBarAction.tsx
@@ -31,7 +31,6 @@ import type { PlatformCapability } from "@/platform/capabilities";
 import { uniq } from "lodash";
 import type { CustomAction } from "@/platform/platformTypes/quickBarProtocol";
 import { propertiesToSchema } from "@/utils/schemaUtils";
-import { mapMessageContextToModComponentRef } from "@/utils/modUtils";
 
 type ActionConfig = {
   /**
@@ -138,9 +137,16 @@ class AddQuickBarAction extends EffectABC {
       // Be explicit about the default priority if non is provided
       priority = DEFAULT_PRIORITY,
     }: BrickArgs<ActionConfig>,
-    { root, logger, runPipeline, abortSignal, platform }: BrickOptions,
+    {
+      root,
+      runPipeline,
+      abortSignal,
+      platform,
+      meta: { modComponentRef },
+    }: BrickOptions,
   ): Promise<void> {
     const { quickBar } = platform;
+    const { modComponentId } = modComponentRef;
 
     // The runtime checks the abortSignal for each brick. But check here too to avoid flickering in the Quick Bar
     if (abortSignal?.aborted) {
@@ -151,13 +157,13 @@ class AddQuickBarAction extends EffectABC {
     let counter = 0;
 
     // Expected parent id from QuickBarProviderExtensionPoint
-    const parentId = `provider-${logger.context.modComponentId}`;
+    const parentId = `provider-${modComponentId}`;
 
     const action: CustomAction = {
-      // XXX: old actions will still appear in the quick bar unless the extension point clears out the old actions
-      id: `${logger.context.modComponentId}-${title}`,
+      // XXX: old actions will still appear in the quick bar unless the starter brick clears out the old actions
+      id: `${modComponentId}-${title}`,
       // Additional metadata, for enabling clearing out old actions
-      modComponentRef: mapMessageContextToModComponentRef(logger.context),
+      modComponentRef,
       // Can only provide a parent if the parent exists
       parent: quickBar.knownGeneratorRootIds.has(parentId)
         ? parentId

--- a/src/bricks/effects/AddTextSnippets.ts
+++ b/src/bricks/effects/AddTextSnippets.ts
@@ -108,20 +108,16 @@ class AddTextSnippets extends EffectABC {
 
   async effect(
     { snippets }: BrickArgs<{ snippets: Snippet[] }>,
-    { logger, abortSignal, platform }: BrickOptions,
+    { meta, logger, abortSignal, platform }: BrickOptions,
   ): Promise<void> {
     // The runtime checks the abortSignal for each brick. But check here too to avoid flickering in the popover
     if (abortSignal?.aborted) {
       return;
     }
 
-    if (logger.context.modComponentId == null) {
-      throw new Error("Must be run in the context of a mod component");
-    }
-
     for (const { shortcut, title, text } of snippets) {
       platform.snippetShortcutMenu.register({
-        componentId: logger.context.modComponentId,
+        componentId: meta.modComponentRef.modComponentId,
         context: logger.context,
         shortcut: normalizeShortcut(shortcut),
         title,

--- a/src/bricks/effects/assignModVariable.test.ts
+++ b/src/bricks/effects/assignModVariable.test.ts
@@ -15,25 +15,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import ConsoleLogger from "@/utils/ConsoleLogger";
 import AssignModVariable from "@/bricks/effects/assignModVariable";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import { getState, setState } from "@/platform/state/stateController";
 import { validateBrickInputOutput } from "@/validators/schemaValidator";
-import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
+import {
+  brickOptionsFactory,
+  runMetadataFactory,
+} from "@/testUtils/factories/runtimeFactories";
 import { modComponentRefFactory } from "@/testUtils/factories/modComponentFactories";
-import { mapModComponentRefToMessageContext } from "@/utils/modUtils";
 import { MergeStrategies, StateNamespaces } from "@/platform/state/stateTypes";
-
-const modComponentRef = modComponentRefFactory();
 
 const brick = new AssignModVariable();
 
-const logger = new ConsoleLogger(
-  mapModComponentRefToMessageContext(modComponentRef),
-);
+const modComponentRef = modComponentRefFactory();
 
-const brickOptions = brickOptionsFactory({ logger });
+const brickOptions = brickOptionsFactory({
+  meta: runMetadataFactory({ modComponentRef }),
+});
 
 beforeEach(() => {
   setState({

--- a/src/bricks/effects/assignModVariable.ts
+++ b/src/bricks/effects/assignModVariable.ts
@@ -7,7 +7,6 @@ import { EffectABC } from "@/types/bricks/effectTypes";
 import { type BrickConfig } from "@/bricks/types";
 import { castTextLiteralOrThrow } from "@/utils/expressionUtils";
 import { propertiesToSchema } from "@/utils/schemaUtils";
-import { mapMessageContextToModComponentRef } from "@/utils/modUtils";
 import { MergeStrategies, StateNamespaces } from "@/platform/state/stateTypes";
 
 /**
@@ -92,13 +91,13 @@ class AssignModVariable extends EffectABC {
       // Input is validated, so we know value is a JsonPrimitive or JsonObject
       value: JsonPrimitive | JsonObject;
     }>,
-    { logger }: BrickOptions,
+    { meta: { modComponentRef } }: BrickOptions,
   ): Promise<void> {
     setState({
       namespace: StateNamespaces.MOD,
       data: { [variableName]: value },
       mergeStrategy: MergeStrategies.SHALLOW,
-      modComponentRef: mapMessageContextToModComponentRef(logger.context),
+      modComponentRef,
     });
   }
 }

--- a/src/bricks/effects/attachAutocomplete.test.ts
+++ b/src/bricks/effects/attachAutocomplete.test.ts
@@ -16,16 +16,10 @@
  */
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import ConsoleLogger from "@/utils/ConsoleLogger";
 import { AttachAutocomplete } from "@/bricks/effects/attachAutocomplete";
-import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new AttachAutocomplete();
-
-const logger = new ConsoleLogger({
-  modComponentId: uuidSequence(0),
-});
 
 describe("AttachAutocomplete", () => {
   beforeEach(() => {
@@ -52,7 +46,6 @@ describe("AttachAutocomplete", () => {
       unsafeAssumeValidArg({ selector: "[name='name']" }),
       brickOptionsFactory({
         root: document,
-        logger,
       }),
     );
 
@@ -66,7 +59,6 @@ describe("AttachAutocomplete", () => {
       unsafeAssumeValidArg({ selector: "[name='name']", isRootAware: true }),
       brickOptionsFactory({
         root: document.querySelector<HTMLElement>("#noForm")!,
-        logger,
       }),
     );
 
@@ -78,7 +70,6 @@ describe("AttachAutocomplete", () => {
       unsafeAssumeValidArg({ selector: "[name='name']", isRootAware: true }),
       brickOptionsFactory({
         root: document.querySelector<HTMLElement>("#hasForm")!,
-        logger,
       }),
     );
 

--- a/src/bricks/effects/customEvent.test.ts
+++ b/src/bricks/effects/customEvent.test.ts
@@ -16,16 +16,10 @@
  */
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import ConsoleLogger from "@/utils/ConsoleLogger";
 import CustomEventEffect from "@/bricks/effects/customEvent";
-import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new CustomEventEffect();
-
-const logger = new ConsoleLogger({
-  modComponentId: uuidSequence(0),
-});
 
 describe("CustomEventEffect", () => {
   beforeEach(() => {
@@ -52,7 +46,6 @@ describe("CustomEventEffect", () => {
       unsafeAssumeValidArg({ eventName: "foo" }),
       brickOptionsFactory({
         root: document.querySelector("button")!,
-        logger,
       }),
     );
 
@@ -67,7 +60,6 @@ describe("CustomEventEffect", () => {
       unsafeAssumeValidArg({ eventName: "foo" }),
       brickOptionsFactory({
         root: document.querySelector("button")!,
-        logger,
       }),
     );
 

--- a/src/bricks/effects/pageState.test.ts
+++ b/src/bricks/effects/pageState.test.ts
@@ -16,12 +16,13 @@
  */
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
+import {
+  brickOptionsFactory,
+  runMetadataFactory,
+} from "@/testUtils/factories/runtimeFactories";
 import { toExpression } from "@/utils/expressionUtils";
 import { GetPageState, SetPageState } from "@/bricks/effects/pageState";
 import { TEST_resetState } from "@/platform/state/stateController";
-import ConsoleLogger from "@/utils/ConsoleLogger";
-import { mapModComponentRefToMessageContext } from "@/utils/modUtils";
 import { standaloneModComponentRefFactory } from "@/testUtils/factories/modComponentFactories";
 import { MergeStrategies, StateNamespaces } from "@/platform/state/stateTypes";
 
@@ -176,9 +177,9 @@ describe("set and get", () => {
     const setState = new SetPageState();
     const getState = new GetPageState();
     const brickOptions = brickOptionsFactory({
-      logger: new ConsoleLogger(
-        mapModComponentRefToMessageContext(standaloneModComponentRefFactory()),
-      ),
+      meta: runMetadataFactory({
+        modComponentRef: standaloneModComponentRefFactory(),
+      }),
     });
 
     await setState.transform(

--- a/src/bricks/effects/pageState.ts
+++ b/src/bricks/effects/pageState.ts
@@ -25,7 +25,6 @@ import { isObject } from "@/utils/objectUtils";
 import { mapValues } from "lodash";
 import { castTextLiteralOrThrow } from "@/utils/expressionUtils";
 import { propertiesToSchema } from "@/utils/schemaUtils";
-import { mapMessageContextToModComponentRef } from "@/utils/modUtils";
 import {
   MergeStrategies,
   type MergeStrategy,
@@ -149,13 +148,13 @@ export class SetPageState extends TransformerABC {
       namespace?: StateNamespace;
       mergeStrategy?: MergeStrategy;
     }>,
-    { logger, platform }: BrickOptions,
+    { meta: { modComponentRef }, platform }: BrickOptions,
   ): Promise<JsonObject> {
     return platform.state.setState({
       namespace,
       data,
       mergeStrategy,
-      modComponentRef: mapMessageContextToModComponentRef(logger.context),
+      modComponentRef,
     });
   }
 }
@@ -200,11 +199,11 @@ export class GetPageState extends TransformerABC {
     {
       namespace = StateNamespaces.MOD,
     }: BrickArgs<{ namespace?: StateNamespace }>,
-    { logger, platform }: BrickOptions,
+    { meta: { modComponentRef }, platform }: BrickOptions,
   ): Promise<JsonObject> {
     return platform.state.getState({
       namespace,
-      modComponentRef: mapMessageContextToModComponentRef(logger.context),
+      modComponentRef,
     });
   }
 }

--- a/src/bricks/effects/sidebarEffects.ts
+++ b/src/bricks/effects/sidebarEffects.ts
@@ -68,7 +68,7 @@ export class ShowSidebar extends EffectABC {
       panelHeading?: string;
       forcePanel?: boolean;
     }>,
-    { logger }: BrickOptions,
+    { meta: { modComponentRef } }: BrickOptions,
   ): Promise<void> {
     expectContext("contentScript");
 
@@ -79,7 +79,8 @@ export class ShowSidebar extends EffectABC {
       sidebarController.updateSidebar({
         force: forcePanel,
         panelHeading,
-        blueprintId: logger.context.modId,
+        // ActivatePanelOptions currently expects undefined not null
+        blueprintId: modComponentRef.modId ?? undefined,
       }),
     );
   }

--- a/src/bricks/effects/tourEffect.ts
+++ b/src/bricks/effects/tourEffect.ts
@@ -122,7 +122,7 @@ export class TourEffect extends EffectABC {
       steps?: Step[];
       isRootAware?: boolean;
     }>,
-    { root = document, abortSignal: blockAbortSignal, logger }: BrickOptions,
+    { root = document, abortSignal: brickAbortSignal }: BrickOptions,
   ): Promise<void> {
     if (steps.length === 0) {
       throw new PropError(
@@ -133,7 +133,6 @@ export class TourEffect extends EffectABC {
       );
     }
 
-    const { modComponentId } = logger.context;
     const abortController = new AbortController();
     const stylesheetLink = await injectStylesheet(stylesheetUrl);
 
@@ -165,11 +164,6 @@ export class TourEffect extends EffectABC {
         "No matching element found for first step in tour",
       );
     }
-
-    assertNotNullish(
-      modComponentId,
-      "modComponentId is required to run a tour",
-    );
 
     const tour = introJs()
       .setOptions({
@@ -204,7 +198,7 @@ export class TourEffect extends EffectABC {
     };
 
     abortController.signal.addEventListener("abort", handleAbort);
-    blockAbortSignal?.addEventListener("abort", handleAbort);
+    brickAbortSignal?.addEventListener("abort", handleAbort);
 
     await tourPromise;
   }

--- a/src/bricks/renderers/customForm.test.tsx
+++ b/src/bricks/renderers/customForm.test.tsx
@@ -39,7 +39,6 @@ import {
   setState,
 } from "@/platform/state/stateController";
 import type { Target } from "@/types/messengerTypes";
-import { mapMessageContextToModComponentRef } from "@/utils/modUtils";
 import { StateNamespaces } from "@/platform/state/stateTypes";
 
 const brick = new CustomFormRenderer();
@@ -353,9 +352,7 @@ describe("CustomFormRenderer", () => {
       expect(
         getState({
           namespace: StateNamespaces.MOD,
-          modComponentRef: mapMessageContextToModComponentRef(
-            options.logger.context,
-          ),
+          modComponentRef: options.meta.modComponentRef,
         }),
       ).toStrictEqual({
         name: value,

--- a/src/bricks/renderers/customForm.tsx
+++ b/src/bricks/renderers/customForm.tsx
@@ -47,7 +47,6 @@ import { type CustomFormComponentProps } from "./CustomFormComponent";
 import { PIXIEBRIX_INTEGRATION_FIELD_SCHEMA } from "@/integrations/constants";
 import { assumeNotNullish_UNSAFE } from "@/utils/nullishUtils";
 import { type ModComponentRef } from "@/types/modComponentTypes";
-import { mapMessageContextToModComponentRef } from "@/utils/modUtils";
 import {
   MergeStrategies,
   type StateNamespace,
@@ -278,10 +277,8 @@ export class CustomFormRenderer extends RendererABC {
       onSubmit?: PipelineExpression;
       postSubmitAction?: PostSubmitAction;
     }>,
-    { logger, runPipeline, platform }: BrickOptions,
+    { meta: { modComponentRef }, runPipeline, platform }: BrickOptions,
   ): Promise<ComponentRef> {
-    const modComponentRef = mapMessageContextToModComponentRef(logger.context);
-
     // Redundant with the JSON Schema input validation for `required`. But keeping here for clarity
     if (!storage) {
       throw new PropError(

--- a/src/bricks/renderers/documentView/DocumentView.tsx
+++ b/src/bricks/renderers/documentView/DocumentView.tsx
@@ -26,6 +26,7 @@ import { joinPathParts } from "@/utils/formUtils";
 import StylesheetsContext, {
   useStylesheetsContextWithDocumentDefault,
 } from "@/components/StylesheetsContext";
+import { assertNotNullish } from "@/utils/nullishUtils";
 
 const DocumentView: React.FC<DocumentViewProps> = ({
   body,
@@ -35,15 +36,13 @@ const DocumentView: React.FC<DocumentViewProps> = ({
   meta,
   onAction,
 }) => {
-  if (!meta?.runId) {
-    // The sidebar panel should dynamically pass the prop through
-    throw new Error("meta.runId is required for DocumentView");
-  }
-
-  if (!meta?.modComponentId) {
-    // The sidebar panel should dynamically pass the prop through
-    throw new Error("meta.modComponentId is required for DocumentView");
-  }
+  // The code for RendererComponent isn't fully type-safe. So dynamically check the necessary meta props are passed in.
+  assertNotNullish(meta, "meta is required for DocumentView");
+  assertNotNullish(meta.runId, "meta.runId is required for DocumentView");
+  assertNotNullish(
+    meta.modComponentRef,
+    "meta.modComponentRef is required for DocumentView",
+  );
 
   const { stylesheets } = useStylesheetsContextWithDocumentDefault({
     newStylesheets,

--- a/src/bricks/renderers/documentView/DocumentViewProps.tsx
+++ b/src/bricks/renderers/documentView/DocumentViewProps.tsx
@@ -17,8 +17,11 @@
 
 import { type DocumentBuilderElement } from "@/pageEditor/documentBuilder/documentBuilderTypes";
 import { type SubmitPanelAction } from "@/bricks/errors";
-import { type BrickArgsContext, type BrickOptions } from "@/types/runtimeTypes";
-import { type UUID } from "@/types/stringTypes";
+import {
+  type BrickArgsContext,
+  type BrickOptions,
+  type RunMetadata,
+} from "@/types/runtimeTypes";
 
 export type DocumentViewProps = {
   /**
@@ -39,8 +42,6 @@ export type DocumentViewProps = {
   disableParentStyles?: boolean;
 
   options: BrickOptions<BrickArgsContext>;
-  meta: {
-    runId: UUID;
-    modComponentId: UUID;
-  };
+
+  meta: Pick<RunMetadata, "runId" | "modComponentRef">;
 };

--- a/src/bricks/transformers/RunMetadataTransformer.test.ts
+++ b/src/bricks/transformers/RunMetadataTransformer.test.ts
@@ -24,6 +24,8 @@ import {
 } from "@/testUtils/factories/stringFactories";
 import ConsoleLogger from "@/utils/ConsoleLogger";
 import type { SemVerString } from "@/types/registryTypes";
+import { modComponentRefFactory } from "@/testUtils/factories/modComponentFactories";
+import { mapModComponentRefToMessageContext } from "@/utils/modUtils";
 
 const brick = new RunMetadataTransformer();
 
@@ -77,14 +79,13 @@ describe("RunMetadataTransformer", () => {
   });
 
   it("returns deployed mod metadata", async () => {
-    const modComponentId = autoUUIDSequence();
+    const modComponentRef = modComponentRefFactory();
     const deploymentId = autoUUIDSequence();
-    const modId = registryIdFactory();
+
     const runId = autoUUIDSequence();
 
     const logger = new ConsoleLogger({
-      modComponentId,
-      modId,
+      ...mapModComponentRefToMessageContext(modComponentRef),
       modVersion: "1.0.0" as SemVerString,
       deploymentId,
     });
@@ -95,17 +96,17 @@ describe("RunMetadataTransformer", () => {
         logger,
         meta: {
           runId,
-          modComponentId,
+          modComponentRef,
           branches: [],
         },
       }),
     );
 
     expect(result).toEqual({
-      modComponentId,
+      modComponentRef,
       deploymentId,
       mod: {
-        id: modId,
+        id: modComponentRef.modId,
         version: "1.0.0",
       },
       runId,

--- a/src/bricks/transformers/RunMetadataTransformer.test.ts
+++ b/src/bricks/transformers/RunMetadataTransformer.test.ts
@@ -21,13 +21,14 @@ import {
   brickOptionsFactory,
   runMetadataFactory,
 } from "@/testUtils/factories/runtimeFactories";
-import {
-  autoUUIDSequence,
-  registryIdFactory,
-} from "@/testUtils/factories/stringFactories";
+import { autoUUIDSequence } from "@/testUtils/factories/stringFactories";
 import ConsoleLogger from "@/utils/ConsoleLogger";
 import type { SemVerString } from "@/types/registryTypes";
-import { standaloneModComponentRefFactory } from "@/testUtils/factories/modComponentFactories";
+import {
+  modComponentRefFactory,
+  standaloneModComponentRefFactory,
+} from "@/testUtils/factories/modComponentFactories";
+import { mapModComponentRefToMessageContext } from "@/utils/modUtils";
 
 const brick = new RunMetadataTransformer();
 
@@ -50,26 +51,26 @@ describe("RunMetadataTransformer", () => {
   });
 
   it("returns packaged mod metadata", async () => {
-    const modComponentId = autoUUIDSequence();
-    const modId = registryIdFactory();
+    const modComponentRef = modComponentRefFactory();
+
     const logger = new ConsoleLogger({
-      modComponentId,
-      modId,
+      ...mapModComponentRefToMessageContext(modComponentRef),
       modVersion: "1.0.0" as SemVerString,
     });
 
     const result = await brick.run(
       unsafeAssumeValidArg({}),
       brickOptionsFactory({
+        meta: runMetadataFactory({ modComponentRef }),
         logger,
       }),
     );
 
     expect(result).toEqual({
-      modComponentId,
+      modComponentId: modComponentRef.modComponentId,
       deploymentId: null,
       mod: {
-        id: modId,
+        id: modComponentRef.modId,
         version: "1.0.0",
       },
       runId: null,
@@ -78,6 +79,7 @@ describe("RunMetadataTransformer", () => {
 
   it("returns deployed mod metadata", async () => {
     const deploymentId = autoUUIDSequence();
+
     const brickOptions = brickOptionsFactory();
     brickOptions.logger = brickOptions.logger.childLogger({
       modVersion: "1.0.0" as SemVerString,
@@ -92,13 +94,13 @@ describe("RunMetadataTransformer", () => {
     const result = await brick.run(unsafeAssumeValidArg({}), brickOptions);
 
     expect(result).toEqual({
+      runId,
       modComponentId,
       deploymentId,
       mod: {
         id: modId,
         version: "1.0.0",
       },
-      runId,
     });
   });
 });

--- a/src/bricks/transformers/RunMetadataTransformer.ts
+++ b/src/bricks/transformers/RunMetadataTransformer.ts
@@ -117,7 +117,7 @@ class RunMetadataTransformer extends TransformerABC {
               version: context.modVersion,
             },
       deploymentId: context.deploymentId ?? null,
-      modComponentId: context.modComponentId ?? null,
+      modComponentId: meta.modComponentRef.modComponentId,
       runId: meta.runId,
     };
   }

--- a/src/bricks/transformers/brickFactory.test.ts
+++ b/src/bricks/transformers/brickFactory.test.ts
@@ -36,10 +36,10 @@ import { extraEmptyModStateContext } from "@/runtime/extendModVariableContext";
 import { TEST_setContext } from "webext-detect";
 import { uuidv4, validateRegistryId } from "@/types/helpers";
 import registerBuiltinBricks from "@/bricks/registerBuiltinBricks";
-
 import { toExpression } from "@/utils/expressionUtils";
 import { DefinitionKinds } from "@/types/registryTypes";
 import { reduceOptionsFactory } from "@/testUtils/factories/runtimeFactories";
+import { modComponentRefFactory } from "@/testUtils/factories/modComponentFactories";
 
 TEST_setContext("contentScript");
 
@@ -377,7 +377,8 @@ describe("tracing", () => {
     };
 
     const runId = uuidv4();
-    const modComponentId = uuidv4();
+    const modComponentRef = modComponentRefFactory();
+
     // Provide initial value to ensure it's preserved
     const initialBranches = [{ key: "body", counter: 1 }];
 
@@ -387,20 +388,20 @@ describe("tracing", () => {
       {
         ...reduceOptionsFactory("v3"),
         runId,
-        modComponentId,
+        modComponentRef,
         branches: initialBranches,
       },
     );
 
     expect(OptionsBrick.options[0].meta).toStrictEqual({
       runId,
-      modComponentId,
+      modComponentRef,
       branches: initialBranches,
     });
 
     expect(OptionsBrick.options[1].meta).toStrictEqual({
       runId,
-      modComponentId,
+      modComponentRef,
       branches: [
         ...initialBranches,
         // Branch is added by the @pixiebrix/run brick

--- a/src/bricks/transformers/controlFlow/WithAsyncModVariable.test.ts
+++ b/src/bricks/transformers/controlFlow/WithAsyncModVariable.test.ts
@@ -23,7 +23,6 @@ import {
 } from "@/runtime/pipelineTests/pipelineTestHelpers";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import brickRegistry from "@/bricks/registry";
-import ConsoleLogger from "@/utils/ConsoleLogger";
 import { getState, setState } from "@/platform/state/stateController";
 import pDefer, { type DeferredPromise } from "p-defer";
 import { tick } from "@/starterBricks/starterBrickTestUtils";
@@ -32,7 +31,6 @@ import { type UUID } from "@/types/stringTypes";
 import { type Expression } from "@/types/runtimeTypes";
 import { toExpression } from "@/utils/expressionUtils";
 import { modComponentRefFactory } from "@/testUtils/factories/modComponentFactories";
-import { mapModComponentRefToMessageContext } from "@/utils/modUtils";
 import { reduceOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 import { MergeStrategies, StateNamespaces } from "@/platform/state/stateTypes";
 
@@ -58,10 +56,6 @@ const makeAsyncModVariablePipeline = (
 });
 
 const modComponentRef = modComponentRefFactory();
-
-const logger = new ConsoleLogger(
-  mapModComponentRefToMessageContext(modComponentRef),
-);
 
 function expectPageState(expectedState: UnknownObject): void {
   const pageState = getState({
@@ -100,10 +94,11 @@ describe("WithAsyncModVariable", () => {
   test("returns request nonce and initializes page state immediately", async () => {
     const pipeline = makeAsyncModVariablePipeline(asyncEchoBrick, "bar", "foo");
 
-    const brickOutput = await reducePipeline(pipeline, simpleInput({}), {
-      ...reduceOptionsFactory("v3"),
-      logger,
-    });
+    const brickOutput = await reducePipeline(
+      pipeline,
+      simpleInput({}),
+      reduceOptionsFactory("v3", { modComponentRef }),
+    );
 
     expect(brickOutput).toStrictEqual({
       requestId: expect.toBeString(),
@@ -127,10 +122,11 @@ describe("WithAsyncModVariable", () => {
   test("returns request nonce and sets page state on success", async () => {
     const pipeline = makeAsyncModVariablePipeline(asyncEchoBrick, "bar", "foo");
 
-    const brickOutput = await reducePipeline(pipeline, simpleInput({}), {
-      ...reduceOptionsFactory("v3"),
-      logger,
-    });
+    const brickOutput = await reducePipeline(
+      pipeline,
+      simpleInput({}),
+      reduceOptionsFactory("v3", { modComponentRef }),
+    );
 
     deferred.resolve();
     await tick();
@@ -157,10 +153,11 @@ describe("WithAsyncModVariable", () => {
   test("returns request nonce and sets page state on error", async () => {
     const pipeline = makeAsyncModVariablePipeline(throwBrick, "error", "foo");
 
-    const brickOutput = await reducePipeline(pipeline, simpleInput({}), {
-      ...reduceOptionsFactory("v3"),
-      logger,
-    });
+    const brickOutput = await reducePipeline(
+      pipeline,
+      simpleInput({}),
+      reduceOptionsFactory("v3", { modComponentRef }),
+    );
 
     await tick();
 
@@ -214,15 +211,17 @@ describe("WithAsyncModVariable", () => {
       modVariable,
     );
 
-    await reducePipeline(stalePipeline, simpleInput({}), {
-      ...reduceOptionsFactory("v3"),
-      logger,
-    });
+    await reducePipeline(
+      stalePipeline,
+      simpleInput({}),
+      reduceOptionsFactory("v3", { modComponentRef }),
+    );
 
-    const secondOutput = await reducePipeline(pipeline, simpleInput({}), {
-      ...reduceOptionsFactory("v3"),
-      logger,
-    });
+    const secondOutput = await reducePipeline(
+      pipeline,
+      simpleInput({}),
+      reduceOptionsFactory("v3", { modComponentRef }),
+    );
 
     // Neither are resolved, should be in loading state
     expectPageState({

--- a/src/bricks/transformers/controlFlow/WithAsyncModVariable.ts
+++ b/src/bricks/transformers/controlFlow/WithAsyncModVariable.ts
@@ -33,7 +33,6 @@ import { PropError } from "@/errors/businessErrors";
 import { type BrickConfig } from "@/bricks/types";
 import { castTextLiteralOrThrow } from "@/utils/expressionUtils";
 import { propertiesToSchema } from "@/utils/schemaUtils";
-import { mapMessageContextToModComponentRef } from "@/utils/modUtils";
 import { MergeStrategies, StateNamespaces } from "@/platform/state/stateTypes";
 
 /**
@@ -174,7 +173,7 @@ export class WithAsyncModVariable extends TransformerABC {
       body: PipelineExpression;
       stateKey: string;
     }>,
-    { logger, runPipeline }: BrickOptions,
+    { meta: { modComponentRef }, runPipeline }: BrickOptions,
   ) {
     const requestId = uuidv4();
 
@@ -199,7 +198,7 @@ export class WithAsyncModVariable extends TransformerABC {
         // Using shallow will replace the state key, but keep other keys
         mergeStrategy:
           strategy === "put" ? MergeStrategies.SHALLOW : MergeStrategies.DEEP,
-        modComponentRef: mapMessageContextToModComponentRef(logger.context),
+        modComponentRef,
       });
     };
 
@@ -209,7 +208,7 @@ export class WithAsyncModVariable extends TransformerABC {
     // Get/set page state calls are synchronous from the content script, so safe to call sequentially
     const currentState = getState({
       namespace: StateNamespaces.MOD,
-      modComponentRef: mapMessageContextToModComponentRef(logger.context),
+      modComponentRef,
     });
 
     // eslint-disable-next-line security/detect-object-injection -- user provided value that's readonly

--- a/src/bricks/transformers/ephemeralForm/formTransformer.ts
+++ b/src/bricks/transformers/ephemeralForm/formTransformer.ts
@@ -23,7 +23,6 @@ import { type BrickConfig } from "@/bricks/types";
 import { type FormDefinition } from "@/platform/forms/formTypes";
 import { isExpression } from "@/utils/expressionUtils";
 import type { PlatformCapability } from "@/platform/capabilities";
-import { mapMessageContextToModComponentRef } from "@/utils/modUtils";
 
 export const TEMPORARY_FORM_SCHEMA: Schema = {
   type: "object",
@@ -117,7 +116,7 @@ export class FormTransformer extends TransformerABC {
       stylesheets = [],
       disableParentStyles = false,
     }: BrickArgs<FormDefinition>,
-    { logger, abortSignal, platform }: BrickOptions,
+    { meta: { modComponentRef }, abortSignal, platform }: BrickOptions,
   ): Promise<unknown> {
     // Repackage the definition from the brick input with default values
     const formDefinition: FormDefinition = {
@@ -138,11 +137,7 @@ export class FormTransformer extends TransformerABC {
 
     try {
       // `mapMessageContextToModComponentRef` throws if there's no mod component or starter brick in the context
-      return await platform.form(
-        formDefinition,
-        controller,
-        mapMessageContextToModComponentRef(logger.context),
-      );
+      return await platform.form(formDefinition, controller, modComponentRef);
     } finally {
       controller.abort();
     }

--- a/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
+++ b/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
@@ -107,12 +107,11 @@ describe("DisplayTemporaryInfo", () => {
       },
     };
 
-    await reducePipeline(pipeline, simpleInput({}), {
-      ...reduceOptionsFactory("v3"),
-      logger: new ConsoleLogger(
-        mapModComponentRefToMessageContext(modComponentRef),
-      ),
-    });
+    await reducePipeline(
+      pipeline,
+      simpleInput({}),
+      reduceOptionsFactory("v3", { modComponentRef }),
+    );
 
     // Show function will be called with a "loading" payload
     expect(showTemporarySidebarPanel).toHaveBeenCalledExactlyOnceWith({
@@ -183,15 +182,11 @@ describe("DisplayTemporaryInfo", () => {
     };
 
     const modComponentRef = modComponentRefFactory();
-
-    const options = {
-      ...reduceOptionsFactory("v3"),
-      logger: new ConsoleLogger(
-        mapModComponentRefToMessageContext(modComponentRef),
-      ),
-    };
-
-    await reducePipeline(pipeline, simpleInput({}), options);
+    await reducePipeline(
+      pipeline,
+      simpleInput({}),
+      reduceOptionsFactory("v3", { modComponentRef }),
+    );
 
     expect(showModal).toHaveBeenCalled();
     expect(showTemporarySidebarPanel).not.toHaveBeenCalled();
@@ -343,14 +338,11 @@ describe("DisplayTemporaryInfo", () => {
 
     const modComponentRef = standaloneModComponentRefFactory();
 
-    const options = {
-      ...reduceOptionsFactory("v3"),
-      logger: new ConsoleLogger(
-        mapModComponentRefToMessageContext(modComponentRef),
-      ),
-    };
-
-    void reducePipeline(pipeline, simpleInput({}), options);
+    void reducePipeline(
+      pipeline,
+      simpleInput({}),
+      reduceOptionsFactory("v3", { modComponentRef }),
+    );
 
     await tick();
 

--- a/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.ts
+++ b/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.ts
@@ -32,7 +32,6 @@ import {
   RefreshTriggers,
   type TemporaryPanelEntryMetadata,
 } from "@/platform/panels/panelTypes";
-import { mapMessageContextToModComponentRef } from "@/utils/modUtils";
 
 class DisplayTemporaryInfo extends TransformerABC {
   static BRICK_ID = validateRegistryId("@pixiebrix/display");
@@ -105,11 +104,11 @@ class DisplayTemporaryInfo extends TransformerABC {
       isRootAware: boolean;
     }>,
     {
-      logger: { context },
       root = document,
       platform,
       runRendererPipeline,
       abortSignal,
+      meta: { modComponentRef },
     }: BrickOptions,
   ): Promise<JsonObject | null> {
     expectContext("contentScript");
@@ -121,8 +120,7 @@ class DisplayTemporaryInfo extends TransformerABC {
 
     const panelEntryMetadata: TemporaryPanelEntryMetadata = {
       heading: title,
-      // Throws if there's no mod component or starter brick in the context
-      modComponentRef: mapMessageContextToModComponentRef(context),
+      modComponentRef,
     };
 
     const getPayload = async () => {

--- a/src/contentScript/ephemeralPanel.ts
+++ b/src/contentScript/ephemeralPanel.ts
@@ -86,6 +86,7 @@ export async function ephemeralPanel({
   onCloseClick,
 }: TemporaryPanelDefinition): Promise<JsonObject> {
   expectContext("contentScript");
+  const { modComponentId } = panelEntryMetadata.modComponentRef;
 
   if (location === "panel" && isLoadedInIframe()) {
     // Validate before registerEmptyTemporaryPanel to avoid an uncaught promise rejection
@@ -118,7 +119,7 @@ export async function ephemeralPanel({
     registerEmptyTemporaryPanel({
       nonce,
       location,
-      modComponentId: panelEntryMetadata.modComponentRef.modComponentId,
+      modComponentId,
     });
 
     await showSidebar();
@@ -129,7 +130,7 @@ export async function ephemeralPanel({
       nonce,
       payload: {
         key: uuidv4(),
-        modComponentId: panelEntryMetadata.modComponentRef.modComponentId,
+        modComponentRef: panelEntryMetadata.modComponentRef,
         loadingMessage: "Loading",
       },
     });
@@ -152,7 +153,7 @@ export async function ephemeralPanel({
     registerEmptyTemporaryPanel({
       nonce,
       location,
-      modComponentId: panelEntryMetadata.modComponentRef.modComponentId,
+      modComponentId,
     });
 
     // Create a source URL for content that will be loaded in the panel iframe
@@ -239,7 +240,7 @@ export async function ephemeralPanel({
       nonce,
       location,
       entry,
-      modComponentId: entry.modComponentRef.modComponentId,
+      modComponentId,
       onRegister: onReady,
     });
     return panelAction ?? {};

--- a/src/contentScript/pageEditor/runBrickPreview.ts
+++ b/src/contentScript/pageEditor/runBrickPreview.ts
@@ -29,7 +29,6 @@ import { $safeFind } from "@/utils/domUtils";
 import { BusinessError } from "@/errors/businessErrors";
 import { type RunBrickArgs } from "@/contentScript/pageEditor/types";
 import { type ModComponentRef } from "@/types/modComponentTypes";
-import { type Except } from "type-fest";
 
 /**
  * Run a single brick (e.g., for generating output previews)
@@ -42,7 +41,7 @@ export async function runBrickPreview({
   modComponentRef,
   rootSelector,
 }: RunBrickArgs & {
-  modComponentRef: Except<ModComponentRef, "starterBrickId">;
+  modComponentRef: ModComponentRef;
 }): Promise<unknown> {
   const versionOptions = apiVersionOptions(apiVersion);
 
@@ -84,13 +83,15 @@ export async function runBrickPreview({
 
   const options: ReduceOptions = {
     ...versionOptions,
+    modComponentRef,
     branches: [],
     headless: true,
-    logValues: false,
+    // Exclude logger context to prevent the run from being shown in logs for the mod component/brick
     logger: new ConsoleLogger(),
-    // Excluding runId will prevent the run from being stored in traces
+    logValues: false,
+    // Exclude runId to prevent the run from being stored in traces. (Including the run in traces would reset the
+    // run shown in the brick actions panel of the Page Editor.)
     runId: null,
-    modComponentId: null,
   };
 
   // Exclude the outputKey so that `output` is the output of the brick. Alternatively we could have taken then

--- a/src/contentScript/pageEditor/runRendererBrick.ts
+++ b/src/contentScript/pageEditor/runRendererBrick.ts
@@ -74,14 +74,14 @@ export async function runRendererBrick({
         brickId: error.brickId,
         args: error.args,
         ctxt: error.ctxt,
-        modComponentId: modComponentRef.modComponentId,
+        modComponentRef,
         runId,
       };
     } else {
       payload = {
         key: nonce,
         error: serializeError(error),
-        modComponentId: modComponentRef.modComponentId,
+        modComponentRef,
         runId,
       };
     }

--- a/src/contentScript/pipelineProtocol/runHeadlessPipeline.ts
+++ b/src/contentScript/pipelineProtocol/runHeadlessPipeline.ts
@@ -33,10 +33,6 @@ export async function runHeadlessPipeline({
 }: RunPipelineParams): Promise<unknown> {
   expectContext("contentScript");
 
-  if (meta.modComponentId == null) {
-    throw new Error("runHeadlessPipeline requires meta.extensionId");
-  }
-
   return reducePipeline(
     pipeline,
     {

--- a/src/pageEditor/documentBuilder/render/BlockElement.tsx
+++ b/src/pageEditor/documentBuilder/render/BlockElement.tsx
@@ -30,6 +30,7 @@ import { getConnectedTarget } from "@/sidebar/connectedTarget";
 import { type PanelContext } from "@/types/sidebarTypes";
 import { type RendererRunPayload } from "@/types/rendererTypes";
 import useAsyncState from "@/hooks/useAsyncState";
+import { mapModComponentRefToMessageContext } from "@/utils/modUtils";
 
 type BlockElementProps = {
   pipeline: BrickPipeline;
@@ -46,7 +47,10 @@ const BlockElement: React.FC<BlockElementProps> = ({ pipeline, tracePath }) => {
   } = useContext(DocumentContext);
 
   // Logger context will have both modComponentId and modId because they're passed from the containing PanelBody
-  const panelContext = logger.context as PanelContext;
+  const panelContext = {
+    ...logger.context,
+    ...mapModComponentRefToMessageContext(meta.modComponentRef),
+  } satisfies PanelContext;
 
   const {
     data: payload,

--- a/src/pageEditor/documentBuilder/render/ButtonElement.tsx
+++ b/src/pageEditor/documentBuilder/render/ButtonElement.tsx
@@ -58,10 +58,6 @@ const ButtonElement: React.FC<ButtonElementProps> = ({
 
   const [counter, setCounter] = useState(0);
 
-  if (!meta.modComponentId) {
-    throw new Error("ButtonElement requires meta.extensionId");
-  }
-
   const handler = async () => {
     const currentCounter = counter;
     setCounter((previous) => previous + 1);

--- a/src/pageEditor/documentBuilder/render/DocumentContext.tsx
+++ b/src/pageEditor/documentBuilder/render/DocumentContext.tsx
@@ -24,9 +24,10 @@ import {
   type BrickOptions,
   type SelectorRoot,
 } from "@/types/runtimeTypes";
-import { UNSET_UUID } from "@/types/helpers";
-
+import { UNSET_UUID, validateRegistryId } from "@/types/helpers";
 import { uninitializedPlatform } from "@/platform/platformContext";
+import { type ModComponentRef } from "@/types/modComponentTypes";
+import { INNER_SCOPE } from "@/types/registryTypes";
 
 type DocumentState = {
   onAction?: (action: { type: string; detail: JsonObject }) => void;
@@ -38,6 +39,12 @@ const BLANK_CONTEXT = {
   "@options": {},
 } as BrickArgsContext;
 
+const UNINITIALIZED_MOD_COMPONENT_REF = {
+  modComponentId: UNSET_UUID,
+  modId: validateRegistryId(`${INNER_SCOPE}/unset`),
+  starterBrickId: validateRegistryId(`${INNER_SCOPE}/unset`),
+} satisfies ModComponentRef;
+
 export const initialValue: DocumentState = {
   onAction() {
     throw new BusinessError("Panel actions not available for panel type");
@@ -46,7 +53,7 @@ export const initialValue: DocumentState = {
     platform: uninitializedPlatform,
     meta: {
       runId: null,
-      modComponentId: UNSET_UUID,
+      modComponentRef: UNINITIALIZED_MOD_COMPONENT_REF,
       branches: [],
     },
     ctxt: BLANK_CONTEXT,

--- a/src/pageEditor/documentBuilder/render/ListElement.tsx
+++ b/src/pageEditor/documentBuilder/render/ListElement.tsx
@@ -36,7 +36,6 @@ import { isNullOrBlank } from "@/utils/stringUtils";
 import { joinPathParts } from "@/utils/formUtils";
 import { getConnectedTarget } from "@/sidebar/connectedTarget";
 import { freeze } from "@/utils/objectUtils";
-import { mapMessageContextToModComponentRef } from "@/utils/modUtils";
 
 type DocumentListProps = {
   array: UnknownObject[];
@@ -94,9 +93,7 @@ const ListElementInternal: React.FC<DocumentListProps> = ({
               config: config.__value__,
               context: elementContext.options.ctxt,
               options: apiVersionOptions("v3"),
-              modComponentRef: mapMessageContextToModComponentRef(
-                documentContext.options.logger.context,
-              ),
+              modComponentRef: documentContext.options.meta.modComponentRef,
             },
           )) as DocumentBuilderElement;
         } else {

--- a/src/runtime/pipelineTests/modVariableContext.test.ts
+++ b/src/runtime/pipelineTests/modVariableContext.test.ts
@@ -25,7 +25,6 @@ import { setState } from "@/platform/state/stateController";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import { contextAsPlainObject } from "@/runtime/extendModVariableContext";
 import { toExpression } from "@/utils/expressionUtils";
-import { mapMessageContextToModComponentRef } from "@/utils/modUtils";
 import { reduceOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 import { MergeStrategies, StateNamespaces } from "@/platform/state/stateTypes";
 
@@ -42,9 +41,7 @@ describe("modVariableContext", () => {
       namespace: StateNamespaces.MOD,
       data: { run: true },
       mergeStrategy: MergeStrategies.REPLACE,
-      modComponentRef: mapMessageContextToModComponentRef(
-        options.logger.context,
-      ),
+      modComponentRef: options.modComponentRef,
     });
 
     const pipeline = [
@@ -71,9 +68,7 @@ describe("modVariableContext", () => {
       namespace: StateNamespaces.MOD,
       data: { run: true },
       mergeStrategy: MergeStrategies.REPLACE,
-      modComponentRef: mapMessageContextToModComponentRef(
-        options.logger.context,
-      ),
+      modComponentRef: options.modComponentRef,
     });
 
     const pipeline = [
@@ -100,9 +95,7 @@ describe("modVariableContext", () => {
       namespace: StateNamespaces.MOD,
       data: { name: "Bob" },
       mergeStrategy: MergeStrategies.REPLACE,
-      modComponentRef: mapMessageContextToModComponentRef(
-        options.logger.context,
-      ),
+      modComponentRef: options.modComponentRef,
     });
 
     const pipeline = [
@@ -130,9 +123,7 @@ describe("modVariableContext", () => {
       namespace: StateNamespaces.MOD,
       data: { name: "Bob" },
       mergeStrategy: MergeStrategies.REPLACE,
-      modComponentRef: mapMessageContextToModComponentRef(
-        options.logger.context,
-      ),
+      modComponentRef: options.modComponentRef,
     });
 
     const pipeline = [
@@ -158,9 +149,7 @@ describe("modVariableContext", () => {
       namespace: StateNamespaces.MOD,
       data: { name: "Bob" },
       mergeStrategy: MergeStrategies.REPLACE,
-      modComponentRef: mapMessageContextToModComponentRef(
-        options.logger.context,
-      ),
+      modComponentRef: options.modComponentRef,
     });
 
     const pipeline = [

--- a/src/runtime/pipelineTests/trace.test.ts
+++ b/src/runtime/pipelineTests/trace.test.ts
@@ -231,9 +231,6 @@ describe("Trace normal execution", () => {
     const instanceId = autoUUIDSequence();
     const runId = autoUUIDSequence();
     const modComponentRef = standaloneModComponentRefFactory();
-    const logger = new ConsoleLogger(
-      mapModComponentRefToMessageContext(modComponentRef),
-    );
 
     const brickConfig = {
       id: echoBrick.id,
@@ -241,14 +238,13 @@ describe("Trace normal execution", () => {
       instanceId,
     };
 
-    await reducePipeline(brickConfig, simpleInput({ inputArg: "hello" }), {
-      ...reduceOptionsFactory("v2"),
-      runId,
-      logger,
-      modComponentRef,
-    });
+    await reducePipeline(
+      brickConfig,
+      simpleInput({ inputArg: "hello" }),
+      reduceOptionsFactory("v2", { runId, modComponentRef }),
+    );
 
-    const meta: TraceRecordMeta = {
+    const expectedMeta: TraceRecordMeta = {
       modComponentId: modComponentRef.modComponentId,
       runId,
       branches: [],
@@ -257,7 +253,7 @@ describe("Trace normal execution", () => {
     };
 
     const expectedEntry: TraceEntryData = {
-      ...meta,
+      ...expectedMeta,
       timestamp: timestamp.toISOString(),
       brickConfig,
       templateContext: { "@input": { inputArg: "hello" }, "@options": {} },
@@ -266,7 +262,7 @@ describe("Trace normal execution", () => {
     };
 
     const expectedExit: TraceExitData = {
-      ...meta,
+      ...expectedMeta,
       outputKey: undefined,
       output: { message: "hello" },
       skippedRun: false,
@@ -290,9 +286,6 @@ describe("Trace normal execution", () => {
     const outputKey = validateOutputKey("echo");
 
     const modComponentRef = standaloneModComponentRefFactory();
-    const logger = new ConsoleLogger(
-      mapModComponentRefToMessageContext(modComponentRef),
-    );
 
     const brickPipeline: BrickPipeline = [
       {
@@ -308,14 +301,13 @@ describe("Trace normal execution", () => {
       },
     ];
 
-    await reducePipeline(brickPipeline, simpleInput({ inputArg: "hello" }), {
-      ...reduceOptionsFactory("v2"),
-      modComponentRef,
-      runId,
-      logger,
-    });
+    await reducePipeline(
+      brickPipeline,
+      simpleInput({ inputArg: "hello" }),
+      reduceOptionsFactory("v2", { modComponentRef, runId }),
+    );
 
-    const meta: TraceRecordMeta = {
+    const expectedMeta: TraceRecordMeta = {
       modComponentId: modComponentRef.modComponentId,
       runId,
       branches: [],
@@ -324,7 +316,7 @@ describe("Trace normal execution", () => {
     };
 
     const expectedExit: TraceExitData = {
-      ...meta,
+      ...expectedMeta,
       outputKey,
       output: { message: "hello" },
       skippedRun: false,

--- a/src/runtime/pipelineTests/trace.test.ts
+++ b/src/runtime/pipelineTests/trace.test.ts
@@ -39,6 +39,7 @@ import { toExpression } from "@/utils/expressionUtils";
 import { reduceOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 import { standaloneModComponentRefFactory } from "@/testUtils/factories/modComponentFactories";
 import { mapModComponentRefToMessageContext } from "@/utils/modUtils";
+import { autoUUIDSequence } from "@/testUtils/factories/stringFactories";
 
 const addEntryMock = jest.mocked(traces.addEntry);
 const addExitMock = jest.mocked(traces.addExit);
@@ -227,8 +228,8 @@ describe("Trace normal execution", () => {
     const timestamp = new Date("10/31/2021");
     MockDate.set(timestamp);
 
-    const instanceId = uuidv4();
-    const runId = uuidv4();
+    const instanceId = autoUUIDSequence();
+    const runId = autoUUIDSequence();
     const modComponentRef = standaloneModComponentRefFactory();
     const logger = new ConsoleLogger(
       mapModComponentRefToMessageContext(modComponentRef),
@@ -284,8 +285,8 @@ describe("Trace normal execution", () => {
     const timestamp = new Date("10/31/2021");
     MockDate.set(timestamp);
 
-    const instanceId = uuidv4();
-    const runId = uuidv4();
+    const instanceId = autoUUIDSequence();
+    const runId = autoUUIDSequence();
     const outputKey = validateOutputKey("echo");
 
     const modComponentRef = standaloneModComponentRefFactory();
@@ -293,7 +294,7 @@ describe("Trace normal execution", () => {
       mapModComponentRefToMessageContext(modComponentRef),
     );
 
-    const blockConfig: BrickPipeline = [
+    const brickPipeline: BrickPipeline = [
       {
         id: echoBrick.id,
         config: { message: "{{@input.inputArg}}" },
@@ -307,7 +308,7 @@ describe("Trace normal execution", () => {
       },
     ];
 
-    await reducePipeline(blockConfig, simpleInput({ inputArg: "hello" }), {
+    await reducePipeline(brickPipeline, simpleInput({ inputArg: "hello" }), {
       ...reduceOptionsFactory("v2"),
       modComponentRef,
       runId,
@@ -348,7 +349,7 @@ describe("Trace normal execution", () => {
 
     const outputKey = validateOutputKey("never");
 
-    const brickConfig: BrickPipeline = [
+    const brickPipeline: BrickPipeline = [
       {
         id: throwBrick.id,
         config: { message: "{{@input.inputArg}}" },
@@ -363,7 +364,7 @@ describe("Trace normal execution", () => {
     ];
 
     await expect(async () => {
-      await reducePipeline(brickConfig, simpleInput({ inputArg: "hello" }), {
+      await reducePipeline(brickPipeline, simpleInput({ inputArg: "hello" }), {
         ...reduceOptionsFactory("v2"),
         runId,
         logger,

--- a/src/runtime/pipelineTests/trace.test.ts
+++ b/src/runtime/pipelineTests/trace.test.ts
@@ -244,7 +244,7 @@ describe("Trace normal execution", () => {
       ...reduceOptionsFactory("v2"),
       runId,
       logger,
-      modComponentId: modComponentRef.modComponentId,
+      modComponentRef,
     });
 
     const meta: TraceRecordMeta = {
@@ -309,7 +309,7 @@ describe("Trace normal execution", () => {
 
     await reducePipeline(blockConfig, simpleInput({ inputArg: "hello" }), {
       ...reduceOptionsFactory("v2"),
-      modComponentId: modComponentRef.modComponentId,
+      modComponentRef,
       runId,
       logger,
     });

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -16,7 +16,7 @@
  */
 
 import { type Logger } from "@/types/loggerTypes";
-import { castArray, isPlainObject, once } from "lodash";
+import { castArray, isPlainObject, omit, once } from "lodash";
 import { requestRun, sendDeploymentAlert } from "@/background/messenger/api";
 import { hideNotification, showNotification } from "@/utils/notify";
 import { serializeError } from "serialize-error";
@@ -527,9 +527,9 @@ function selectTraceRecordMeta(
   resolvedConfig: ResolvedBrickConfig,
   options: RunBrickOptions,
 ): TraceRecordMeta {
-  // TODO: where does modComponentId come from?
   return {
-    ...options.trace,
+    // TraceRecordMeta uses modComponentId instead of modComponentRef
+    ...omit(options.trace, "modComponentRef"),
     brickId: resolvedConfig.config.id,
     modComponentId: options.trace.modComponentRef.modComponentId,
   };

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -575,7 +575,7 @@ async function runBrick(
     if (selectTraceEnabled(trace)) {
       getPlatform().debugger.traces.exit({
         ...trace,
-        modComponentId: logger.context.modComponentId,
+        modComponentId: trace.modComponentRef.modComponentId,
         brickId: brick.id,
         isFinal: true,
         isRenderer: true,
@@ -845,7 +845,7 @@ function throwBrickError(
     getPlatform().debugger.traces.exit({
       runId,
       branches,
-      modComponentId: logger.context.modComponentId,
+      modComponentId: options.modComponentRef.modComponentId,
       brickId: brickConfig.id,
       brickInstanceId: brickConfig.instanceId,
       error: serializeError(error),

--- a/src/sidebar/PanelBody.test.tsx
+++ b/src/sidebar/PanelBody.test.tsx
@@ -23,15 +23,15 @@ import { serializeError } from "serialize-error";
 import { BusinessError, CancelError } from "@/errors/businessErrors";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import registerBuiltinBricks from "@/bricks/registerBuiltinBricks";
-import { registryIdFactory } from "@/testUtils/factories/stringFactories";
 import {
   type RendererErrorPayload,
   type RendererRunPayload,
 } from "@/types/rendererTypes";
 import { screen } from "shadow-dom-testing-library";
+import { modComponentRefFactory } from "@/testUtils/factories/modComponentFactories";
+import { mapModComponentRefToMessageContext } from "@/utils/modUtils";
 
-const modComponentId = uuidv4();
-const modId = registryIdFactory();
+const modComponentRef = modComponentRefFactory();
 
 describe("PanelBody", () => {
   beforeAll(() => {
@@ -43,14 +43,14 @@ describe("PanelBody", () => {
       key: uuidv4(),
       error: serializeError(new Error("test error")),
       runId: uuidv4(),
-      modComponentId,
+      modComponentRef,
     };
 
     const { asFragment } = render(
       <PanelBody
         isRootPanel
         onAction={jest.fn()}
-        context={{ modComponentId, modId }}
+        context={mapModComponentRefToMessageContext(modComponentRef)}
         payload={payload}
       />,
     );
@@ -63,14 +63,14 @@ describe("PanelBody", () => {
       key: uuidv4(),
       error: serializeError(new BusinessError("test error")),
       runId: uuidv4(),
-      modComponentId,
+      modComponentRef,
     };
 
     const { asFragment } = render(
       <PanelBody
         isRootPanel
         onAction={jest.fn()}
-        context={{ modComponentId, modId }}
+        context={mapModComponentRefToMessageContext(modComponentRef)}
         payload={payload}
       />,
     );
@@ -83,14 +83,14 @@ describe("PanelBody", () => {
       key: uuidv4(),
       error: serializeError(new CancelError("test error")),
       runId: uuidv4(),
-      modComponentId,
+      modComponentRef,
     };
 
     const { asFragment } = render(
       <PanelBody
         isRootPanel
         onAction={jest.fn()}
-        context={{ modComponentId, modId }}
+        context={mapModComponentRefToMessageContext(modComponentRef)}
         payload={payload}
       />,
     );
@@ -102,7 +102,7 @@ describe("PanelBody", () => {
     const payload: RendererRunPayload = {
       key: uuidv4(),
       runId: uuidv4(),
-      modComponentId,
+      modComponentRef,
       brickId: validateRegistryId("@pixiebrix/html"),
       args: {
         html: "<h1>Test</h1>",
@@ -114,7 +114,7 @@ describe("PanelBody", () => {
       <PanelBody
         isRootPanel
         onAction={jest.fn()}
-        context={{ modComponentId, modId }}
+        context={mapModComponentRefToMessageContext(modComponentRef)}
         payload={payload}
       />,
     );
@@ -129,7 +129,7 @@ describe("PanelBody", () => {
     const payload: RendererRunPayload = {
       key: uuidv4(),
       runId: uuidv4(),
-      modComponentId,
+      modComponentRef,
       brickId: validateRegistryId("@pixiebrix/html"),
       args: {
         html: "<h1>Test</h1>",
@@ -141,7 +141,7 @@ describe("PanelBody", () => {
       <PanelBody
         isRootPanel
         onAction={jest.fn()}
-        context={{ modComponentId, modId }}
+        context={mapModComponentRefToMessageContext(modComponentRef)}
         payload={payload}
       />,
     );
@@ -157,7 +157,7 @@ describe("PanelBody", () => {
     const payload: RendererRunPayload = {
       key: uuidv4(),
       runId: uuidv4(),
-      modComponentId,
+      modComponentRef,
       brickId: validateRegistryId("@pixiebrix/document"),
       args: {
         body: [
@@ -215,7 +215,7 @@ describe("PanelBody", () => {
       <PanelBody
         isRootPanel
         onAction={jest.fn()}
-        context={{ modComponentId, modId }}
+        context={mapModComponentRefToMessageContext(modComponentRef)}
         payload={payload}
       />,
     );

--- a/src/sidebar/PanelBody.tsx
+++ b/src/sidebar/PanelBody.tsx
@@ -25,7 +25,7 @@ import {
   isRendererLoadingPayload,
   type PanelContext,
   type PanelPayload,
-  type PanelRunMeta,
+  type PanelRunMetadata,
 } from "@/types/sidebarTypes";
 import RendererComponent from "@/sidebar/RendererComponent";
 import { BusinessError, CancelError } from "@/errors/businessErrors";
@@ -53,7 +53,7 @@ import { getPlatform } from "@/platform/platformContext";
 type BodyProps = {
   brickId?: RegistryId;
   body?: RendererOutput;
-  meta?: PanelRunMeta;
+  meta?: PanelRunMetadata;
 };
 
 const BodyContainer: React.FC<
@@ -173,7 +173,7 @@ const PanelBody: React.FunctionComponent<{
           ctxt: brickArgsContext,
           args,
           runId,
-          modComponentId,
+          modComponentRef,
         } = payload;
 
         console.debug("Running panel body for panel payload", payload);
@@ -192,7 +192,7 @@ const PanelBody: React.FunctionComponent<{
           ctxt: brickArgsContext as UnknownObject,
           meta: {
             runId,
-            modComponentId,
+            modComponentRef,
             branches,
           },
           logger,
@@ -216,7 +216,7 @@ const PanelBody: React.FunctionComponent<{
               options: apiVersionOptions("v3"),
               messageContext: logger.context,
               meta: {
-                modComponentId,
+                modComponentRef,
                 runId,
                 branches: [...branches, branch],
               },
@@ -229,12 +229,6 @@ const PanelBody: React.FunctionComponent<{
           },
         });
 
-        if (!runId || !modComponentId) {
-          console.warn("PanelBody requires runId in RendererPayload", {
-            payload,
-          });
-        }
-
         if (!isMounted()) {
           return;
         }
@@ -244,7 +238,7 @@ const PanelBody: React.FunctionComponent<{
             data: {
               brickId,
               body: body as RendererOutput,
-              meta: { runId, modComponentId },
+              meta: { runId, modComponentRef },
             },
           }),
         );

--- a/src/sidebar/RendererComponent.test.tsx
+++ b/src/sidebar/RendererComponent.test.tsx
@@ -81,7 +81,7 @@ describe("RendererComponent", () => {
       <RendererComponent
         brickId={validateRegistryId("@pixiebrix/document")}
         body={{ Component: DocumentView as any, props }}
-        meta={{ runId, modComponentRef }}
+        meta={props.options.meta}
         onAction={onAction}
       />,
     );

--- a/src/sidebar/RendererComponent.test.tsx
+++ b/src/sidebar/RendererComponent.test.tsx
@@ -16,19 +16,20 @@
  */
 
 import React from "react";
-import { render, act } from "@/sidebar/testHelpers";
+import { act, render } from "@/sidebar/testHelpers";
 import RendererComponent from "@/sidebar/RendererComponent";
-import { uuidv4, validateRegistryId } from "@/types/helpers";
+import { validateRegistryId } from "@/types/helpers";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import DocumentView from "@/bricks/renderers/documentView/DocumentView";
 import { screen } from "shadow-dom-testing-library";
 import { SubmitPanelAction } from "@/bricks/errors";
-import ConsoleLogger from "@/utils/ConsoleLogger";
 import { runHeadlessPipeline } from "@/contentScript/messenger/api";
-import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
+import {
+  brickOptionsFactory,
+  runMetadataFactory,
+} from "@/testUtils/factories/runtimeFactories";
 import { toExpression } from "@/utils/expressionUtils";
-import { modComponentRefFactory } from "@/testUtils/factories/modComponentFactories";
-import { mapModComponentRefToMessageContext } from "@/utils/modUtils";
+import { autoUUIDSequence } from "@/testUtils/factories/stringFactories";
 
 jest.mock("@/contentScript/messenger/api", () => ({
   runHeadlessPipeline: jest
@@ -44,9 +45,6 @@ describe("RendererComponent", () => {
   });
 
   test("provide onAction to document renderer", async () => {
-    const runId = uuidv4();
-
-    const modComponentRef = modComponentRefFactory();
     const onAction = jest.fn();
 
     runHeadlessPipelineMock.mockRejectedValue(
@@ -66,21 +64,16 @@ describe("RendererComponent", () => {
     const props = {
       body: [config],
       options: brickOptionsFactory({
-        logger: new ConsoleLogger(
-          mapModComponentRefToMessageContext(modComponentRef),
-        ),
-        meta: {
-          runId,
-          modComponentRef,
-          branches: [],
-        },
+        meta: runMetadataFactory({
+          runId: autoUUIDSequence(),
+        }),
       }),
     };
 
     render(
       <RendererComponent
         brickId={validateRegistryId("@pixiebrix/document")}
-        body={{ Component: DocumentView as any, props }}
+        body={{ Component: DocumentView, props }}
         meta={props.options.meta}
         onAction={onAction}
       />,

--- a/src/sidebar/RendererComponent.test.tsx
+++ b/src/sidebar/RendererComponent.test.tsx
@@ -27,6 +27,8 @@ import ConsoleLogger from "@/utils/ConsoleLogger";
 import { runHeadlessPipeline } from "@/contentScript/messenger/api";
 import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 import { toExpression } from "@/utils/expressionUtils";
+import { modComponentRefFactory } from "@/testUtils/factories/modComponentFactories";
+import { mapModComponentRefToMessageContext } from "@/utils/modUtils";
 
 jest.mock("@/contentScript/messenger/api", () => ({
   runHeadlessPipeline: jest
@@ -43,7 +45,8 @@ describe("RendererComponent", () => {
 
   test("provide onAction to document renderer", async () => {
     const runId = uuidv4();
-    const modComponentId = uuidv4();
+
+    const modComponentRef = modComponentRefFactory();
     const onAction = jest.fn();
 
     runHeadlessPipelineMock.mockRejectedValue(
@@ -63,10 +66,12 @@ describe("RendererComponent", () => {
     const props = {
       body: [config],
       options: brickOptionsFactory({
-        logger: new ConsoleLogger({ modComponentId }),
+        logger: new ConsoleLogger(
+          mapModComponentRefToMessageContext(modComponentRef),
+        ),
         meta: {
           runId,
-          modComponentId,
+          modComponentRef,
           branches: [],
         },
       }),
@@ -76,7 +81,7 @@ describe("RendererComponent", () => {
       <RendererComponent
         brickId={validateRegistryId("@pixiebrix/document")}
         body={{ Component: DocumentView as any, props }}
-        meta={{ runId, modComponentId }}
+        meta={{ runId, modComponentRef }}
         onAction={onAction}
       />,
     );

--- a/src/sidebar/RendererComponent.tsx
+++ b/src/sidebar/RendererComponent.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { type PanelRunMeta } from "@/types/sidebarTypes";
+import { type PanelRunMetadata } from "@/types/sidebarTypes";
 import { type SubmitPanelAction } from "@/bricks/errors";
 import { type RegistryId } from "@/types/registryTypes";
 import { type RendererOutput } from "@/types/runtimeTypes";
@@ -12,7 +12,7 @@ const RendererComponent: React.FunctionComponent<{
   onAction?: (action: SubmitPanelAction) => void;
   brickId?: RegistryId;
   body?: RendererOutput;
-  meta?: PanelRunMeta;
+  meta?: PanelRunMetadata;
 }> = ({ body, meta, brickId, onAction }) =>
   useMemo(() => {
     if (!body) {

--- a/src/starterBricks/button/buttonStarterBrick.ts
+++ b/src/starterBricks/button/buttonStarterBrick.ts
@@ -92,7 +92,10 @@ import {
   type ButtonTargetMode,
 } from "@/starterBricks/button/buttonStarterBrickTypes";
 import { assertNotNullish } from "@/utils/nullishUtils";
-import { mapModComponentToMessageContext } from "@/utils/modUtils";
+import {
+  getModComponentRef,
+  mapModComponentToMessageContext,
+} from "@/utils/modUtils";
 
 const DATA_ATTR = "data-pb-uuid";
 
@@ -537,6 +540,7 @@ export abstract class ButtonStarterBrickABC extends StarterBrickABC<ButtonStarte
       const show = await reducePipeline(modComponent.config.if, initialValues, {
         // Don't pass extension: modComponentLogger because our log display doesn't handle the in-starter brick
         // conditionals yet
+        modComponentRef: getModComponentRef(modComponent),
         ...versionOptions,
       });
 
@@ -619,6 +623,7 @@ export abstract class ButtonStarterBrickABC extends StarterBrickABC<ButtonStarte
 
           await reduceModComponentPipeline(actionConfig, initialValues, {
             logger: modComponentLogger,
+            modComponentRef: getModComponentRef(modComponent),
             ...apiVersionOptions(modComponent.apiVersion),
           });
 

--- a/src/starterBricks/contextMenu/contextMenuStarterBrick.ts
+++ b/src/starterBricks/contextMenu/contextMenuStarterBrick.ts
@@ -75,7 +75,10 @@ import {
   type ContextMenuDefinition,
 } from "@/starterBricks/contextMenu/contextMenuTypes";
 import { assertNotNullish } from "@/utils/nullishUtils";
-import { mapModComponentToMessageContext } from "@/utils/modUtils";
+import {
+  getModComponentRef,
+  mapModComponentToMessageContext,
+} from "@/utils/modUtils";
 
 const DEFAULT_MENU_ITEM_TITLE = "Untitled menu item";
 
@@ -373,6 +376,7 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
 
         await reduceModComponentPipeline(actionConfig, initialValues, {
           logger: modComponentLogger,
+          modComponentRef: getModComponentRef(modComponent),
           ...apiVersionOptions(modComponent.apiVersion),
         });
 

--- a/src/starterBricks/quickBar/quickBarStarterBrick.tsx
+++ b/src/starterBricks/quickBar/quickBarStarterBrick.tsx
@@ -250,6 +250,7 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
 
           await reduceModComponentPipeline(actionConfig, initialValues, {
             logger: modComponentLogger,
+            modComponentRef: getModComponentRef(modComponent),
             ...apiVersionOptions(modComponent.apiVersion),
           });
         } catch (error) {

--- a/src/starterBricks/quickBarProvider/quickBarProviderStarterBrick.tsx
+++ b/src/starterBricks/quickBarProvider/quickBarProviderStarterBrick.tsx
@@ -299,6 +299,7 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
       try {
         await reduceModComponentPipeline(generator, initialValues, {
           logger: modComponentLogger,
+          modComponentRef: getModComponentRef(modComponent),
           ...apiVersionOptions(modComponent.apiVersion),
           abortSignal,
         });

--- a/src/starterBricks/sidebar/sidebarStarterBrick.ts
+++ b/src/starterBricks/sidebar/sidebarStarterBrick.ts
@@ -62,7 +62,10 @@ import {
   SidebarTriggers,
 } from "@/starterBricks/sidebar/sidebarStarterBrickTypes";
 import { assertNotNullish, type Nullishable } from "@/utils/nullishUtils";
-import { mapModComponentToMessageContext } from "@/utils/modUtils";
+import {
+  getModComponentRef,
+  mapModComponentToMessageContext,
+} from "@/utils/modUtils";
 import { STATE_CHANGE_JS_EVENT_TYPE } from "@/platform/state/stateTypes";
 
 export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConfig> {
@@ -203,6 +206,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
       await reduceModComponentPipeline(body, initialValues, {
         headless: true,
         logger: componentLogger,
+        modComponentRef: getModComponentRef(modComponent),
         ...apiVersionOptions(modComponent.apiVersion),
         runId,
       });
@@ -218,7 +222,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
 
       const runMetadata = {
         runId,
-        modComponentId: modComponent.id,
+        modComponentRef,
       };
 
       if (error instanceof HeadlessModeError) {

--- a/src/starterBricks/trigger/triggerStarterBrick.ts
+++ b/src/starterBricks/trigger/triggerStarterBrick.ts
@@ -88,7 +88,10 @@ import type { PlatformCapability } from "@/platform/capabilities";
 import type { PlatformProtocol } from "@/platform/platformProtocol";
 import { propertiesToSchema } from "@/utils/schemaUtils";
 import { type Nullishable, assertNotNullish } from "@/utils/nullishUtils";
-import { mapModComponentToMessageContext } from "@/utils/modUtils";
+import {
+  getModComponentRef,
+  mapModComponentToMessageContext,
+} from "@/utils/modUtils";
 
 type TriggerTarget = Document | HTMLElement;
 
@@ -417,6 +420,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
 
     await reduceModComponentPipeline(actionConfig, initialValues, {
       logger: componentLogger,
+      modComponentRef: getModComponentRef(modComponent),
       ...apiVersionOptions(modComponent.apiVersion),
     });
   }

--- a/src/telemetry/trace.ts
+++ b/src/telemetry/trace.ts
@@ -46,7 +46,7 @@ export type TraceRecordMeta = {
   modComponentId: Nullishable<UUID>;
 
   /**
-   * Extension run id. Unique run id to correlate trace entries from the same extension run.
+   * Mod component run id. Unique run id to correlate trace entries from the same mod component run.
    */
   runId: Nullishable<UUID>;
 

--- a/src/testUtils/factories/modComponentFactories.ts
+++ b/src/testUtils/factories/modComponentFactories.ts
@@ -23,6 +23,7 @@ import {
   type ModMetadata,
 } from "@/types/modComponentTypes";
 import {
+  autoUUIDSequence,
   registryIdFactory,
   timestampFactory,
   uuidSequence,
@@ -36,7 +37,8 @@ import { type StandaloneModDefinition } from "@/types/contract";
 import { type Metadata, DefinitionKinds } from "@/types/registryTypes";
 
 export const modComponentRefFactory = define<ModComponentRef>({
-  modComponentId: uuidSequence,
+  // Don't repeat UUIDs across contexts
+  modComponentId: () => autoUUIDSequence(),
   modId: registryIdFactory,
   starterBrickId: registryIdFactory,
 });
@@ -46,7 +48,8 @@ export const modComponentRefFactory = define<ModComponentRef>({
  * @deprecated standalone mod components are deprecated
  */
 export const standaloneModComponentRefFactory = define<ModComponentRef>({
-  modComponentId: uuidSequence,
+  // Don't repeat UUIDs across contexts
+  modComponentId: () => autoUUIDSequence(),
   modId: undefined,
   starterBrickId: registryIdFactory,
 });

--- a/src/testUtils/factories/runtimeFactories.ts
+++ b/src/testUtils/factories/runtimeFactories.ts
@@ -31,6 +31,7 @@ import {
 import type { ReduceOptions } from "@/runtime/reducePipeline";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import { type ModComponentRef } from "@/types/modComponentTypes";
 
 /**
  * Factory for BrickOptions to pass to Brick.run method.
@@ -75,7 +76,7 @@ export const brickOptionsFactory = define<BrickOptions>({
 export const runMetadataFactory = define<RunMetadata>({
   runId: null,
   modComponentRef: modComponentRefFactory,
-  branches: [],
+  branches: () => [] as RunMetadata["branches"],
 });
 
 /**
@@ -85,8 +86,11 @@ export const runMetadataFactory = define<RunMetadata>({
  */
 export function reduceOptionsFactory(
   runtimeVersion: ApiVersion = "v3",
+  {
+    modComponentRef: modComponentRefOverride,
+  }: { modComponentRef?: ModComponentRef } = {},
 ): ReduceOptions {
-  const modComponentRef = modComponentRefFactory();
+  const modComponentRef = modComponentRefOverride ?? modComponentRefFactory();
   const logger = new ConsoleLogger(
     mapModComponentRefToMessageContext(modComponentRef),
   );

--- a/src/testUtils/factories/runtimeFactories.ts
+++ b/src/testUtils/factories/runtimeFactories.ts
@@ -28,7 +28,6 @@ import { mapModComponentRefToMessageContext } from "@/utils/modUtils";
 import type { ReduceOptions } from "@/runtime/reducePipeline";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { assertNotNullish } from "@/utils/nullishUtils";
-import { type ModComponentRef } from "@/types/modComponentTypes";
 
 export const runMetadataFactory = define<RunMetadata>({
   runId: null,
@@ -73,23 +72,23 @@ export const brickOptionsFactory = define<BrickOptions>({
  * @see apiVersionOptions
  */
 export function reduceOptionsFactory(
+  // XXX: How to handle traits in cooky-cutter similar to Python's Factory Boy?
+  // https://factoryboy.readthedocs.io/en/stable/introduction.html#altering-a-factory-s-behavior-parameters-and-traits
   runtimeVersion: ApiVersion = "v3",
-  {
-    modComponentRef: modComponentRefOverride,
-  }: { modComponentRef?: ModComponentRef } = {},
+  overrides: Partial<ReduceOptions> = {},
 ): ReduceOptions {
-  const modComponentRef = modComponentRefOverride ?? modComponentRefFactory();
-  const logger = new ConsoleLogger(
-    mapModComponentRefToMessageContext(modComponentRef),
-  );
+  const modComponentRef = overrides.modComponentRef ?? modComponentRefFactory();
+  const logger =
+    overrides.logger ??
+    new ConsoleLogger(mapModComponentRefToMessageContext(modComponentRef));
 
   return {
     modComponentRef,
     logger,
-    runId: null,
-    headless: false,
-    branches: [],
-    logValues: true,
+    runId: overrides.runId ?? null,
+    headless: overrides.headless ?? false,
+    branches: overrides.branches ?? [],
+    logValues: overrides.logValues ?? true,
     ...apiVersionOptions(runtimeVersion),
   };
 }

--- a/src/types/rendererTypes.ts
+++ b/src/types/rendererTypes.ts
@@ -19,6 +19,7 @@ import { type RegistryId } from "@/types/registryTypes";
 import { type UUID } from "@/types/stringTypes";
 import { type Nullishable } from "@/utils/nullishUtils";
 import { type Except } from "type-fest";
+import { type ModComponentRef } from "@/types/modComponentTypes";
 
 type BaseRendererPayload = {
   /**
@@ -27,10 +28,9 @@ type BaseRendererPayload = {
   key: Nullishable<string>;
   /**
    * The ModComponent that produced the payload.
-   * Marked Nullishable as part of the StrictNullChecks migration.
-   * TODO: Revisit and determine if modComponentId should be required.
+   * @since 2.0.6 is a ModComponentRef
    */
-  modComponentId: Nullishable<UUID>;
+  modComponentRef: ModComponentRef;
   /**
    * The ModComponent run that produced the payload
    * @since 1.7.0

--- a/src/types/runtimeTypes.ts
+++ b/src/types/runtimeTypes.ts
@@ -24,7 +24,7 @@ import { type BrickPipeline } from "@/bricks/types";
 import { type PanelPayload } from "./sidebarTypes";
 import { type PlatformProtocol } from "@/platform/platformProtocol";
 import { type Nullishable } from "@/utils/nullishUtils";
-import { ModComponentRef } from "@/types/modComponentTypes";
+import { type ModComponentRef } from "@/types/modComponentTypes";
 
 /**
  * The PixieBrix brick definition API. Controls how the PixieBrix runtime interprets brick definitions.

--- a/src/types/runtimeTypes.ts
+++ b/src/types/runtimeTypes.ts
@@ -24,6 +24,7 @@ import { type BrickPipeline } from "@/bricks/types";
 import { type PanelPayload } from "./sidebarTypes";
 import { type PlatformProtocol } from "@/platform/platformProtocol";
 import { type Nullishable } from "@/utils/nullishUtils";
+import { ModComponentRef } from "@/types/modComponentTypes";
 
 /**
  * The PixieBrix brick definition API. Controls how the PixieBrix runtime interprets brick definitions.
@@ -302,12 +303,14 @@ export type Branch = {
  */
 export interface RunMetadata {
   /**
-   * The mod component that's running the brick. Used to correlate trace records across all runs/branches.
-   * @since 1.7.0
-   * Marked Nullishable as part of the StrictNullChecks migration.
-   * TODO: Revisit and determine if modComponentId should be required.
+   * The mod component that's running the brick. Used to:
+   *
+   * - Associate UI elements with the mod component (e.g., forms, quickbar actions, etc.)
+   * - Used to correlate trace records across all runs/branches.
+   *
+   * @since 2.0.6 is the full ModComponentRef instead of just the modComponentId
    */
-  modComponentId: Nullishable<UUID>;
+  modComponentRef: ModComponentRef;
   /**
    * A unique run id to correlate trace records across branches for a run, or null to disable tracing.
    */

--- a/src/types/runtimeTypes.ts
+++ b/src/types/runtimeTypes.ts
@@ -312,7 +312,7 @@ export interface RunMetadata {
    */
   modComponentRef: ModComponentRef;
   /**
-   * A unique run id to correlate trace records across branches for a run, or null to disable tracing.
+   * A unique run id to correlate trace records across branches for a run, or nullish to disable tracing.
    */
   runId: Nullishable<UUID>;
   /**

--- a/src/types/sidebarTypes.ts
+++ b/src/types/sidebarTypes.ts
@@ -303,6 +303,8 @@ export type ActivatePanelOptions = {
    */
   refresh?: boolean;
 
+  // XXX: can't use ModComponentRef directly here, because extensionId and/or blueprintId might be excluded depending
+  // on the specificity of the request
   /**
    * The id of the extension panel to show. Included so the Page Editor can request a specific panel to show when
    * editing the extension
@@ -316,6 +318,7 @@ export type ActivatePanelOptions = {
    * @since 1.6.5
    */
   blueprintId?: RegistryId;
+
   /**
    * A panel heading name to match
    *

--- a/src/types/sidebarTypes.ts
+++ b/src/types/sidebarTypes.ts
@@ -328,7 +328,7 @@ export type ActivatePanelOptions = {
  * Metadata about the extension that produced the panel content
  * @since 1.7.0
  */
-export type PanelRunMeta = Pick<RunMetadata, "runId" | "modComponentId">;
+export type PanelRunMetadata = Pick<RunMetadata, "runId" | "modComponentRef">;
 
 export type SidebarState = SidebarEntries & {
   activeKey: Nullishable<string>;


### PR DESCRIPTION
## What does this PR do?

- Pass mod component ref via `BrickOptions.meta` (vs. bricks mapping from the logger message context)
- Prep work for making `modId` required in the runtime

## Reviewer Notes

- Search codebase for `logger.context` to see places where logger context is passed around. It should only ever be passed into to other context (as opposed to used to get the `modComponentId`/`modId`)
- Search codebase for `mapMessageContextToModComponentRef` to see places where context is being passed in for component ref vs. passing through component ref

## Future Work

- Make `modId` required in `ModComponentRef`: https://github.com/pixiebrix/pixiebrix-extension/pull/8857/files
- Clean up [TraceRecordMeta](https://github.com/pixiebrix/pixiebrix-extension/blob/c73aa30272b96d0da34ba9e4d3a0910a6f252e3b/src/telemetry/trace.ts#L38-L38) properties in the runtime
- Clean up names in [ActivatePanelOptions](https://github.com/pixiebrix/pixiebrix-extension/blob/8779b1c92a3195404df27c3ca5667593173eb8f1/src/types/sidebarTypes.ts#L289-L289)
- Consider passing `deploymentId` in the meta object instead of using the logger context: https://github.com/pixiebrix/pixiebrix-extension/blob/c73aa30272b96d0da34ba9e4d3a0910a6f252e3b/src/runtime/reducePipeline.ts#L862-L862

## Discussion

- I replaced `meta.modComponentId` with `meta.modComponentRef`. We could consider putting the `modComponentRef` directly on `BrickOptions,` but it would complicate the tracing code

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
