### PR TITLE
Allow undefined condition value and warn on constant if-else conditions

### DIFF
--- a/src/analysis/analysisVisitors/conditionAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/conditionAnalysis.test.ts
@@ -22,87 +22,194 @@ import { AnnotationType } from "@/types/annotationTypes";
 import ConditionAnalysis from "@/analysis/analysisVisitors/conditionAnalysis";
 import { toExpression } from "@/utils/expressionUtils";
 import { AnalysisAnnotationActionType } from "@/analysis/analysisTypes";
+import IfElse from "@/bricks/transformers/controlFlow/IfElse";
 
 describe("conditionAnalysis", () => {
-  it("no warning for unset field", async () => {
-    const formState = triggerFormStateFactory({}, [
-      {
-        id: ContextBrick.BRICK_ID,
-        config: {},
-        outputKey: validateOutputKey("foo"),
-      },
-    ]);
+  describe("brick condition", () => {
+    it("no warning for unset field", async () => {
+      const formState = triggerFormStateFactory({}, [
+        {
+          id: ContextBrick.BRICK_ID,
+          config: {},
+          outputKey: validateOutputKey("foo"),
+        },
+      ]);
 
-    const analysis = new ConditionAnalysis();
-    analysis.run(formState);
+      const analysis = new ConditionAnalysis();
+      analysis.run(formState);
 
-    expect(analysis.getAnnotations()).toEqual([]);
+      expect(analysis.getAnnotations()).toEqual([]);
+    });
+
+    it("warning for blank value", async () => {
+      const formState = triggerFormStateFactory({}, [
+        {
+          id: ContextBrick.BRICK_ID,
+          config: {},
+          if: toExpression("nunjucks", " "),
+          outputKey: validateOutputKey("foo"),
+        },
+      ]);
+
+      const analysis = new ConditionAnalysis();
+      analysis.run(formState);
+
+      expect(analysis.getAnnotations()).toStrictEqual([
+        expect.objectContaining({
+          type: AnnotationType.Warning,
+          actions: [
+            expect.objectContaining({
+              caption: "Exclude Condition",
+              type: AnalysisAnnotationActionType.UnsetValue,
+              path: "modComponent.brickPipeline.0.if",
+            }),
+          ],
+        }),
+      ]);
+    });
+
+    it.each([true, false])("info for boolean literal", async (value) => {
+      const formState = triggerFormStateFactory({}, [
+        {
+          id: ContextBrick.BRICK_ID,
+          config: {},
+          if: value,
+          outputKey: validateOutputKey("foo"),
+        },
+      ]);
+
+      const analysis = new ConditionAnalysis();
+      analysis.run(formState);
+
+      expect(analysis.getAnnotations()).toStrictEqual([
+        expect.objectContaining({
+          type: AnnotationType.Info,
+        }),
+      ]);
+    });
+
+    it.each(["y", "f"])("info for template literal", async (value) => {
+      const formState = triggerFormStateFactory({}, [
+        {
+          id: ContextBrick.BRICK_ID,
+          config: {},
+          if: toExpression("nunjucks", value),
+          outputKey: validateOutputKey("foo"),
+        },
+      ]);
+
+      const analysis = new ConditionAnalysis();
+      analysis.run(formState);
+
+      expect(analysis.getAnnotations()).toStrictEqual([
+        expect.objectContaining({
+          type: AnnotationType.Info,
+        }),
+      ]);
+    });
   });
 
-  it("warning for blank value", async () => {
-    const formState = triggerFormStateFactory({}, [
-      {
-        id: ContextBrick.BRICK_ID,
-        config: {},
-        if: toExpression("nunjucks", " "),
-        outputKey: validateOutputKey("foo"),
-      },
-    ]);
+  describe("if-else condition", () => {
+    it("warns for exclude", async () => {
+      const formState = triggerFormStateFactory({}, [
+        {
+          id: IfElse.BRICK_ID,
+          config: {},
+          outputKey: validateOutputKey("foo"),
+        },
+      ]);
 
-    const analysis = new ConditionAnalysis();
-    analysis.run(formState);
+      const analysis = new ConditionAnalysis();
+      analysis.run(formState);
 
-    expect(analysis.getAnnotations()).toStrictEqual([
-      expect.objectContaining({
-        type: AnnotationType.Warning,
-        actions: [
-          expect.objectContaining({
-            caption: "Exclude Condition",
-            type: AnalysisAnnotationActionType.UnsetValue,
-            path: "modComponent.brickPipeline.0.if",
-          }),
-        ],
-      }),
-    ]);
+      expect(analysis.getAnnotations()).toStrictEqual([
+        expect.objectContaining({
+          type: AnnotationType.Warning,
+        }),
+      ]);
+    });
+
+    it.each(["y", "f"])("warns for template literal", async (value) => {
+      const formState = triggerFormStateFactory({}, [
+        {
+          id: IfElse.BRICK_ID,
+          config: {
+            condition: value,
+          },
+          outputKey: validateOutputKey("foo"),
+        },
+      ]);
+
+      const analysis = new ConditionAnalysis();
+      analysis.run(formState);
+
+      expect(analysis.getAnnotations()).toStrictEqual([
+        expect.objectContaining({
+          type: AnnotationType.Warning,
+        }),
+      ]);
+    });
+
+    it("allows expression", async () => {
+      const formState = triggerFormStateFactory({}, [
+        {
+          id: IfElse.BRICK_ID,
+          config: {
+            condition: toExpression("nunjucks", "{{ true if @input.foo }}"),
+          },
+          outputKey: validateOutputKey("foo"),
+        },
+      ]);
+
+      const analysis = new ConditionAnalysis();
+      analysis.run(formState);
+
+      expect(analysis.getAnnotations()).toStrictEqual([]);
+    });
+
+    it.each([true, false])("warns for boolean literal", async (value) => {
+      const formState = triggerFormStateFactory({}, [
+        {
+          id: IfElse.BRICK_ID,
+          config: {
+            condition: value,
+          },
+          outputKey: validateOutputKey("foo"),
+        },
+      ]);
+
+      const analysis = new ConditionAnalysis();
+      analysis.run(formState);
+
+      expect(analysis.getAnnotations()).toStrictEqual([
+        expect.objectContaining({
+          type: AnnotationType.Warning,
+        }),
+      ]);
+    });
   });
 
-  it.each([true, false])("info for boolean literal", async (value) => {
-    const formState = triggerFormStateFactory({}, [
-      {
-        id: ContextBrick.BRICK_ID,
-        config: {},
-        if: value,
-        outputKey: validateOutputKey("foo"),
-      },
-    ]);
+  it.each(["t", "f", ""])(
+    "warns for constant template expression",
+    async (value) => {
+      const formState = triggerFormStateFactory({}, [
+        {
+          id: IfElse.BRICK_ID,
+          config: {
+            condition: toExpression("nunjucks", value),
+          },
+          outputKey: validateOutputKey("foo"),
+        },
+      ]);
 
-    const analysis = new ConditionAnalysis();
-    analysis.run(formState);
+      const analysis = new ConditionAnalysis();
+      analysis.run(formState);
 
-    expect(analysis.getAnnotations()).toStrictEqual([
-      expect.objectContaining({
-        type: AnnotationType.Info,
-      }),
-    ]);
-  });
-
-  it.each(["y", "f"])("info for template literal", async (value) => {
-    const formState = triggerFormStateFactory({}, [
-      {
-        id: ContextBrick.BRICK_ID,
-        config: {},
-        if: toExpression("nunjucks", value),
-        outputKey: validateOutputKey("foo"),
-      },
-    ]);
-
-    const analysis = new ConditionAnalysis();
-    analysis.run(formState);
-
-    expect(analysis.getAnnotations()).toStrictEqual([
-      expect.objectContaining({
-        type: AnnotationType.Info,
-      }),
-    ]);
-  });
+      expect(analysis.getAnnotations()).toStrictEqual([
+        expect.objectContaining({
+          type: AnnotationType.Warning,
+        }),
+      ]);
+    },
+  );
 });

--- a/src/bricks/exampleBrickConfigs.ts
+++ b/src/bricks/exampleBrickConfigs.ts
@@ -36,6 +36,7 @@ import { validateOutputKey } from "@/runtime/runtimeTypes";
 import AddTextSnippets from "@/bricks/effects/AddTextSnippets";
 
 import { MergeStrategies, StateNamespaces } from "@/platform/state/stateTypes";
+import IfElse from "@/bricks/transformers/controlFlow/IfElse";
 
 /**
  * Get an example brick config for a given brick id.
@@ -244,6 +245,15 @@ export function getExampleBrickConfig(
   return x;
 }`,
         arguments: { x: "Hello from PixieBrix!" },
+      };
+    }
+
+    case IfElse.BRICK_ID: {
+      return {
+        // `condition` is not required, default to empty string so it's not excluded
+        condition: toExpression("nunjucks", ""),
+        if: toExpression("pipeline", []),
+        else: toExpression("pipeline", []),
       };
     }
 

--- a/src/bricks/transformers/controlFlow/IfElse.test.ts
+++ b/src/bricks/transformers/controlFlow/IfElse.test.ts
@@ -105,6 +105,22 @@ describe("IfElse", () => {
     expect(result).toStrictEqual({ prop: "I'm a teapot" });
   });
 
+  test("undefined condition follows else branch", async () => {
+    const pipeline = {
+      id: ifElseBlock.id,
+      config: {
+        if: toExpression("pipeline", []),
+        else: toExpression("pipeline", [{ id: teapotBrick.id, config: {} }]),
+      },
+    };
+    const result = await reducePipeline(
+      pipeline,
+      simpleInput({}),
+      reduceOptionsFactory("v3"),
+    );
+    expect(result).toStrictEqual({ prop: "I'm a teapot" });
+  });
+
   test("else optional", async () => {
     const pipeline = {
       id: ifElseBlock.id,

--- a/src/bricks/transformers/controlFlow/IfElse.ts
+++ b/src/bricks/transformers/controlFlow/IfElse.ts
@@ -63,7 +63,7 @@ class IfElse extends TransformerABC {
         description: "The bricks to run if the condition is not met",
       },
     },
-    ["condition", "if"],
+    ["if"],
   );
 
   async transform(


### PR DESCRIPTION
## What does this PR do?

- If Else brick allows undefined condition at runtime (required for passing potentially undefined variable directly as condition)
- Warn on constant if-else conditions

## Demo

![image](https://github.com/user-attachments/assets/34fadbe5-2724-473d-9e2d-6dd9b8eb1cb5)

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
