### PR TITLE
Fix beta starter brick feature flag detection

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -299,6 +299,23 @@ module.exports = {
       },
     },
     {
+      files: ["./src/**/*.tsx", "./src/**/use*.ts"],
+      rules: {
+        "no-restricted-imports": [
+          "error",
+          extendNoRestrictedImports({
+            patterns: [
+              {
+                group: ["@/auth/featureFlagStorage"],
+                message:
+                  "Use useFlags instead of featureFlagStorage in React code.",
+              },
+            ],
+          }),
+        ],
+      },
+    },
+    {
       files: ["./src/pageEditor/**.tsx", "./src/sidebar/**.tsx"],
       rules: {
         "react/forbid-dom-props": forbiddenDomPropsConfig,

--- a/src/auth/featureFlagStorage.ts
+++ b/src/auth/featureFlagStorage.ts
@@ -80,7 +80,11 @@ export async function TEST_overrideFeatureFlags(
 
 /**
  * Returns true if the specified flag is on for the current user. Fetches the flags if they are not already cached.
+ *
+ * In React code, use useFlags instead.
+ *
  * @param flag the feature flag to check
+ * @see useFlags
  */
 export async function flagOn(flag: string): Promise<boolean> {
   const flags = await featureFlags.get();

--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -51,6 +51,7 @@ import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
 import { onContextInvalidated } from "webext-events";
 import StopPropagation from "@/components/StopPropagation";
 import useScrollLock from "@/hooks/useScrollLock";
+// eslint-disable-next-line no-restricted-imports -- being used in initQuickBarApp
 import { flagOn } from "@/auth/featureFlagStorage";
 import useOnMountOnly from "@/hooks/useOnMountOnly";
 

--- a/src/hooks/useFlags.test.tsx
+++ b/src/hooks/useFlags.test.tsx
@@ -22,6 +22,7 @@ import useFlags from "@/hooks/useFlags";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import { TEST_setAuthData, TEST_triggerListeners } from "@/auth/authStorage";
 import { tokenAuthDataFactory } from "@/testUtils/factories/authFactories";
+// eslint-disable-next-line no-restricted-imports -- test file
 import { TEST_deleteFeatureFlagsCache } from "@/auth/featureFlagStorage";
 
 const TestComponent: React.FC<{ name: string }> = ({ name, children }) => {

--- a/src/hooks/useFlags.ts
+++ b/src/hooks/useFlags.ts
@@ -55,7 +55,7 @@ type HookResult = Restrict & {
 /**
  * Hook for feature flags and organization restrictions.
  *
- * For permit/restrict, features will be restricted in the fetching/loading state
+ * For permit/restrict, features will be restricted in the fetching/loading state.
  */
 function useFlags(): HookResult {
   const queryState = useGetFeatureFlagsQuery();

--- a/src/hooks/useFlags.ts
+++ b/src/hooks/useFlags.ts
@@ -57,7 +57,7 @@ type HookResult = Restrict & {
  *
  * For permit/restrict, features will be restricted in the fetching/loading state.
  *
- * If not in a React context, use featureFlagStorage flagOn
+ * If not in a React context, use featureFlagStorage.flagOn.
  *
  * @see flagOn
  */

--- a/src/hooks/useFlags.ts
+++ b/src/hooks/useFlags.ts
@@ -56,6 +56,10 @@ type HookResult = Restrict & {
  * Hook for feature flags and organization restrictions.
  *
  * For permit/restrict, features will be restricted in the fetching/loading state.
+ *
+ * If not in a React context, use featureFlagStorage flagOn
+ *
+ * @see flagOn
  */
 function useFlags(): HookResult {
   const queryState = useGetFeatureFlagsQuery();

--- a/src/pageEditor/hooks/useAddNewModComponent.ts
+++ b/src/pageEditor/hooks/useAddNewModComponent.ts
@@ -44,6 +44,9 @@ type AddNewModComponent = (config: ModComponentFormStateAdapter) => void;
 function useAddNewModComponent(): AddNewModComponent {
   const dispatch = useDispatch();
   const { setInsertingStarterBrickType } = useInsertPane();
+  // XXX: useFlags is async. The flag query might not be initialized by the time the callback is called. Ensure
+  // useFlags has already been used on the page, e.g., the AddStarterBrickButton, to ensure the flags have loaded by
+  // the time the returned callback is called.
   const { flagOff } = useFlags();
   const suggestElements = useSelector<{ settings: SettingsState }, boolean>(
     (x) => x.settings.suggestElements ?? false,
@@ -108,7 +111,7 @@ function useAddNewModComponent(): AddNewModComponent {
         setInsertingStarterBrickType(null);
       }
     },
-    [dispatch, flagOff, suggestElements],
+    [dispatch, flagOff, suggestElements, setInsertingStarterBrickType],
   );
 }
 

--- a/src/pageEditor/modListingPanel/AddStarterBrickButton.tsx
+++ b/src/pageEditor/modListingPanel/AddStarterBrickButton.tsx
@@ -29,8 +29,8 @@ import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
 import { selectSessionId } from "@/pageEditor/store/session/sessionSelectors";
 import { inspectedTab } from "@/pageEditor/context/connection";
-import { flagOn } from "@/auth/featureFlagStorage";
 import { ALL_ADAPTERS } from "@/pageEditor/starterBricks/adapter";
+import useFlags from "@/hooks/useFlags";
 
 const sortedModComponentAdapters = sortBy(ALL_ADAPTERS, (x) => x.displayOrder);
 
@@ -59,6 +59,7 @@ const DropdownEntry: React.FunctionComponent<{
 const AddStarterBrickButton: React.FunctionComponent = () => {
   const tabHasPermissions = useSelector(selectTabHasPermissions);
   const sessionId = useSelector(selectSessionId);
+  const { flagOn } = useFlags();
 
   const addNewModComponent = useAddNewModComponent();
 
@@ -89,7 +90,7 @@ const AddStarterBrickButton: React.FunctionComponent = () => {
           />
         ))
     );
-  }, []);
+  }, [flagOn]);
 
   return (
     <DropdownButton


### PR DESCRIPTION
## What does this PR do?

- Fix starter brick feature flag detection. Bug was preventing beta users from creating the dynamic quick bar starter brick
- Add eslint rule to force using useFlags in an React context

## Remaining Work

- [x] The failing playwright tests appear to be unrelated at first glance

## Future Work

- Fix `useFlags` to return `async` methods for flag checks vs. potentially relying on uninitialized state
- Have `useFlags` fallback to the cached flags while the remote query is fetching / if the remote query fails. (Not possible because the methods are synchronous 🤷 )
- Introduce a constants file for feature flags similar to `Events` constant

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
