### PR TITLE
DX - Quick followup to clean up `insertingStarterBrick` call site

### DIFF
--- a/src/pageEditor/layout/EditorLayout.tsx
+++ b/src/pageEditor/layout/EditorLayout.tsx
@@ -20,7 +20,7 @@ import ModListingPanel from "@/pageEditor/modListingPanel/ModListingPanel";
 import { useDispatch, useSelector } from "react-redux";
 import useFlags from "@/hooks/useFlags";
 import Modals from "../modals/Modals";
-import { selectInsertingStarterBrickType } from "@/pageEditor/store/editor/editorSelectors";
+import { selectIsInsertingStarterBrick } from "@/pageEditor/store/editor/editorSelectors";
 import EditorContent from "@/pageEditor/layout/EditorContent";
 import styles from "./EditorLayout.module.scss";
 import RestrictedPane from "@/pageEditor/panes/RestrictedPane";
@@ -36,7 +36,7 @@ import { usePreviousValue } from "@/hooks/usePreviousValue";
 
 const EditorLayout: React.FunctionComponent = () => {
   const dispatch = useDispatch();
-  const isInserting = useSelector(selectInsertingStarterBrickType);
+  const isInserting = useSelector(selectIsInsertingStarterBrick);
   const { restrict } = useFlags();
   const isRestricted = restrict("page-editor");
   const isStaleSession = useSelector(selectIsStaleSession);
@@ -50,7 +50,7 @@ const EditorLayout: React.FunctionComponent = () => {
       ) : isStaleSession ? (
         <StaleSessionPane />
       ) : isInserting ? (
-        <InsertPane inserting={isInserting} />
+        <InsertPane />
       ) : (
         <>
           <ModListingPanel />

--- a/src/pageEditor/panes/insert/InsertPane.tsx
+++ b/src/pageEditor/panes/insert/InsertPane.tsx
@@ -16,23 +16,21 @@
  */
 
 import React, { useCallback } from "react";
-import {
-  type StarterBrickType,
-  StarterBrickTypes,
-} from "@/types/starterBrickTypes";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 import InsertButtonPane from "@/pageEditor/panes/insert/InsertButtonPane";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { actions } from "@/pageEditor/store/editor/editorSlice";
 import useEscapeHandler from "@/pageEditor/hooks/useEscapeHandler";
 import useAutoInsert from "@/pageEditor/panes/insert/useAutoInsert";
 import { inspectedTab } from "@/pageEditor/context/connection";
 import { cancelSelect } from "@/contentScript/messenger/api";
+import { selectInsertingStarterBrickType } from "@/pageEditor/store/editor/editorSelectors";
 
-const InsertPane: React.FC<{ inserting: StarterBrickType }> = ({
-  inserting,
-}) => {
+const InsertPane: React.FC = () => {
+  const starterBrickType = useSelector(selectInsertingStarterBrickType);
+
   // Auto-insert if the StarterBrickType supports it
-  useAutoInsert(inserting);
+  useAutoInsert(starterBrickType);
 
   const dispatch = useDispatch();
 
@@ -42,9 +40,9 @@ const InsertPane: React.FC<{ inserting: StarterBrickType }> = ({
   }, [dispatch]);
 
   // Cancel insert with escape key
-  useEscapeHandler(cancelInsert, inserting != null);
+  useEscapeHandler(cancelInsert, starterBrickType != null);
 
-  switch (inserting) {
+  switch (starterBrickType) {
     case StarterBrickTypes.BUTTON: {
       return <InsertButtonPane cancel={cancelInsert} />;
     }

--- a/src/pageEditor/store/editor/editorSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors.ts
@@ -76,6 +76,9 @@ export const selectActiveModId = ({ editor }: EditorRootState) =>
 export const selectInsertingStarterBrickType = ({ editor }: EditorRootState) =>
   editor.insertingStarterBrickType;
 
+export const selectIsInsertingStarterBrick = ({ editor }: EditorRootState) =>
+  editor.insertingStarterBrickType != null;
+
 export const selectActiveModComponentRef = createSelector(
   selectActiveModComponentFormState,
   selectActiveModId,


### PR DESCRIPTION
## What does this PR do?

- Quick followup to https://github.com/pixiebrix/pixiebrix-extension/pull/8820
- Related to the `inserting` --> `insertingStarterBrickType` property name change on the `editor` redux slice
- Slight refactoring to make code at call sites more clear with intentions, split into two different selectors

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
