### PR TITLE
Prevent crash with `getContexts` and fix the window reference in `reportError`

### DIFF
--- a/src/data/service/errorService.ts
+++ b/src/data/service/errorService.ts
@@ -162,7 +162,7 @@ export async function reportToErrorService(
     extension_uuid: flatContext.modComponentId,
     extension_label: flatContext.modComponentLabel,
     step_label: flatContext.label,
-    user_agent: window.navigator.userAgent,
+    user_agent: navigator.userAgent,
     user_agent_extension_version: extensionVersion,
     is_application_error: !selectSpecificError(error, BusinessError),
     error_data: data,

--- a/src/tinyPages/offscreen.ts
+++ b/src/tinyPages/offscreen.ts
@@ -99,7 +99,6 @@ export async function setupOffscreenDocument() {
       if (
         errorMessage.includes("Only a single offscreen document may be created")
       ) {
-        // The offscreen document has already been created
         console.debug("Offscreen document already exists");
         return;
       }

--- a/src/tinyPages/offscreen.ts
+++ b/src/tinyPages/offscreen.ts
@@ -49,7 +49,7 @@ export type RecordErrorMessage = {
 export async function setupOffscreenDocument() {
   /*
    * WARNING: The runtime.getContexts() api is crashing the browser under
-   *  certain conditions in chrome versions >127.0.0.0. See issue
+   *  certain conditions in chrome versions >127.0.6533.73. See issue
    *  tracker here: https://issues.chromium.org/issues/355625882
    *
    * Dangerous code to check if the offscreen document exists:

--- a/src/tinyPages/offscreen.ts
+++ b/src/tinyPages/offscreen.ts
@@ -90,13 +90,15 @@ export async function setupOffscreenDocument() {
         justification:
           "Error telemetry SDK usage that is incompatible with service workers",
       });
+      await createOffscreenDocumentPromise;
     } catch (error) {
+      createOffscreenDocumentPromise = null;
+
       const errorMessage = getErrorMessage(error);
       if (
         errorMessage.includes("Only a single offscreen document may be created")
       ) {
         // The offscreen document has already been created
-        createOffscreenDocumentPromise = null;
         return;
       }
 
@@ -108,7 +110,6 @@ export async function setupOffscreenDocument() {
       );
     }
 
-    await createOffscreenDocumentPromise;
     createOffscreenDocumentPromise = null;
   } else {
     await createOffscreenDocumentPromise;

--- a/src/tinyPages/offscreen.ts
+++ b/src/tinyPages/offscreen.ts
@@ -80,6 +80,7 @@ export async function setupOffscreenDocument() {
 
   if (createOffscreenDocumentPromise == null) {
     try {
+      console.debug("Creating the offscreen document");
       createOffscreenDocumentPromise = chrome.offscreen.createDocument({
         url: "offscreen.html",
         // Our reason for creating an offscreen document does not fit nicely into options offered by the Chrome API, which
@@ -99,6 +100,7 @@ export async function setupOffscreenDocument() {
         errorMessage.includes("Only a single offscreen document may be created")
       ) {
         // The offscreen document has already been created
+        console.debug("Offscreen document already exists");
         return;
       }
 
@@ -111,7 +113,11 @@ export async function setupOffscreenDocument() {
     }
 
     createOffscreenDocumentPromise = null;
+    console.debug("Offscreen document created successfully");
   } else {
+    console.debug(
+      "Offscreen document creation in progress from a previous call",
+    );
     await createOffscreenDocumentPromise;
   }
 }


### PR DESCRIPTION
## What does this PR do?

- Avoids calling the broken chrome api `runtime.getContexts()` that is crashing the browser
- Fixes a `window` reference in the `reportError` code chain that is now being executed in the service worker, which does not have `window` available

_Example debug logs showing behavior for two errors in a row_:

![image](https://github.com/user-attachments/assets/d9318e9e-7b6e-4a2a-bdb6-5920d06d736c)


_Example logs for two errors in quick succession to force the promise concurrency handling_:

<img width="571" alt="image" src="https://github.com/user-attachments/assets/e0a0941b-aaa3-4467-9d39-8df18ec2050a">



For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
