### PR TITLE
#8933: adds mousedown handler to solve document mousedown handler bug

### DIFF
--- a/src/contentScript/focusCaptureDialog.ts
+++ b/src/contentScript/focusCaptureDialog.ts
@@ -63,6 +63,12 @@ async function rawFocusCaptureDialog({
   dialog.showModal();
 
   const anyPromiseWillCloseTheDialog = [
+    // In Chrome 127.0.6533.73, the `chrome.sidePanel.open()` API started throwing user gesture errors
+    // when a message from the content script was sent to the background script.
+    // The root cause appears to be a registered mousedown handler on the document that sends a message
+    // Adding `mousedown` here ensures that the sidePanel.open call is made before the message for the mousedown
+    // handler on the document is sent.
+    // See https://issues.chromium.org/issues/355266358 for more details.
     oneEvent(button, "mousedown"),
     oneEvent(button, "click"),
     oneEvent(dialog, "cancel"),

--- a/src/contentScript/focusCaptureDialog.ts
+++ b/src/contentScript/focusCaptureDialog.ts
@@ -63,6 +63,7 @@ async function rawFocusCaptureDialog({
   dialog.showModal();
 
   const anyPromiseWillCloseTheDialog = [
+    oneEvent(button, "mousedown"),
     oneEvent(button, "click"),
     oneEvent(dialog, "cancel"),
     onContextInvalidated.promise,


### PR DESCRIPTION
## What does this PR do?

- Part of #8933
- Allows clicking the button for the focus capture dialog (partial mitigation for https://pixiebrix.slack.com/canvas/C07DGPVQJKH)

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
