### PR TITLE
8744: fix: Deactivated Sidepanel deployments not removed from Mod Launcher

### DIFF
--- a/src/__mocks__/connected-react-router.js
+++ b/src/__mocks__/connected-react-router.js
@@ -16,4 +16,7 @@
  *
  */
 
-export const push = jest.fn();
+export const { push, connectRouter, routerMiddleware } = {
+  ...jest.requireActual("connected-react-router"),
+  push: jest.fn(),
+};

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -429,6 +429,9 @@ async function selectUpdatedDeployments(
  *
  * NOTE: if updates are snoozed, does not activate updated deployments automatically. (To not interrupt the current business
  * process the team member is working on.)
+ *
+ * WARNING: Partially duplicated code with DeploymentsProvider
+ * @see DeploymentsProvider
  */
 export async function syncDeployments(): Promise<void> {
   expectContext("background");

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -439,7 +439,7 @@ async function loadActivatedModComponents(): Promise<StarterBrick[]> {
   // Exclude the following:
   // - disabled deployments: the organization admin might have disabled the deployment because via Admin Console
   // - draft mod components: these are already installed on the page via the Page Editor
-  const activeModComponents = options.extensions.filter((modComponent) => {
+  const modComponentsToActivate = options.extensions.filter((modComponent) => {
     if (_draftModComponentStarterBrickMap.has(modComponent.id)) {
       const draftStarterBrick = _draftModComponentStarterBrickMap.get(
         modComponent.id,
@@ -456,7 +456,7 @@ async function loadActivatedModComponents(): Promise<StarterBrick[]> {
   const hydratedActiveModComponents = await logPromiseDuration(
     "loadActivatedModComponents:hydrateDefinitions",
     Promise.all(
-      activeModComponents.map(async (x) =>
+      modComponentsToActivate.map(async (x) =>
         hydrateModComponentInnerDefinitions(x),
       ),
     ),

--- a/src/extensionConsole/pages/UpdateBanner.tsx
+++ b/src/extensionConsole/pages/UpdateBanner.tsx
@@ -25,7 +25,7 @@ import useAsyncState from "@/hooks/useAsyncState";
 import { getExtensionVersion } from "@/utils/extensionUtils";
 
 // XXX: move this kind of async state to the Redux state.
-export function useUpdateAvailable(): boolean {
+export function useExtensionUpdateAvailable(): boolean {
   const { data: updateAvailable } = useAsyncState(async () => {
     try {
       const available = await getAvailableVersion();
@@ -41,7 +41,7 @@ export function useUpdateAvailable(): boolean {
 }
 
 const UpdateBanner: React.FunctionComponent = () => {
-  const updateAvailable = useUpdateAvailable();
+  const updateAvailable = useExtensionUpdateAvailable();
 
   if (!updateAvailable) {
     return null;

--- a/src/extensionConsole/pages/deployments/DeploymentModal.test.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentModal.test.tsx
@@ -26,7 +26,7 @@ import settingsSlice, {
 import MockDate from "mockdate";
 import { type SettingsState } from "@/store/settings/settingsTypes";
 import { authSlice } from "@/auth/authSlice";
-import { useUpdateAvailable } from "@/extensionConsole/pages/UpdateBanner";
+import { useExtensionUpdateAvailable } from "@/extensionConsole/pages/UpdateBanner";
 import { type AuthState } from "@/auth/authTypes";
 
 jest.mock("@/extensionConsole/pages/UpdateBanner");
@@ -34,7 +34,7 @@ jest.mock("@/extensionConsole/pages/UpdateBanner");
 browser.runtime.reload = jest.fn();
 
 const reloadMock = jest.mocked(browser.runtime.reload);
-const useUpdateAvailableMock = jest.mocked(useUpdateAvailable);
+const useUpdateAvailableMock = jest.mocked(useExtensionUpdateAvailable);
 
 beforeEach(() => {
   reloadMock.mockReset();
@@ -73,7 +73,7 @@ describe("DeploymentModal", () => {
     const date = new Date("12/31/1998");
     MockDate.set(date);
 
-    jest.mocked(useUpdateAvailable).mockReturnValue(true);
+    jest.mocked(useExtensionUpdateAvailable).mockReturnValue(true);
 
     renderModal(
       {
@@ -94,7 +94,7 @@ describe("DeploymentModal", () => {
     const date = new Date("12/31/1998");
     MockDate.set(date);
 
-    jest.mocked(useUpdateAvailable).mockReturnValue(true);
+    jest.mocked(useExtensionUpdateAvailable).mockReturnValue(true);
 
     renderModal(
       {
@@ -144,7 +144,7 @@ describe("DeploymentModal", () => {
     const time = new Date("12/31/1998").getTime();
     MockDate.set(time);
 
-    jest.mocked(useUpdateAvailable).mockReturnValue(true);
+    jest.mocked(useExtensionUpdateAvailable).mockReturnValue(true);
 
     renderModal(
       {
@@ -170,7 +170,7 @@ describe("DeploymentModal", () => {
     const date = new Date("12/31/1998");
     MockDate.set(date);
 
-    jest.mocked(useUpdateAvailable).mockReturnValue(false);
+    jest.mocked(useExtensionUpdateAvailable).mockReturnValue(false);
 
     renderModal(
       {
@@ -195,7 +195,7 @@ describe("DeploymentModal", () => {
     const date = new Date("12/31/1998");
     MockDate.set(date);
 
-    jest.mocked(useUpdateAvailable).mockReturnValue(false);
+    jest.mocked(useExtensionUpdateAvailable).mockReturnValue(false);
 
     renderModal(
       {

--- a/src/extensionConsole/pages/deployments/DeploymentModal.test.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentModal.test.tsx
@@ -73,7 +73,7 @@ describe("DeploymentModal", () => {
     const date = new Date("12/31/1998");
     MockDate.set(date);
 
-    jest.mocked(useExtensionUpdateAvailable).mockReturnValue(true);
+    useUpdateAvailableMock.mockReturnValue(true);
 
     renderModal(
       {
@@ -94,7 +94,7 @@ describe("DeploymentModal", () => {
     const date = new Date("12/31/1998");
     MockDate.set(date);
 
-    jest.mocked(useExtensionUpdateAvailable).mockReturnValue(true);
+    useUpdateAvailableMock.mockReturnValue(true);
 
     renderModal(
       {
@@ -144,7 +144,7 @@ describe("DeploymentModal", () => {
     const time = new Date("12/31/1998").getTime();
     MockDate.set(time);
 
-    jest.mocked(useExtensionUpdateAvailable).mockReturnValue(true);
+    useUpdateAvailableMock.mockReturnValue(true);
 
     renderModal(
       {
@@ -170,7 +170,7 @@ describe("DeploymentModal", () => {
     const date = new Date("12/31/1998");
     MockDate.set(date);
 
-    jest.mocked(useExtensionUpdateAvailable).mockReturnValue(false);
+    useUpdateAvailableMock.mockReturnValue(false);
 
     renderModal(
       {
@@ -195,7 +195,7 @@ describe("DeploymentModal", () => {
     const date = new Date("12/31/1998");
     MockDate.set(date);
 
-    jest.mocked(useExtensionUpdateAvailable).mockReturnValue(false);
+    useUpdateAvailableMock.mockReturnValue(false);
 
     renderModal(
       {

--- a/src/extensionConsole/pages/deployments/DeploymentModal.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentModal.tsx
@@ -21,7 +21,7 @@ import { Alert, Dropdown, DropdownButton, Modal } from "react-bootstrap";
 import { useDispatch, useSelector } from "react-redux";
 import settingsSlice from "@/store/settings/settingsSlice";
 import notify from "@/utils/notify";
-import { useUpdateAvailable } from "@/extensionConsole/pages/UpdateBanner";
+import { useExtensionUpdateAvailable } from "@/extensionConsole/pages/UpdateBanner";
 import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
 import { selectAuth } from "@/auth/authSelectors";
@@ -142,7 +142,7 @@ const DeploymentModal: React.FC<
   >
 > = ({ extensionUpdateRequired, updateExtension, update }) => {
   const dispatch = useDispatch();
-  const hasUpdatesAvailable = useUpdateAvailable();
+  const hasExtensionUpdateAvailable = useExtensionUpdateAvailable();
   const { enforceUpdateMillis } = useSelector(selectAuth);
 
   const currentTime = useCurrentTime();
@@ -187,7 +187,7 @@ const DeploymentModal: React.FC<
     return null;
   }
 
-  if (hasUpdatesAvailable) {
+  if (hasExtensionUpdateAvailable) {
     return (
       <Modal show>
         <Modal.Header>

--- a/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
@@ -120,6 +120,7 @@ function useDeployments(): DeploymentsState {
   const deploymentUpdateState = useDeriveAsyncState(
     deploymentsState,
     flagsState,
+    // Including activatedModComponents in the dependencies to ensure the derived state is recalculated when they change
     valueToAsyncState(activatedModComponents),
     async (
       deployments: Deployment[],

--- a/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
@@ -54,6 +54,8 @@ import useBrowserIdentifier from "@/hooks/useBrowserIdentifier";
 import type { ActivatableDeployment } from "@/types/deploymentTypes";
 import type { Permissions } from "webextension-polyfill";
 import useDeactivateUnassignedDeploymentsEffect from "@/extensionConsole/pages/deployments/useDeactivateUnassignedDeploymentsEffect";
+import { valueToAsyncState } from "@/utils/asyncStateUtils";
+import type { ActivatedModComponent } from "@/types/modComponentTypes";
 
 export type DeploymentsState = {
   /**
@@ -118,8 +120,13 @@ function useDeployments(): DeploymentsState {
   const deploymentUpdateState = useDeriveAsyncState(
     deploymentsState,
     flagsState,
-    async (deployments: Deployment[], { restrict }: Restrict) => {
-      const isUpdated = makeUpdatedFilter(activatedModComponents, {
+    valueToAsyncState(activatedModComponents),
+    async (
+      deployments: Deployment[],
+      { restrict }: Restrict,
+      _activatedModComponents: ActivatedModComponent[],
+    ) => {
+      const isUpdated = makeUpdatedFilter(_activatedModComponents, {
         restricted: restrict("uninstall"),
       });
 
@@ -127,7 +134,7 @@ function useDeployments(): DeploymentsState {
         deployments.map((deployment) => deployment.package.package_id),
       );
 
-      const unassignedModComponents = activatedModComponents.filter(
+      const unassignedModComponents = _activatedModComponents.filter(
         (activeModComponent) =>
           activeModComponent._deployment &&
           activeModComponent._recipe &&
@@ -247,6 +254,7 @@ function useDeployments(): DeploymentsState {
         dispatch,
         activatableDeployments,
         activatedModComponents,
+        reloadMode: "immediate",
       });
       notify.success("Updated team deployments");
     } catch (error) {

--- a/src/extensionConsole/pages/deployments/activateDeployments.ts
+++ b/src/extensionConsole/pages/deployments/activateDeployments.ts
@@ -21,17 +21,13 @@ import { Events } from "@/telemetry/events";
 import reportEvent from "@/telemetry/reportEvent";
 import { type ModComponentBase } from "@/types/modComponentTypes";
 import { mergeDeploymentIntegrationDependencies } from "@/utils/deploymentUtils";
-import {
-  type AnyAction,
-  type Dispatch,
-  type ThunkDispatch,
-} from "@reduxjs/toolkit";
+import { type Dispatch } from "@reduxjs/toolkit";
 import type { ActivatableDeployment } from "@/types/deploymentTypes";
 import {
   queueReloadModEveryTab,
   reloadModsEveryTab,
 } from "@/contentScript/messenger/api";
-import { persistor, type RootState } from "@/store/optionsStore";
+import { persistor } from "@/store/optionsStore";
 
 const { actions } = extensionsSlice;
 
@@ -40,7 +36,7 @@ async function activateDeployment({
   activatableDeployment,
   activatedModComponents,
 }: {
-  dispatch: ThunkDispatch<RootState, unknown, AnyAction>;
+  dispatch: Dispatch;
   activatableDeployment: ActivatableDeployment;
   activatedModComponents: ModComponentBase[];
 }): Promise<void> {

--- a/src/extensionConsole/pages/deployments/useAutoDeploy.test.ts
+++ b/src/extensionConsole/pages/deployments/useAutoDeploy.test.ts
@@ -126,6 +126,7 @@ describe("useAutoDeploy", () => {
         dispatch: expect.any(Function),
         activatableDeployments,
         activatedModComponents,
+        reloadMode: "queue",
       });
 
       await waitForValueToChange(() => result.current.isAutoDeploying);

--- a/src/extensionConsole/pages/deployments/useAutoDeploy.ts
+++ b/src/extensionConsole/pages/deployments/useAutoDeploy.ts
@@ -91,6 +91,7 @@ function useAutoDeploy({
           dispatch,
           activatableDeployments,
           activatedModComponents,
+          reloadMode: "queue",
         });
         notify.success("Updated team deployments");
       } catch (error) {

--- a/src/utils/deploymentUtils.ts
+++ b/src/utils/deploymentUtils.ts
@@ -60,7 +60,7 @@ export function isDeploymentActive(extensionLike: {
  * - Same as above, but ignore deployments where the user has a newer version of the blueprint installed because that
  *   means they are doing local deployment on the blueprint.
  *
- * @param activatedModComponents the user's currently installed extensions (including for paused deployments)
+ * @param activatedModComponents the user's currently installed modComponents (including for paused deployments)
  * @param restricted `true` if the user is a restricted organization user (i.e., as opposed to a developer)
  */
 export const makeUpdatedFilter =
@@ -70,7 +70,7 @@ export const makeUpdatedFilter =
   ) =>
   (deployment: Deployment) => {
     const deploymentMatch = activatedModComponents.find(
-      (extension) => extension._deployment?.id === deployment.id,
+      (modComponent) => modComponent._deployment?.id === deployment.id,
     );
 
     if (restricted) {


### PR DESCRIPTION
## What does this PR do?

- Closes #8744
- Closes #8158

This change fixes a bug related to mod deployments not properly reflecting the new deployed mod immediately in open tabs. It ensures the mod state is persisted before continuing after activating in the extension console so the content script can immediately pick up the changes 

Some renaming and added documentation was done for clarity surrounding related code.

## Future Work

- E2E test coverage

## Checklist

- [x] Added jest or playwright tests and/or storybook stories