### PR TITLE
#8856: fix display of mod variables and page state warnings for standalone mod components

### DIFF
--- a/src/analysis/analysisVisitors/pageStateAnalysis/pageStateAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/pageStateAnalysis/pageStateAnalysis.test.ts
@@ -76,58 +76,8 @@ describe("PageStateAnalysis", () => {
     ]);
   });
 
-  it("shows warning on mod page state for custom form if not mod", async () => {
-    const state = formStateFactory({
-      brickPipeline: [
-        {
-          id: CustomFormRenderer.BRICK_ID,
-          config: {
-            storage: {
-              type: "state",
-              namespace: StateNamespaces.MOD,
-            },
-          },
-        },
-      ],
-    });
-
-    const analysis = new PageStateAnalysis();
-    await analysis.run(state);
-
-    expect(analysis.getAnnotations()).toEqual([
-      expect.objectContaining({
-        type: AnnotationType.Warning,
-      }),
-    ]);
-  });
-
   it.each([SetPageState.BRICK_ID, GetPageState.BRICK_ID])(
-    "shows warning on blueprint if not in mod %s",
-    async (registryId) => {
-      const state = formStateFactory({
-        brickPipeline: [
-          {
-            id: registryId,
-            config: {
-              namespace: StateNamespaces.MOD,
-            },
-          },
-        ],
-      });
-
-      const analysis = new PageStateAnalysis();
-      await analysis.run(state);
-
-      expect(analysis.getAnnotations()).toEqual([
-        expect.objectContaining({
-          type: AnnotationType.Warning,
-        }),
-      ]);
-    },
-  );
-
-  it.each([SetPageState.BRICK_ID, GetPageState.BRICK_ID])(
-    "no warning on blueprint if in mod %s",
+    "no warning on mod if in mod %s",
     async (registryId) => {
       const state = formStateFactory({
         brickPipeline: [

--- a/src/analysis/analysisVisitors/pageStateAnalysis/pageStateAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/pageStateAnalysis/pageStateAnalysis.test.ts
@@ -77,7 +77,7 @@ describe("PageStateAnalysis", () => {
   });
 
   it.each([SetPageState.BRICK_ID, GetPageState.BRICK_ID])(
-    "no warning on mod if in mod %s",
+    "shows no warning mod namespace for brick in mod: %s",
     async (registryId) => {
       const state = formStateFactory({
         brickPipeline: [

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/ModVariablesTab.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/ModVariablesTab.tsx
@@ -19,10 +19,7 @@ import React from "react";
 import JsonTree from "@/components/jsonTree/JsonTree";
 import { getPageState } from "@/contentScript/messenger/api";
 import { getErrorMessage } from "@/errors/errorHelpers";
-import {
-  selectActiveModComponentFormState,
-  selectActiveModComponentRef,
-} from "@/pageEditor/store/editor/editorSelectors";
+import { selectActiveModComponentRef } from "@/pageEditor/store/editor/editorSelectors";
 import { faExternalLinkAlt, faSync } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Button } from "react-bootstrap";
@@ -54,9 +51,6 @@ type StateValues = {
  */
 const ModVariablesTab: React.VFC = () => {
   const modComponentRef = useSelector(selectActiveModComponentRef);
-  const activeModComponentFormState = useSelector(
-    selectActiveModComponentFormState,
-  );
 
   const state = useAsyncState<StateValues>(
     async () =>
@@ -66,12 +60,10 @@ const ModVariablesTab: React.VFC = () => {
           namespace: StateNamespaces.PUBLIC,
           modComponentRef,
         }),
-        Mod: activeModComponentFormState?.modMetadata
-          ? getPageState(inspectedTab, {
-              namespace: StateNamespaces.MOD,
-              modComponentRef,
-            })
-          : Promise.resolve("Starter Brick is not in a mod package"),
+        Mod: getPageState(inspectedTab, {
+          namespace: StateNamespaces.MOD,
+          modComponentRef,
+        }),
         Private: getPageState(inspectedTab, {
           namespace: StateNamespaces.PRIVATE,
           modComponentRef,

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/__snapshots__/ModVariablesTab.test.tsx.snap
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/__snapshots__/ModVariablesTab.test.tsx.snap
@@ -429,20 +429,72 @@ exports[`ModVariablesTab renders with standalone mod component 1`] = `
               </ul>
             </li>
             <li
-              style="padding-top: 0.25em; padding-right: 0px; margin-left: 0.875em; word-wrap: break-word; padding-left: 1.25em; text-indent: -0.5em; word-break: break-all; white-space: pre-wrap;"
+              style="position: relative; padding-top: 0.25em; margin-left: 0px; padding-left: 0px;"
             >
+              <div
+                style="display: inline-block; padding-right: 0.5em; padding-left: 0px; cursor: pointer;"
+              >
+                <div
+                  style="margin-left: 0px; transition: 150ms; transform: rotateZ(90deg); transform-origin: 45% 50%; position: relative; line-height: 1.1em; font-size: 0.75em; color: rgb(57, 113, 237);"
+                >
+                  ▶
+                </div>
+              </div>
               <label
-                style="display: inline-block; color: rgb(57, 113, 237); margin: 0px 0.5em 0px 0px;"
+                style="display: inline-block; color: rgb(57, 113, 237); margin: 0px; padding: 0px; cursor: pointer;"
               >
                 <span>
                   Mod:
                 </span>
               </label>
               <span
-                style="color: rgb(0, 113, 36);"
+                style="padding-left: 0.5em; cursor: default; color: rgb(0, 113, 36);"
               >
-                "Starter Brick is not in a mod package"
+                <span>
+                  <span
+                    style="margin-left: 0.3em; margin-right: 0.3em;"
+                  >
+                    {}
+                  </span>
+                   2 keys
+                </span>
               </span>
+              <ul
+                style="padding: 0px; margin: 0px; list-style: none; display: block;"
+              >
+                <li
+                  style="padding-top: 0.25em; padding-right: 0px; margin-left: 0.875em; word-wrap: break-word; padding-left: 2.125em; text-indent: -0.5em; word-break: break-all; white-space: pre-wrap;"
+                >
+                  <label
+                    style="display: inline-block; color: rgb(57, 113, 237); margin: 0px 0.5em 0px 0px;"
+                  >
+                    <span>
+                      foo:
+                    </span>
+                  </label>
+                  <span
+                    style="color: rgb(0, 113, 36);"
+                  >
+                    "bar"
+                  </span>
+                </li>
+                <li
+                  style="padding-top: 0.25em; padding-right: 0px; margin-left: 0.875em; word-wrap: break-word; padding-left: 2.125em; text-indent: -0.5em; word-break: break-all; white-space: pre-wrap;"
+                >
+                  <label
+                    style="display: inline-block; color: rgb(57, 113, 237); margin: 0px 0.5em 0px 0px;"
+                  >
+                    <span>
+                      baz:
+                    </span>
+                  </label>
+                  <span
+                    style="color: rgb(249, 106, 56);"
+                  >
+                    32
+                  </span>
+                </li>
+              </ul>
             </li>
             <li
               style="position: relative; padding-top: 0.25em; margin-left: 0px; padding-left: 0px;"


### PR DESCRIPTION
## What does this PR do?

- Part of #8856 
- 🐛  Fixes bugs in https://github.com/pixiebrix/pixiebrix-extension/pull/8857
  - Don't show standalone mod warning in the Mod Variables tab
  - Don't generate analysis warnings for page state use in standalone mod components 

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
