### PR TITLE
#8893: fix mod component ref selector

### DIFF
--- a/src/pageEditor/store/editor/editorSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors.ts
@@ -73,8 +73,19 @@ export const selectActiveModComponentFormState = createSelector(
     formStates.find((x) => x.uuid === activeModComponentId),
 );
 
+/**
+ * Select the id of the mod being edited. Is null when editing a mod component within the mod.
+ * @see selectExpandedModId
+ */
 export const selectActiveModId = ({ editor }: EditorRootState) =>
   editor.activeModId;
+
+/**
+ * Select the id of the mod being edited. Will be set when editing the mod or a mod component within the mod.
+ * @see selectActiveModId
+ */
+export const selectExpandedModId = ({ editor }: EditorRootState) =>
+  editor.expandedModId;
 
 /**
  * Select a runtime ModComponentRef for the mod component being edited
@@ -84,7 +95,7 @@ export const selectActiveModId = ({ editor }: EditorRootState) =>
  */
 export const selectActiveModComponentRef = createSelector(
   selectActiveModComponentFormState,
-  selectActiveModId,
+  selectExpandedModId,
   (formState, modId) => {
     assertNotNullish(
       formState,
@@ -296,9 +307,6 @@ export const selectIsDataPanelExpanded = ({ editor }: EditorRootState) =>
 
 export const selectKeepLocalCopyOnCreateMod = ({ editor }: EditorRootState) =>
   editor.keepLocalCopyOnCreateMod;
-
-export const selectExpandedModId = ({ editor }: EditorRootState) =>
-  editor.expandedModId;
 
 // UI state
 export function selectActiveBrickPipelineUIState({

--- a/src/pageEditor/store/editor/pageEditorTypes.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes.ts
@@ -260,7 +260,7 @@ export type EditorStateV3 = Except<
   activeModComponentId: UUID | null;
 
   /**
-   * The registry id of the active mod, if a mod is selected
+   * The registry id of the active mod, if a mod is selected. Is null if a mod component within the mod is selected.
    */
   activeModId: RegistryId | null;
 


### PR DESCRIPTION
## What does this PR do?

- Closes #8893
- Fixes bug in `selectActiveModComponentRef` where it was using `selectActiveModId` instead of `selectExpandedModId`

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
