### PR TITLE
#8421: default sidebar to a panel for mod that set the badge

### DIFF
--- a/src/background/toolbarBadge.ts
+++ b/src/background/toolbarBadge.ts
@@ -17,6 +17,9 @@
 
 import { browserAction } from "@/mv3/api";
 import { type MessengerMeta } from "webext-messenger";
+import { type ModComponentRef } from "@/types/modComponentTypes";
+import { setTabBadgeModComponentRef } from "@/background/browserAction";
+import { assertNotNullish } from "@/utils/nullishUtils";
 
 /**
  * Browsers will set the badge text color to white or black depending on the background color for accessible contrast.
@@ -29,22 +32,21 @@ export const DEFAULT_BADGE_COLOR = "#b4183f";
 export async function setToolbarBadge(
   this: MessengerMeta,
   text: string | null,
+  options: { modComponentRef?: ModComponentRef },
 ): Promise<void> {
   const tabId = this?.trace?.[0]?.tab?.id;
-  text ??= "";
 
-  if (!tabId) {
-    throw new Error("Unable to set toolbar badge: no tabId");
-  }
+  assertNotNullish(tabId, "Unable to set toolbar badge: no tabId");
 
   await Promise.all([
     browserAction.setBadgeText({
-      text,
+      text: text ?? "",
       tabId,
     }),
     browserAction.setBadgeBackgroundColor({
       color: DEFAULT_BADGE_COLOR,
       tabId,
     }),
+    setTabBadgeModComponentRef(tabId, text ? options.modComponentRef : null),
   ]);
 }

--- a/src/background/toolbarBadge.ts
+++ b/src/background/toolbarBadge.ts
@@ -32,7 +32,7 @@ export const DEFAULT_BADGE_COLOR = "#b4183f";
 export async function setToolbarBadge(
   this: MessengerMeta,
   text: string | null,
-  options: { modComponentRef?: ModComponentRef },
+  options: { modComponentRef?: ModComponentRef } = {},
 ): Promise<void> {
   const tabId = this?.trace?.[0]?.tab?.id;
 

--- a/src/bricks/effects/setToolbarBadge.test.ts
+++ b/src/bricks/effects/setToolbarBadge.test.ts
@@ -29,14 +29,14 @@ jest.mock("@/utils/iframeUtils", () => ({
 describe("SetToolbarBadge", () => {
   it("runs without error", async () => {
     const expectedText = "test";
+    const options = brickOptionsFactory();
     await expect(
-      brick.run(
-        unsafeAssumeValidArg({ text: expectedText }),
-        brickOptionsFactory(),
-      ),
+      brick.run(unsafeAssumeValidArg({ text: expectedText }), options),
     ).resolves.not.toThrow();
 
-    expect(setToolbarBadge).toHaveBeenCalledWith(expectedText);
+    expect(setToolbarBadge).toHaveBeenCalledWith(expectedText, {
+      modComponentRef: options.meta.modComponentRef,
+    });
   });
 
   it("throws a BusinessError if run in an iframe", async () => {

--- a/src/bricks/effects/setToolbarBadge.ts
+++ b/src/bricks/effects/setToolbarBadge.ts
@@ -49,13 +49,13 @@ class SetToolbarBadge extends EffectABC {
 
   async effect(
     { text }: BrickArgs<{ text: string }>,
-    { platform }: BrickOptions,
+    { platform, meta: { modComponentRef } }: BrickOptions,
   ): Promise<void> {
     if (isLoadedInIframe()) {
       throw new BusinessError("Cannot set toolbar badge from an iframe.");
     }
 
-    platform.badge.setText(text);
+    platform.badge.setText(text, { modComponentRef });
   }
 }
 

--- a/src/platform/platformTypes/badgeProtocol.ts
+++ b/src/platform/platformTypes/badgeProtocol.ts
@@ -16,6 +16,7 @@
  */
 
 import type { Nullishable } from "@/utils/nullishUtils";
+import type { ModComponentRef } from "@/types/modComponentTypes";
 
 /**
  * Protocol for a badge displayed in the context. For the extension, corresponds to the browser action badge.
@@ -25,5 +26,8 @@ export type BadgeProtocol = {
   /**
    * Set the badge text. If the text is null, the badge will be hidden.
    */
-  setText(text: Nullishable<string>): void;
+  setText(
+    text: Nullishable<string>,
+    options: { modComponentRef: ModComponentRef },
+  ): void;
 };

--- a/src/platform/platformTypes/badgeProtocol.ts
+++ b/src/platform/platformTypes/badgeProtocol.ts
@@ -28,6 +28,6 @@ export type BadgeProtocol = {
    */
   setText(
     text: Nullishable<string>,
-    options: { modComponentRef: ModComponentRef },
+    options?: { modComponentRef?: ModComponentRef },
   ): void;
 };

--- a/src/sidebar/ConnectedSidebar.tsx
+++ b/src/sidebar/ConnectedSidebar.tsx
@@ -53,8 +53,10 @@ import addTemporaryPanel from "@/store/sidebar/thunks/addTemporaryPanel";
 import removeTemporaryPanel from "@/store/sidebar/thunks/removeTemporaryPanel";
 import { type AsyncDispatch } from "@/sidebar/store";
 import useEventListener from "@/hooks/useEventListener";
-import { ModComponentRef } from "@/types/modComponentTypes";
-import { validateModComponentRef } from "@/utils/modUtils";
+import {
+  type ModComponentRef,
+  validateModComponentRef,
+} from "@/types/modComponentTypes";
 
 /**
  * Listeners to update the Sidebar's Redux state upon receiving messages from the contentScript.
@@ -101,8 +103,8 @@ function useConnectedListener(): SidebarListener {
   );
 }
 
-function getInitialModComponentRef(): ModComponentRef | undefined {
-  const param = new URL(location.href).searchParams.get(
+function getInitialModComponentRef(url?: string): ModComponentRef | undefined {
+  const param = new URL(url ?? location.href).searchParams.get(
     "initialModComponentRef",
   );
   return param ? validateModComponentRef(JSON.parse(param)) : undefined;

--- a/src/sidebar/ConnectedSidebar.tsx
+++ b/src/sidebar/ConnectedSidebar.tsx
@@ -53,6 +53,8 @@ import addTemporaryPanel from "@/store/sidebar/thunks/addTemporaryPanel";
 import removeTemporaryPanel from "@/store/sidebar/thunks/removeTemporaryPanel";
 import { type AsyncDispatch } from "@/sidebar/store";
 import useEventListener from "@/hooks/useEventListener";
+import { ModComponentRef } from "@/types/modComponentTypes";
+import { validateModComponentRef } from "@/utils/modUtils";
 
 /**
  * Listeners to update the Sidebar's Redux state upon receiving messages from the contentScript.
@@ -99,6 +101,13 @@ function useConnectedListener(): SidebarListener {
   );
 }
 
+function getInitialModComponentRef(): ModComponentRef | undefined {
+  const param = new URL(location.href).searchParams.get(
+    "initialModComponentRef",
+  );
+  return param ? validateModComponentRef(JSON.parse(param)) : undefined;
+}
+
 const staticPanels = [MOD_LAUNCHER];
 
 const ConnectedSidebar: React.VFC = () => {
@@ -136,7 +145,7 @@ const ConnectedSidebar: React.VFC = () => {
   useAsyncEffect(async () => {
     const topFrame = await getConnectedTarget();
 
-    // Ensure persistent sidebar extension points have been installed to have reserve their panels for the sidebar
+    // Ensure persistent sidebar starter bricks have been installed to reserve their panels for the sidebar
     await ensureStarterBricksInstalled(topFrame);
 
     const { panels, temporaryPanels, forms, modActivationPanel } =
@@ -153,6 +162,7 @@ const ConnectedSidebar: React.VFC = () => {
 
     dispatch(
       sidebarSlice.actions.setInitialPanels({
+        initialModComponentRef: getInitialModComponentRef(),
         panels,
         temporaryPanels,
         forms,

--- a/src/sidebar/sidebarSelectors.ts
+++ b/src/sidebar/sidebarSelectors.ts
@@ -21,7 +21,7 @@ import {
 } from "@/types/sidebarTypes";
 import { isEmpty } from "lodash";
 import { eventKeyForEntry } from "@/store/sidebar/eventKeyUtils";
-import { getVisiblePanelCount } from "@/store/sidebar/utils";
+import { getVisiblePanelCount } from "@/store/sidebar/sidebarUtils";
 import { createSelector } from "@reduxjs/toolkit";
 import { selectActivatedModComponents } from "@/store/extensionsSelectors";
 import { type ActivatedModComponent } from "@/types/modComponentTypes";

--- a/src/store/sidebar/sidebarSlice.ts
+++ b/src/store/sidebar/sidebarSlice.ts
@@ -41,7 +41,7 @@ import {
   eventKeyExists,
   findInitialPanelEntry,
   getVisiblePanelCount,
-} from "@/store/sidebar/utils";
+} from "@/store/sidebar/sidebarUtils";
 import { MOD_LAUNCHER } from "@/store/sidebar/constants";
 import { type Nullishable } from "@/utils/nullishUtils";
 import addFormPanel from "@/store/sidebar/thunks/addFormPanel";
@@ -170,11 +170,11 @@ const sidebarSlice = createSlice({
         action.payload,
         action.payload.initialModComponentRef,
       );
+      let initialEventKey: string;
       if (initialPanel) {
-        const initialPanelKey = eventKeyForEntry(initialPanel);
-        // eslint-disable-next-line security/detect-object-injection -- generated value
-        state.closedTabs[initialPanelKey] = false;
-        state.activeKey = initialPanelKey;
+        initialEventKey = eventKeyForEntry(initialPanel);
+        // eslint-disable-next-line security/detect-object-injection -- event key
+        state.closedTabs[initialEventKey] = false;
       }
 
       /**
@@ -206,7 +206,7 @@ const sidebarSlice = createSlice({
             -- Immer Draft<T> type resolution can't handle JsonObject (recursive) types properly
             See: https://github.com/immerjs/immer/issues/839 */
             // @ts-ignore-error -- SidebarEntries.panels --> PanelEntry.actions --> PanelButton.detail is JsonObject
-            defaultEventKey(state, state.closedTabs);
+            initialEventKey ?? defaultEventKey(state, state.closedTabs);
     },
     selectTab(state, action: PayloadAction<string>) {
       // We were seeing some automatic calls to selectTab with a stale event key...

--- a/src/store/sidebar/sidebarSlice.ts
+++ b/src/store/sidebar/sidebarSlice.ts
@@ -46,6 +46,7 @@ import removeTemporaryPanel from "@/store/sidebar/thunks/removeTemporaryPanel";
 import resolveTemporaryPanel from "@/store/sidebar/thunks/resolveTemporaryPanel";
 import { initialSidebarState } from "@/store/sidebar/initialState";
 import removeFormPanel from "@/store/sidebar/thunks/removeFormPanel";
+import { ModComponentRef } from "@/types/modComponentTypes";
 
 function eventKeyExists(
   state: SidebarState,
@@ -169,6 +170,7 @@ const sidebarSlice = createSlice({
     setInitialPanels(
       state,
       action: PayloadAction<{
+        initialModComponentRef: Nullishable<ModComponentRef>;
         staticPanels: StaticPanelEntry[];
         panels: PanelEntry[];
         temporaryPanels: TemporaryPanelEntry[];
@@ -176,6 +178,8 @@ const sidebarSlice = createSlice({
         modActivationPanel: ModActivationPanelEntry | null;
       }>,
     ) {
+      // TODO: if initialModComponentRef is set, find the corresponding panel and set it as active/not-closed
+
       /**
        * We need a visible count > 1 to prevent useHideEmptySidebar from closing it on first load. If there are no visible panels,
        * we'll show mod launcher. activatePanel then hides the modLauncher if there is another visible panel.

--- a/src/store/sidebar/sidebarUtils.ts
+++ b/src/store/sidebar/sidebarUtils.ts
@@ -29,12 +29,16 @@ import { isEqual } from "lodash";
 import type { Nullishable } from "@/utils/nullishUtils";
 
 /**
- * Returns the initial panel entry given a modComponentRef.
+ * Returns the initial panel entry given a modComponentRef, or undefined if not found.
  */
 export function findInitialPanelEntry(
   entries: SidebarEntries,
-  modComponentRef: ModComponentRef,
+  modComponentRef: Nullishable<ModComponentRef>,
 ): SidebarEntry | undefined {
+  if (modComponentRef == null) {
+    return;
+  }
+
   // Prefer an exact match, but fallback to a match from the same mod
   return (
     entries.panels.find((panel) =>
@@ -46,14 +50,14 @@ export function findInitialPanelEntry(
   );
 }
 
-export const getVisiblePanelCount = ({
+export function getVisiblePanelCount({
   panels,
   forms,
   temporaryPanels,
   staticPanels,
   modActivationPanel,
   closedTabs,
-}: SidebarState) => {
+}: SidebarState): number {
   // Temporary Panels are removed from the sidebar state when they are closed, so we don't need to filter them out
   const closablePanels = [...panels, ...staticPanels];
   const openPanels = getOpenPanelEntries(closablePanels, closedTabs);
@@ -64,7 +68,7 @@ export const getVisiblePanelCount = ({
     temporaryPanels.length +
     (modActivationPanel ? 1 : 0)
   );
-};
+}
 
 export function eventKeyExists(
   state: SidebarState,

--- a/src/store/sidebar/utils.ts
+++ b/src/store/sidebar/utils.ts
@@ -15,8 +15,36 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type SidebarState } from "@/types/sidebarTypes";
-import { getOpenPanelEntries } from "@/store/sidebar/eventKeyUtils";
+import {
+  type SidebarEntries,
+  type SidebarEntry,
+  type SidebarState,
+} from "@/types/sidebarTypes";
+import {
+  eventKeyForEntry,
+  getOpenPanelEntries,
+} from "@/store/sidebar/eventKeyUtils";
+import { type ModComponentRef } from "@/types/modComponentTypes";
+import { isEqual } from "lodash";
+import type { Nullishable } from "@/utils/nullishUtils";
+
+/**
+ * Returns the initial panel entry given a modComponentRef.
+ */
+export function findInitialPanelEntry(
+  entries: SidebarEntries,
+  modComponentRef: ModComponentRef,
+): SidebarEntry | undefined {
+  // Prefer an exact match, but fallback to a match from the same mod
+  return (
+    entries.panels.find((panel) =>
+      isEqual(panel.modComponentRef, modComponentRef),
+    ) ??
+    entries.panels.find(
+      (panel) => panel.modComponentRef.modId === modComponentRef.modId,
+    )
+  );
+}
 
 export const getVisiblePanelCount = ({
   panels,
@@ -37,3 +65,20 @@ export const getVisiblePanelCount = ({
     (modActivationPanel ? 1 : 0)
   );
 };
+
+export function eventKeyExists(
+  state: SidebarState,
+  query: Nullishable<string>,
+): boolean {
+  if (query == null) {
+    return false;
+  }
+
+  return (
+    state.forms.some((x) => eventKeyForEntry(x) === query) ||
+    state.temporaryPanels.some((x) => eventKeyForEntry(x) === query) ||
+    state.panels.some((x) => eventKeyForEntry(x) === query) ||
+    state.staticPanels.some((x) => eventKeyForEntry(x) === query) ||
+    eventKeyForEntry(state.modActivationPanel) === query
+  );
+}

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -1555,7 +1555,7 @@
     "./store/sidebar/thunks/removeFormPanel.ts",
     "./store/sidebar/thunks/removeTemporaryPanel.ts",
     "./store/sidebar/thunks/resolveTemporaryPanel.ts",
-    "./store/sidebar/utils.ts",
+    "./store/sidebar/sidebarUtils.ts",
     "./store/workshopSlice.ts",
     "./telemetry/BackgroundLogger.ts",
     "./telemetry/deployments.ts",

--- a/src/types/modComponentTypes.ts
+++ b/src/types/modComponentTypes.ts
@@ -34,6 +34,7 @@ import {
   type IntegrationDependencyV1,
   type IntegrationDependencyV2,
 } from "@/integrations/integrationTypes";
+import { isRegistryId, isUUID } from "@/types/helpers";
 
 /**
  * ModMetadata that includes sharing information.
@@ -297,3 +298,35 @@ export type ModComponentRef = {
    */
   starterBrickId: RegistryId;
 };
+
+/**
+ * Returns true if the value is a syntactically valid non-null ModComponentRef. Does not validate the existence of the
+ * mod component, mod, or starter brick.
+ * @see validateModComponentRef
+ */
+export function isModComponentRef(value: unknown): value is ModComponentRef {
+  if (typeof value !== "object" || value == null) {
+    return false;
+  }
+
+  const obj = value as ModComponentRef;
+
+  return (
+    isUUID(obj.modComponentId) &&
+    isRegistryId(obj.modId) &&
+    isRegistryId(obj.starterBrickId)
+  );
+}
+
+/**
+ * Validates and returns a ModComponentRef. Does not validate the existence of the mod component, mod, or starter brick.
+ * @throws TypeError if the value is not a valid ModComponentRef
+ * @see isModComponentRef
+ */
+export function validateModComponentRef(value: unknown): ModComponentRef {
+  if (!isModComponentRef(value)) {
+    throw new TypeError("Invalid ModComponentRef");
+  }
+
+  return value;
+}

--- a/src/types/modComponentTypes.ts
+++ b/src/types/modComponentTypes.ts
@@ -304,7 +304,7 @@ export type ModComponentRef = {
  * mod component, mod, or starter brick.
  * @see validateModComponentRef
  */
-export function isModComponentRef(value: unknown): value is ModComponentRef {
+function isModComponentRef(value: unknown): value is ModComponentRef {
   if (typeof value !== "object" || value == null) {
     return false;
   }

--- a/src/utils/modUtils.ts
+++ b/src/utils/modUtils.ts
@@ -61,7 +61,7 @@ import { isStarterBrickDefinitionLike } from "@/starterBricks/types";
 import { normalizeStarterBrickDefinitionProp } from "@/starterBricks/starterBrickUtils";
 import { type MessageContext } from "@/types/loggerTypes";
 import { type SetRequired } from "type-fest";
-import { validateRegistryId } from "@/types/helpers";
+import { isRegistryId, isUUID, validateRegistryId } from "@/types/helpers";
 
 /**
  * Returns a synthetic mod id for a standalone mod component for use in the runtime
@@ -100,6 +100,31 @@ export function getModComponentRef(
     modId: getRuntimeModId(modComponent),
     starterBrickId: modComponent.extensionPointId,
   };
+}
+
+/**
+ * Returns true if the value is a ModComponentRef
+ */
+export function isModComponentRef(value: unknown): value is ModComponentRef {
+  if (typeof value !== "object" || value == null) {
+    return false;
+  }
+
+  const obj = value as ModComponentRef;
+
+  return (
+    isUUID(obj.modComponentId) &&
+    isRegistryId(obj.modId) &&
+    isRegistryId(obj.starterBrickId)
+  );
+}
+
+export function validateModComponentRef(value: unknown): ModComponentRef {
+  if (!isModComponentRef(value)) {
+    throw new TypeError("Invalid ModComponentRef");
+  }
+
+  return value;
 }
 
 /**

--- a/src/utils/modUtils.ts
+++ b/src/utils/modUtils.ts
@@ -61,7 +61,7 @@ import { isStarterBrickDefinitionLike } from "@/starterBricks/types";
 import { normalizeStarterBrickDefinitionProp } from "@/starterBricks/starterBrickUtils";
 import { type MessageContext } from "@/types/loggerTypes";
 import { type SetRequired } from "type-fest";
-import { isRegistryId, isUUID, validateRegistryId } from "@/types/helpers";
+import { validateRegistryId } from "@/types/helpers";
 
 /**
  * Returns a synthetic mod id for a standalone mod component for use in the runtime
@@ -100,31 +100,6 @@ export function getModComponentRef(
     modId: getRuntimeModId(modComponent),
     starterBrickId: modComponent.extensionPointId,
   };
-}
-
-/**
- * Returns true if the value is a ModComponentRef
- */
-export function isModComponentRef(value: unknown): value is ModComponentRef {
-  if (typeof value !== "object" || value == null) {
-    return false;
-  }
-
-  const obj = value as ModComponentRef;
-
-  return (
-    isUUID(obj.modComponentId) &&
-    isRegistryId(obj.modId) &&
-    isRegistryId(obj.starterBrickId)
-  );
-}
-
-export function validateModComponentRef(value: unknown): ModComponentRef {
-  if (!isModComponentRef(value)) {
-    throw new TypeError("Invalid ModComponentRef");
-  }
-
-  return value;
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

- Closes #8421 
- Defaults the open/active panel when the user opens the sidebar panel with a badge set by a mod

## Remaining Work

- [x] On Chrome 127 locally, there appears to be user gesture tracking issues when using the toolbar icon. It doesn't break E2E tests because those can't use the toolbar icon: https://github.com/pixiebrix/pixiebrix-extension/blob/3f02f8b270dc55e0e5069ba8fa137e9ec5cac91f/src/background/browserAction.ts#L73-L73

## Reviewer Notes

- Does not use `SessionMap` which persists across background worker reloads because it was causing Chrome to lose the user gesture

## Discussion

- Uses the sidebar tab URL search param to set the initial panel vs. attempting to get the `webext-messaging` sequence correct. The Show Sidebar brick uses `showSidebar` and `updateSidebar` which isn't available to the background service worker
- Can't write Playwright test because we can't click the toolbar icon?

## Demo

- https://www.loom.com/share/36ec55d8a4c54c3cb7c68579d6aa824d

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
