### PR TITLE
#8864: fix select similar in selection tool

### DIFF
--- a/src/components/selectionToolPopover/SelectionToolPopover.tsx
+++ b/src/components/selectionToolPopover/SelectionToolPopover.tsx
@@ -111,7 +111,7 @@ const SelectionToolPopover: React.FC<{
             size="sm"
             variant="info"
             onClick={() => {
-              // Avoid passing event to onDone method in case the provided method takes an optional argument
+              // Avoid passing event to onCancel method in case the provided method takes an optional argument
               onCancel();
             }}
           >

--- a/src/components/selectionToolPopover/SelectionToolPopover.tsx
+++ b/src/components/selectionToolPopover/SelectionToolPopover.tsx
@@ -107,7 +107,14 @@ const SelectionToolPopover: React.FC<{
             </>
           )}
 
-          <Button size="sm" variant="info" onClick={onCancel}>
+          <Button
+            size="sm"
+            variant="info"
+            onClick={() => {
+              // Avoid passing event to onDone method in case the provided method takes an optional argument
+              onCancel();
+            }}
+          >
             Cancel
           </Button>
           <Button

--- a/src/components/selectionToolPopover/SelectionToolPopover.tsx
+++ b/src/components/selectionToolPopover/SelectionToolPopover.tsx
@@ -114,7 +114,10 @@ const SelectionToolPopover: React.FC<{
             className="info ml-1"
             size="sm"
             variant="primary"
-            onClick={onDone}
+            onClick={() => {
+              // Avoid passing event to onDone method in case the provided method takes an optional argument
+              onDone();
+            }}
           >
             Done
           </Button>


### PR DESCRIPTION
## What does this PR do?

- #8864: fixes select similar
- Inference was failing because the multi-select tool was passing a click event with the elements

## Future Work

- Playwright POM/tests for selection tool: https://github.com/pixiebrix/pixiebrix-extension/issues/8878

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
