### PR TITLE
#8875: show info annotation if selector literal contains template characters

### DIFF
--- a/src/analysis/analysisVisitors/selectorAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/selectorAnalysis.test.ts
@@ -161,6 +161,40 @@ describe("SelectorAnalysis", () => {
     ]);
   });
 
+  it("detects template in selector literal", async () => {
+    const analysis = new SelectorAnalysis();
+
+    const formState = triggerFormStateFactory();
+
+    formState.modComponent.brickPipeline = [
+      {
+        id: highlight.id,
+        config: {
+          elements: [
+            {
+              selector: 'div:contains("{{foo}}")',
+            },
+          ],
+        },
+      },
+    ];
+
+    await analysis.run(formState);
+
+    expect(analysis.getAnnotations()).toStrictEqual([
+      {
+        analysisId: "selector",
+        message: expect.stringMatching(
+          /Selector literal appears to contain a template expression/,
+        ),
+        position: {
+          path: "modComponent.brickPipeline.0.config.elements.0.selector",
+        },
+        type: "info",
+      },
+    ]);
+  });
+
   it("detects selectors passed to highlight brick", async () => {
     const analysis = new SelectorAnalysis();
 

--- a/src/analysis/analysisVisitors/selectorAnalysis.ts
+++ b/src/analysis/analysisVisitors/selectorAnalysis.ts
@@ -36,6 +36,7 @@ import { guessUsefulness } from "@/utils/detectRandomString";
 import type { Schema } from "@/types/schemaTypes";
 import { isObject } from "@/utils/objectUtils";
 import { StarterBrickTypes } from "@/types/starterBrickTypes";
+import IdentityTransformer from "@/bricks/transformers/IdentityTransformer";
 
 // `jQuery` selector extension: https://api.jquery.com/category/selectors/jquery-selector-extensions/
 const jQueryExtensions = new Set([
@@ -230,8 +231,9 @@ class SelectorAnalysis extends AnalysisVisitorWithResolvedBricksABC {
     if (containsTemplateExpression(selector)) {
       this.annotations.push({
         position,
-        message:
-          "Selector literal appears to contain a template expression. To use a text template as a selector, use the Identity Function brick to assign the value to a variable.",
+        message: `Selector literal appears to contain a template expression. To use a text template as a selector, use the ${
+          new IdentityTransformer().name
+        } brick to assign the value to a variable.`,
         analysisId: this.id,
         type: AnnotationType.Info,
       });

--- a/src/analysis/analysisVisitors/selectorAnalysis.ts
+++ b/src/analysis/analysisVisitors/selectorAnalysis.ts
@@ -28,11 +28,13 @@ import pluralize from "@/utils/pluralize";
 import type { BrickConfig, BrickPosition } from "@/bricks/types";
 import { nestedPosition, type VisitBlockExtra } from "@/bricks/PipelineVisitor";
 import { inputProperties } from "@/utils/schemaUtils";
-import { castTextLiteralOrThrow } from "@/utils/expressionUtils";
+import {
+  castTextLiteralOrThrow,
+  containsTemplateExpression,
+} from "@/utils/expressionUtils";
 import { guessUsefulness } from "@/utils/detectRandomString";
 import type { Schema } from "@/types/schemaTypes";
 import { isObject } from "@/utils/objectUtils";
-import { assertNotNullish } from "@/utils/nullishUtils";
 import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 // `jQuery` selector extension: https://api.jquery.com/category/selectors/jquery-selector-extensions/
@@ -198,8 +200,12 @@ class SelectorAnalysis extends AnalysisVisitorWithResolvedBricksABC {
     selector,
   }: {
     position: BrickPosition;
-    selector: string;
+    selector: string | null;
   }) {
+    if (selector == null) {
+      return;
+    }
+
     if (!isValidSelector(selector)) {
       this.annotations.push({
         position,
@@ -220,6 +226,16 @@ class SelectorAnalysis extends AnalysisVisitorWithResolvedBricksABC {
         type: AnnotationType.Warning,
       });
     }
+
+    if (containsTemplateExpression(selector)) {
+      this.annotations.push({
+        position,
+        message:
+          "Selector literal appears to contain a template expression. To use a text template as a selector, use the Identity Function brick to assign the value to a variable.",
+        analysisId: this.id,
+        type: AnnotationType.Info,
+      });
+    }
   }
 
   visitValue(position: BrickPosition, value: unknown, schema: Schema): void {
@@ -234,8 +250,6 @@ class SelectorAnalysis extends AnalysisVisitorWithResolvedBricksABC {
     } catch {
       return;
     }
-
-    assertNotNullish(selector, "Selector is null.");
 
     this.visitSelector({
       position,


### PR DESCRIPTION
## What does this PR do?

- Closes #8875
- Show info annotation if selector literal contains template

## Discussion

- Consider making it a warning annotation. Is currently "info" because `{{` could theoretically appear in the attribute strings or in a `:contains` selector if it's actually in the value being matched

## Demo/Screenshot

![image](https://github.com/user-attachments/assets/a52753f8-524d-45ca-b333-6e9eaa58fdf5)

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
