### PR TITLE
8925: fix sidebar not being updated on deployment group membership removal

### DIFF
--- a/end-to-end-tests/tests/runtime/insertAtCursor.spec.ts
+++ b/end-to-end-tests/tests/runtime/insertAtCursor.spec.ts
@@ -113,8 +113,8 @@ test.describe("Insert at Cursor", () => {
     chromiumChannel,
   }) => {
     test.skip(
-      chromiumChannel === "chrome",
-      "Skip test on Chrome. See: https://pixiebrix.slack.com/archives/C07DQ2J7C78",
+      true,
+      "Skip test due to chromium bug. See: https://pixiebrix.slack.com/archives/C07DGPVQJKH",
     );
     // This mod opens the sidebar with a selection menu option, and then inserts "Hello world!" at the cursor from the sidebar
     const modId = "@pixies/test/insert-at-cursor-with-selection-menu";

--- a/src/extensionConsole/pages/deployments/DeploymentsContext.test.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentsContext.test.tsx
@@ -206,6 +206,11 @@ describe("DeploymentsContext", () => {
       expect(axiosMock.history.post).toHaveLength(1);
     });
 
+    // The initial load will automatically remove the old mod.
+    const { options } = getReduxStore().getState();
+    expect((options as ModComponentState).extensions).toHaveLength(0);
+    expect(jest.mocked(reloadModsEveryTab)).toHaveBeenCalledTimes(1);
+
     await userEvent.click(screen.getByText("Update"));
 
     await waitFor(() => {
@@ -213,10 +218,10 @@ describe("DeploymentsContext", () => {
       expect(axiosMock.history.post).toHaveLength(3);
     });
 
-    const { options } = getReduxStore().getState();
-    expect((options as ModComponentState).extensions).toHaveLength(1);
+    const { options: updatedOptions } = getReduxStore().getState();
+    expect((updatedOptions as ModComponentState).extensions).toHaveLength(1);
 
-    expect(jest.mocked(reloadModsEveryTab)).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(reloadModsEveryTab)).toHaveBeenCalledTimes(2);
   });
 
   it("automatically deactivates unassigned deployments", async () => {

--- a/src/extensionConsole/pages/deployments/useDeactivateUnassignedDeploymentsEffect.ts
+++ b/src/extensionConsole/pages/deployments/useDeactivateUnassignedDeploymentsEffect.ts
@@ -34,7 +34,7 @@ const useDeactivateUnassignedDeploymentsEffect = (
       dispatch,
       unassignedModComponents,
     });
-  }, [unassignedModComponents]);
+  }, [dispatch, unassignedModComponents]);
 };
 
 export default useDeactivateUnassignedDeploymentsEffect;


### PR DESCRIPTION
## What does this PR do?

- Fixes #8925 

## Discussion

This behavior change will automatically reload all tabs when the user loads the extension console with activated mods which should be removed.

## Demo

https://www.loom.com/share/a4459c4bba704a29af1226d8bf54ffcc

## Future Work

- playwright test

## Checklist

_Leave all that are relevant and check off as completed_

- [ ] This PR requires a security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change
- [X] Added jest or playwright tests and/or storybook stories

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
