### PR TITLE
#8827: add support for re-ordering array items in the Page Editor

### DIFF
--- a/src/components/fields/schemaFields/widgets/ArrayWidget.module.scss
+++ b/src/components/fields/schemaFields/widgets/ArrayWidget.module.scss
@@ -18,3 +18,12 @@
 .addButton {
   padding: 0;
 }
+
+.moveButton {
+  // Match the padding in TemplateToggleWidget.module.scss
+  padding: 0.25rem !important;
+
+  svg {
+    height: 1.2em;
+  }
+}

--- a/src/components/fields/schemaFields/widgets/ArrayWidget.module.scss
+++ b/src/components/fields/schemaFields/widgets/ArrayWidget.module.scss
@@ -23,7 +23,10 @@
   // Match the padding in TemplateToggleWidget.module.scss
   padding: 0.25rem !important;
 
+  // Match the style in OptionIcon.module.scss
   svg {
-    height: 1.2em;
+    height: 1.2rem;
+    vertical-align: text-bottom;
+    margin-top: 2px;
   }
 }

--- a/src/components/fields/schemaFields/widgets/ArrayWidget.test.tsx
+++ b/src/components/fields/schemaFields/widgets/ArrayWidget.test.tsx
@@ -153,4 +153,44 @@ describe("ArrayWidget", () => {
       [fieldName]: ["abc"],
     });
   });
+
+  test("move item", async () => {
+    const schema: Schema = {
+      type: "array",
+      additionalItems: true,
+      items: {
+        type: "string",
+      },
+    };
+    const { getFormState } = render(
+      <ArrayWidget
+        name={fieldName}
+        schema={schema}
+        isRequired
+        description={fieldDescription}
+        defaultType="array"
+      />,
+      {
+        initialValues: {
+          [fieldName]: ["abc", "def"],
+        },
+      },
+    );
+
+    await userEvent.click(
+      screen.getAllByRole("button", { name: "Move down" })[0]!,
+    );
+
+    expect(getFormState()).toStrictEqual({
+      [fieldName]: ["def", "abc"],
+    });
+
+    await userEvent.click(
+      screen.getAllByRole("button", { name: "Move up" })[1]!,
+    );
+
+    expect(getFormState()).toStrictEqual({
+      [fieldName]: ["abc", "def"],
+    });
+  });
 });

--- a/src/components/fields/schemaFields/widgets/ArrayWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/ArrayWidget.tsx
@@ -26,6 +26,8 @@ import {
   textPredicate,
 } from "@/components/fields/schemaFields/schemaUtils";
 import { defaultBrickConfig } from "@/bricks/util";
+import ArrowUpwardIcon from "@/icons/arrow-upward.svg?loadAsComponent";
+import ArrowDownwardIcon from "@/icons/arrow-downward.svg?loadAsComponent";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import styles from "./ArrayWidget.module.scss";
 import { joinName } from "@/utils/formUtils";
@@ -87,21 +89,52 @@ const ArrayWidget: React.VFC<ArrayWidgetProps> = ({
 
   return (
     <FieldArray name={name}>
-      {({ push }) => (
+      {({ push, swap }) => (
         <>
           <ul className="list-group mb-2">
-            {field.value?.map((_, index) => (
-              // eslint-disable-next-line react/no-array-index-key -- They have no other unique identifier
-              <li className="list-group-item py-1" key={index}>
-                <SchemaField
-                  name={joinName(name, String(index))}
-                  schema={schemaItems}
-                  validationSchema={validationSchema}
-                  hideLabel
-                  isArrayItem
-                />
-              </li>
-            ))}
+            {field.value?.map((_, index) => {
+              const canMoveUp = index > 0;
+              const canMoveDown = index < field.value.length - 1;
+
+              return (
+                // eslint-disable-next-line react/no-array-index-key -- They have no other unique identifier
+                <li className="list-group-item py-1 d-flex pl-1" key={index}>
+                  <div>
+                    <Button
+                      className={styles.moveButton}
+                      title="Move up"
+                      variant="link"
+                      disabled={!canMoveUp}
+                      onClick={() => {
+                        swap(index, index - 1);
+                      }}
+                    >
+                      <ArrowUpwardIcon />
+                    </Button>
+                    <Button
+                      className={styles.moveButton}
+                      title="Move down"
+                      variant="link"
+                      disabled={!canMoveDown}
+                      onClick={() => {
+                        swap(index, index + 1);
+                      }}
+                    >
+                      <ArrowDownwardIcon />
+                    </Button>
+                  </div>
+                  <div className="flex-grow-1">
+                    <SchemaField
+                      name={joinName(name, String(index))}
+                      schema={schemaItems}
+                      validationSchema={validationSchema}
+                      hideLabel
+                      isArrayItem
+                    />
+                  </div>
+                </li>
+              );
+            })}
           </ul>
           <Button
             variant="link"

--- a/src/components/fields/schemaFields/widgets/__snapshots__/ArrayWidget.test.tsx.snap
+++ b/src/components/fields/schemaFields/widgets/__snapshots__/ArrayWidget.test.tsx.snap
@@ -32,165 +32,227 @@ exports[`ArrayWidget renders widget with items 1`] = `
       class="list-group mb-2"
     >
       <li
-        class="list-group-item py-1"
+        class="list-group-item py-1 d-flex pl-1"
       >
+        <div>
+          <button
+            class="moveButton btn btn-link"
+            disabled=""
+            title="Move up"
+            type="button"
+          >
+            <test-file-stub />
+          </button>
+          <button
+            class="moveButton btn btn-link"
+            title="Move down"
+            type="button"
+          >
+            <test-file-stub />
+          </button>
+        </div>
         <div
-          class="formGroup mb-0 form-group"
+          class="flex-grow-1"
         >
           <div
-            class="mb-2 w-100 collapse"
+            class="formGroup mb-0 form-group"
           >
             <div
-              class="annotationPlaceholder"
-            />
-          </div>
-          <div
-            class="formField"
-          >
-            <div
-              class="root"
+              class="mb-2 w-100 collapse"
             >
               <div
-                class="field"
-              >
-                <textarea
-                  class="form-control"
-                  id="testField.0"
-                  name="testField.0"
-                  rows="1"
-                >
-                  abc
-                </textarea>
-              </div>
+                class="annotationPlaceholder"
+              />
+            </div>
+            <div
+              class="formField"
+            >
               <div
-                class="dropdown dropdown"
-                data-test-selected="Text"
-                data-testid="toggle-testField.0"
+                class="root"
               >
-                <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="dropdown-toggle btn btn-link"
-                  type="button"
+                <div
+                  class="field"
                 >
-                  <span
-                    class="symbol"
+                  <textarea
+                    class="form-control"
+                    id="testField.0"
+                    name="testField.0"
+                    rows="1"
                   >
-                    <test-file-stub
-                      classname="root"
-                    />
-                  </span>
-                </button>
+                    abc
+                  </textarea>
+                </div>
+                <div
+                  class="dropdown dropdown"
+                  data-test-selected="Text"
+                  data-testid="toggle-testField.0"
+                >
+                  <button
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    class="dropdown-toggle btn btn-link"
+                    type="button"
+                  >
+                    <span
+                      class="symbol"
+                    >
+                      <test-file-stub
+                        classname="root"
+                      />
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </li>
       <li
-        class="list-group-item py-1"
+        class="list-group-item py-1 d-flex pl-1"
       >
+        <div>
+          <button
+            class="moveButton btn btn-link"
+            title="Move up"
+            type="button"
+          >
+            <test-file-stub />
+          </button>
+          <button
+            class="moveButton btn btn-link"
+            title="Move down"
+            type="button"
+          >
+            <test-file-stub />
+          </button>
+        </div>
         <div
-          class="formGroup mb-0 form-group"
+          class="flex-grow-1"
         >
           <div
-            class="mb-2 w-100 collapse"
+            class="formGroup mb-0 form-group"
           >
             <div
-              class="annotationPlaceholder"
-            />
-          </div>
-          <div
-            class="formField"
-          >
-            <div
-              class="root"
+              class="mb-2 w-100 collapse"
             >
               <div
-                class="field"
-              >
-                <textarea
-                  class="form-control"
-                  id="testField.1"
-                  name="testField.1"
-                  rows="1"
-                >
-                  def
-                </textarea>
-              </div>
+                class="annotationPlaceholder"
+              />
+            </div>
+            <div
+              class="formField"
+            >
               <div
-                class="dropdown dropdown"
-                data-test-selected="Text"
-                data-testid="toggle-testField.1"
+                class="root"
               >
-                <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="dropdown-toggle btn btn-link"
-                  type="button"
+                <div
+                  class="field"
                 >
-                  <span
-                    class="symbol"
+                  <textarea
+                    class="form-control"
+                    id="testField.1"
+                    name="testField.1"
+                    rows="1"
                   >
-                    <test-file-stub
-                      classname="root"
-                    />
-                  </span>
-                </button>
+                    def
+                  </textarea>
+                </div>
+                <div
+                  class="dropdown dropdown"
+                  data-test-selected="Text"
+                  data-testid="toggle-testField.1"
+                >
+                  <button
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    class="dropdown-toggle btn btn-link"
+                    type="button"
+                  >
+                    <span
+                      class="symbol"
+                    >
+                      <test-file-stub
+                        classname="root"
+                      />
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </li>
       <li
-        class="list-group-item py-1"
+        class="list-group-item py-1 d-flex pl-1"
       >
+        <div>
+          <button
+            class="moveButton btn btn-link"
+            title="Move up"
+            type="button"
+          >
+            <test-file-stub />
+          </button>
+          <button
+            class="moveButton btn btn-link"
+            disabled=""
+            title="Move down"
+            type="button"
+          >
+            <test-file-stub />
+          </button>
+        </div>
         <div
-          class="formGroup mb-0 form-group"
+          class="flex-grow-1"
         >
           <div
-            class="mb-2 w-100 collapse"
+            class="formGroup mb-0 form-group"
           >
             <div
-              class="annotationPlaceholder"
-            />
-          </div>
-          <div
-            class="formField"
-          >
-            <div
-              class="root"
+              class="mb-2 w-100 collapse"
             >
               <div
-                class="field"
-              >
-                <textarea
-                  class="form-control"
-                  id="testField.2"
-                  name="testField.2"
-                  rows="1"
-                >
-                  this is a really long string to see what happens when the array value is long
-                </textarea>
-              </div>
+                class="annotationPlaceholder"
+              />
+            </div>
+            <div
+              class="formField"
+            >
               <div
-                class="dropdown dropdown"
-                data-test-selected="Text"
-                data-testid="toggle-testField.2"
+                class="root"
               >
-                <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="dropdown-toggle btn btn-link"
-                  type="button"
+                <div
+                  class="field"
                 >
-                  <span
-                    class="symbol"
+                  <textarea
+                    class="form-control"
+                    id="testField.2"
+                    name="testField.2"
+                    rows="1"
                   >
-                    <test-file-stub
-                      classname="root"
-                    />
-                  </span>
-                </button>
+                    this is a really long string to see what happens when the array value is long
+                  </textarea>
+                </div>
+                <div
+                  class="dropdown dropdown"
+                  data-test-selected="Text"
+                  data-testid="toggle-testField.2"
+                >
+                  <button
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    class="dropdown-toggle btn btn-link"
+                    type="button"
+                  >
+                    <span
+                      class="symbol"
+                    >
+                      <test-file-stub
+                        classname="root"
+                      />
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/src/pageEditor/components/__snapshots__/UrlPatternWidget.test.tsx.snap
+++ b/src/pageEditor/components/__snapshots__/UrlPatternWidget.test.tsx.snap
@@ -32,356 +32,378 @@ exports[`UrlPatternWidget render single pattern 1`] = `
       class="list-group mb-2"
     >
       <li
-        class="list-group-item py-1"
+        class="list-group-item py-1 d-flex pl-1"
       >
+        <div>
+          <button
+            class="moveButton btn btn-link"
+            disabled=""
+            title="Move up"
+            type="button"
+          >
+            <test-file-stub />
+          </button>
+          <button
+            class="moveButton btn btn-link"
+            disabled=""
+            title="Move down"
+            type="button"
+          >
+            <test-file-stub />
+          </button>
+        </div>
         <div
-          class="formGroup mb-0 form-group"
+          class="flex-grow-1"
         >
           <div
-            class="mb-2 w-100 collapse"
+            class="formGroup mb-0 form-group"
           >
             <div
-              class="annotationPlaceholder"
-            />
-          </div>
-          <div
-            class="formField"
-          >
-            <div
-              class="root"
+              class="mb-2 w-100 collapse"
             >
               <div
-                class="field"
+                class="annotationPlaceholder"
+              />
+            </div>
+            <div
+              class="formField"
+            >
+              <div
+                class="root"
               >
-                <div>
-                  <table
-                    class="mb-0 table table-sm"
-                  >
-                    <thead>
-                      <tr>
-                        <th
-                          scope="col"
-                        >
-                          Property name
-                        </th>
-                        <th
-                          scope="col"
-                        >
-                          Value
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td>
-                          <input
-                            class="form-control"
-                            data-testid="pattern.0.hostname-name"
-                            readonly=""
-                            type="text"
-                            value="hostname"
-                          />
-                        </td>
-                        <td>
-                          <div
-                            class="formGroup mb-0 form-group"
+                <div
+                  class="field"
+                >
+                  <div>
+                    <table
+                      class="mb-0 table table-sm"
+                    >
+                      <thead>
+                        <tr>
+                          <th
+                            scope="col"
                           >
-                            <div
-                              class="mb-2 w-100 collapse"
-                            >
-                              <div
-                                class="annotationPlaceholder"
-                              />
-                            </div>
-                            <div
-                              class="formField"
-                            >
-                              <div
-                                class="root"
-                              >
-                                <div
-                                  class="field"
-                                >
-                                  <input
-                                    class="form-control"
-                                    id="pattern.0.hostname"
-                                    name="pattern.0.hostname"
-                                    readonly=""
-                                    value=""
-                                  />
-                                </div>
-                                <div
-                                  class="dropdown dropdown"
-                                  data-test-selected="Exclude"
-                                  data-testid="toggle-pattern.0.hostname"
-                                >
-                                  <button
-                                    aria-expanded="false"
-                                    aria-haspopup="true"
-                                    class="dropdown-toggle btn btn-link"
-                                    type="button"
-                                  >
-                                    <span
-                                      class="symbol"
-                                    >
-                                      <test-file-stub
-                                        classname="root"
-                                      />
-                                    </span>
-                                  </button>
-                                </div>
-                              </div>
-                              <small
-                                class="text-muted form-text"
-                              >
-                                <span>
-                                  Pattern to match the hostname part of a URL.
-                                </span>
-                              </small>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td>
-                          <input
-                            class="form-control"
-                            data-testid="pattern.0.pathname-name"
-                            readonly=""
-                            type="text"
-                            value="pathname"
-                          />
-                        </td>
-                        <td>
-                          <div
-                            class="formGroup mb-0 form-group"
+                            Property name
+                          </th>
+                          <th
+                            scope="col"
                           >
+                            Value
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          <td>
+                            <input
+                              class="form-control"
+                              data-testid="pattern.0.hostname-name"
+                              readonly=""
+                              type="text"
+                              value="hostname"
+                            />
+                          </td>
+                          <td>
                             <div
-                              class="mb-2 w-100 collapse"
+                              class="formGroup mb-0 form-group"
                             >
                               <div
-                                class="annotationPlaceholder"
-                              />
-                            </div>
-                            <div
-                              class="formField"
-                            >
-                              <div
-                                class="root"
+                                class="mb-2 w-100 collapse"
                               >
                                 <div
-                                  class="field"
-                                >
-                                  <input
-                                    class="form-control"
-                                    id="pattern.0.pathname"
-                                    name="pattern.0.pathname"
-                                    readonly=""
-                                    value=""
-                                  />
-                                </div>
-                                <div
-                                  class="dropdown dropdown"
-                                  data-test-selected="Exclude"
-                                  data-testid="toggle-pattern.0.pathname"
-                                >
-                                  <button
-                                    aria-expanded="false"
-                                    aria-haspopup="true"
-                                    class="dropdown-toggle btn btn-link"
-                                    type="button"
-                                  >
-                                    <span
-                                      class="symbol"
-                                    >
-                                      <test-file-stub
-                                        classname="root"
-                                      />
-                                    </span>
-                                  </button>
-                                </div>
+                                  class="annotationPlaceholder"
+                                />
                               </div>
-                              <small
-                                class="text-muted form-text"
-                              >
-                                <span>
-                                  Pattern to match the pathname part of a URL.
-                                </span>
-                              </small>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td>
-                          <input
-                            class="form-control"
-                            data-testid="pattern.0.hash-name"
-                            readonly=""
-                            type="text"
-                            value="hash"
-                          />
-                        </td>
-                        <td>
-                          <div
-                            class="formGroup mb-0 form-group"
-                          >
-                            <div
-                              class="mb-2 w-100 collapse"
-                            >
                               <div
-                                class="annotationPlaceholder"
-                              />
-                            </div>
-                            <div
-                              class="formField"
-                            >
-                              <div
-                                class="root"
+                                class="formField"
                               >
                                 <div
-                                  class="field"
+                                  class="root"
                                 >
-                                  <textarea
-                                    class="form-control"
-                                    id="pattern.0.hash"
-                                    name="pattern.0.hash"
-                                    rows="1"
+                                  <div
+                                    class="field"
                                   >
-                                    /requests/ref/16-2
-                                  </textarea>
-                                </div>
-                                <div
-                                  class="dropdown dropdown"
-                                  data-test-selected="Text"
-                                  data-testid="toggle-pattern.0.hash"
-                                >
-                                  <button
-                                    aria-expanded="false"
-                                    aria-haspopup="true"
-                                    class="dropdown-toggle btn btn-link"
-                                    type="button"
+                                    <input
+                                      class="form-control"
+                                      id="pattern.0.hostname"
+                                      name="pattern.0.hostname"
+                                      readonly=""
+                                      value=""
+                                    />
+                                  </div>
+                                  <div
+                                    class="dropdown dropdown"
+                                    data-test-selected="Exclude"
+                                    data-testid="toggle-pattern.0.hostname"
                                   >
-                                    <span
-                                      class="symbol"
+                                    <button
+                                      aria-expanded="false"
+                                      aria-haspopup="true"
+                                      class="dropdown-toggle btn btn-link"
+                                      type="button"
                                     >
-                                      <test-file-stub
-                                        classname="root"
-                                      />
-                                    </span>
-                                  </button>
+                                      <span
+                                        class="symbol"
+                                      >
+                                        <test-file-stub
+                                          classname="root"
+                                        />
+                                      </span>
+                                    </button>
+                                  </div>
                                 </div>
+                                <small
+                                  class="text-muted form-text"
+                                >
+                                  <span>
+                                    Pattern to match the hostname part of a URL.
+                                  </span>
+                                </small>
                               </div>
-                              <small
-                                class="text-muted form-text"
-                              >
-                                <span>
-                                  Pattern to match the hash part of a URL.
-                                </span>
-                              </small>
                             </div>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td>
-                          <input
-                            class="form-control"
-                            data-testid="pattern.0.search-name"
-                            readonly=""
-                            type="text"
-                            value="search"
-                          />
-                        </td>
-                        <td>
-                          <div
-                            class="formGroup mb-0 form-group"
-                          >
+                          </td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <input
+                              class="form-control"
+                              data-testid="pattern.0.pathname-name"
+                              readonly=""
+                              type="text"
+                              value="pathname"
+                            />
+                          </td>
+                          <td>
                             <div
-                              class="mb-2 w-100 collapse"
+                              class="formGroup mb-0 form-group"
                             >
                               <div
-                                class="annotationPlaceholder"
-                              />
-                            </div>
-                            <div
-                              class="formField"
-                            >
-                              <div
-                                class="root"
+                                class="mb-2 w-100 collapse"
                               >
                                 <div
-                                  class="field"
-                                >
-                                  <input
-                                    class="form-control"
-                                    id="pattern.0.search"
-                                    name="pattern.0.search"
-                                    readonly=""
-                                    value=""
-                                  />
-                                </div>
+                                  class="annotationPlaceholder"
+                                />
+                              </div>
+                              <div
+                                class="formField"
+                              >
                                 <div
-                                  class="dropdown dropdown"
-                                  data-test-selected="Exclude"
-                                  data-testid="toggle-pattern.0.search"
+                                  class="root"
                                 >
-                                  <button
-                                    aria-expanded="false"
-                                    aria-haspopup="true"
-                                    class="dropdown-toggle btn btn-link"
-                                    type="button"
+                                  <div
+                                    class="field"
                                   >
-                                    <span
-                                      class="symbol"
+                                    <input
+                                      class="form-control"
+                                      id="pattern.0.pathname"
+                                      name="pattern.0.pathname"
+                                      readonly=""
+                                      value=""
+                                    />
+                                  </div>
+                                  <div
+                                    class="dropdown dropdown"
+                                    data-test-selected="Exclude"
+                                    data-testid="toggle-pattern.0.pathname"
+                                  >
+                                    <button
+                                      aria-expanded="false"
+                                      aria-haspopup="true"
+                                      class="dropdown-toggle btn btn-link"
+                                      type="button"
                                     >
-                                      <test-file-stub
-                                        classname="root"
-                                      />
-                                    </span>
-                                  </button>
+                                      <span
+                                        class="symbol"
+                                      >
+                                        <test-file-stub
+                                          classname="root"
+                                        />
+                                      </span>
+                                    </button>
+                                  </div>
                                 </div>
+                                <small
+                                  class="text-muted form-text"
+                                >
+                                  <span>
+                                    Pattern to match the pathname part of a URL.
+                                  </span>
+                                </small>
                               </div>
-                              <small
-                                class="text-muted form-text"
-                              >
-                                <span>
-                                  Pattern to match the search part of a URL.
-                                </span>
-                              </small>
                             </div>
-                          </div>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <input
+                              class="form-control"
+                              data-testid="pattern.0.hash-name"
+                              readonly=""
+                              type="text"
+                              value="hash"
+                            />
+                          </td>
+                          <td>
+                            <div
+                              class="formGroup mb-0 form-group"
+                            >
+                              <div
+                                class="mb-2 w-100 collapse"
+                              >
+                                <div
+                                  class="annotationPlaceholder"
+                                />
+                              </div>
+                              <div
+                                class="formField"
+                              >
+                                <div
+                                  class="root"
+                                >
+                                  <div
+                                    class="field"
+                                  >
+                                    <textarea
+                                      class="form-control"
+                                      id="pattern.0.hash"
+                                      name="pattern.0.hash"
+                                      rows="1"
+                                    >
+                                      /requests/ref/16-2
+                                    </textarea>
+                                  </div>
+                                  <div
+                                    class="dropdown dropdown"
+                                    data-test-selected="Text"
+                                    data-testid="toggle-pattern.0.hash"
+                                  >
+                                    <button
+                                      aria-expanded="false"
+                                      aria-haspopup="true"
+                                      class="dropdown-toggle btn btn-link"
+                                      type="button"
+                                    >
+                                      <span
+                                        class="symbol"
+                                      >
+                                        <test-file-stub
+                                          classname="root"
+                                        />
+                                      </span>
+                                    </button>
+                                  </div>
+                                </div>
+                                <small
+                                  class="text-muted form-text"
+                                >
+                                  <span>
+                                    Pattern to match the hash part of a URL.
+                                  </span>
+                                </small>
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <input
+                              class="form-control"
+                              data-testid="pattern.0.search-name"
+                              readonly=""
+                              type="text"
+                              value="search"
+                            />
+                          </td>
+                          <td>
+                            <div
+                              class="formGroup mb-0 form-group"
+                            >
+                              <div
+                                class="mb-2 w-100 collapse"
+                              >
+                                <div
+                                  class="annotationPlaceholder"
+                                />
+                              </div>
+                              <div
+                                class="formField"
+                              >
+                                <div
+                                  class="root"
+                                >
+                                  <div
+                                    class="field"
+                                  >
+                                    <input
+                                      class="form-control"
+                                      id="pattern.0.search"
+                                      name="pattern.0.search"
+                                      readonly=""
+                                      value=""
+                                    />
+                                  </div>
+                                  <div
+                                    class="dropdown dropdown"
+                                    data-test-selected="Exclude"
+                                    data-testid="toggle-pattern.0.search"
+                                  >
+                                    <button
+                                      aria-expanded="false"
+                                      aria-haspopup="true"
+                                      class="dropdown-toggle btn btn-link"
+                                      type="button"
+                                    >
+                                      <span
+                                        class="symbol"
+                                      >
+                                        <test-file-stub
+                                          classname="root"
+                                        />
+                                      </span>
+                                    </button>
+                                  </div>
+                                </div>
+                                <small
+                                  class="text-muted form-text"
+                                >
+                                  <span>
+                                    Pattern to match the search part of a URL.
+                                  </span>
+                                </small>
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <button
+                      class="btn btn-primary"
+                      type="button"
+                    >
+                      Add Property
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="dropdown dropdown"
+                  data-test-selected="Object properties"
+                  data-testid="toggle-pattern.0"
+                >
                   <button
-                    class="btn btn-primary"
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    class="dropdown-toggle btn btn-link"
                     type="button"
                   >
-                    Add Property
+                    <span
+                      class="symbol"
+                    >
+                      <test-file-stub
+                        classname="root"
+                      />
+                    </span>
                   </button>
                 </div>
-              </div>
-              <div
-                class="dropdown dropdown"
-                data-test-selected="Object properties"
-                data-testid="toggle-pattern.0"
-              >
-                <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="dropdown-toggle btn btn-link"
-                  type="button"
-                >
-                  <span
-                    class="symbol"
-                  >
-                    <test-file-stub
-                      classname="root"
-                    />
-                  </span>
-                </button>
               </div>
             </div>
           </div>

--- a/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
@@ -672,55 +672,77 @@ exports[`renders a mod component with sub pipeline 1`] = `
                   class="list-group mb-2"
                 >
                   <li
-                    class="list-group-item py-1"
+                    class="list-group-item py-1 d-flex pl-1"
                   >
+                    <div>
+                      <button
+                        class="moveButton btn btn-link"
+                        disabled=""
+                        title="Move up"
+                        type="button"
+                      >
+                        <test-file-stub />
+                      </button>
+                      <button
+                        class="moveButton btn btn-link"
+                        disabled=""
+                        title="Move down"
+                        type="button"
+                      >
+                        <test-file-stub />
+                      </button>
+                    </div>
                     <div
-                      class="formGroup mb-0 form-group"
+                      class="flex-grow-1"
                     >
                       <div
-                        class="mb-2 w-100 collapse"
+                        class="formGroup mb-0 form-group"
                       >
                         <div
-                          class="annotationPlaceholder"
-                        />
-                      </div>
-                      <div
-                        class="formField"
-                      >
-                        <div
-                          class="root"
+                          class="mb-2 w-100 collapse"
                         >
                           <div
-                            class="field"
-                          >
-                            <textarea
-                              class="form-control"
-                              id="starterBrick.definition.isAvailable.matchPatterns.0"
-                              name="starterBrick.definition.isAvailable.matchPatterns.0"
-                              rows="1"
-                            >
-                              https://www.mySite2.com/*
-                            </textarea>
-                          </div>
+                            class="annotationPlaceholder"
+                          />
+                        </div>
+                        <div
+                          class="formField"
+                        >
                           <div
-                            class="dropdown dropdown"
-                            data-test-selected="Text"
-                            data-testid="toggle-starterBrick.definition.isAvailable.matchPatterns.0"
+                            class="root"
                           >
-                            <button
-                              aria-expanded="false"
-                              aria-haspopup="true"
-                              class="dropdown-toggle btn btn-link"
-                              type="button"
+                            <div
+                              class="field"
                             >
-                              <span
-                                class="symbol"
+                              <textarea
+                                class="form-control"
+                                id="starterBrick.definition.isAvailable.matchPatterns.0"
+                                name="starterBrick.definition.isAvailable.matchPatterns.0"
+                                rows="1"
                               >
-                                <test-file-stub
-                                  classname="root"
-                                />
-                              </span>
-                            </button>
+                                https://www.mySite2.com/*
+                              </textarea>
+                            </div>
+                            <div
+                              class="dropdown dropdown"
+                              data-test-selected="Text"
+                              data-testid="toggle-starterBrick.definition.isAvailable.matchPatterns.0"
+                            >
+                              <button
+                                aria-expanded="false"
+                                aria-haspopup="true"
+                                class="dropdown-toggle btn btn-link"
+                                type="button"
+                              >
+                                <span
+                                  class="symbol"
+                                >
+                                  <test-file-stub
+                                    classname="root"
+                                  />
+                                </span>
+                              </button>
+                            </div>
                           </div>
                         </div>
                       </div>

--- a/src/pageEditor/tabs/__snapshots__/ExtraPermissionsSection.test.tsx.snap
+++ b/src/pageEditor/tabs/__snapshots__/ExtraPermissionsSection.test.tsx.snap
@@ -201,55 +201,77 @@ exports[`ExtraPermissionsSection render populated section 1`] = `
               class="list-group mb-2"
             >
               <li
-                class="list-group-item py-1"
+                class="list-group-item py-1 d-flex pl-1"
               >
+                <div>
+                  <button
+                    class="moveButton btn btn-link"
+                    disabled=""
+                    title="Move up"
+                    type="button"
+                  >
+                    <test-file-stub />
+                  </button>
+                  <button
+                    class="moveButton btn btn-link"
+                    disabled=""
+                    title="Move down"
+                    type="button"
+                  >
+                    <test-file-stub />
+                  </button>
+                </div>
                 <div
-                  class="formGroup mb-0 form-group"
+                  class="flex-grow-1"
                 >
                   <div
-                    class="mb-2 w-100 collapse"
+                    class="formGroup mb-0 form-group"
                   >
                     <div
-                      class="annotationPlaceholder"
-                    />
-                  </div>
-                  <div
-                    class="formField"
-                  >
-                    <div
-                      class="root"
+                      class="mb-2 w-100 collapse"
                     >
                       <div
-                        class="field"
-                      >
-                        <textarea
-                          class="form-control"
-                          id="permissions.origins.0"
-                          name="permissions.origins.0"
-                          rows="1"
-                        >
-                          http://web.archive.org/web/20150905193945/http://www.hamsterdance.com/
-                        </textarea>
-                      </div>
+                        class="annotationPlaceholder"
+                      />
+                    </div>
+                    <div
+                      class="formField"
+                    >
                       <div
-                        class="dropdown dropdown"
-                        data-test-selected="Text"
-                        data-testid="toggle-permissions.origins.0"
+                        class="root"
                       >
-                        <button
-                          aria-expanded="false"
-                          aria-haspopup="true"
-                          class="dropdown-toggle btn btn-link"
-                          type="button"
+                        <div
+                          class="field"
                         >
-                          <span
-                            class="symbol"
+                          <textarea
+                            class="form-control"
+                            id="permissions.origins.0"
+                            name="permissions.origins.0"
+                            rows="1"
                           >
-                            <test-file-stub
-                              classname="root"
-                            />
-                          </span>
-                        </button>
+                            http://web.archive.org/web/20150905193945/http://www.hamsterdance.com/
+                          </textarea>
+                        </div>
+                        <div
+                          class="dropdown dropdown"
+                          data-test-selected="Text"
+                          data-testid="toggle-permissions.origins.0"
+                        >
+                          <button
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            class="dropdown-toggle btn btn-link"
+                            type="button"
+                          >
+                            <span
+                              class="symbol"
+                            >
+                              <test-file-stub
+                                classname="root"
+                              />
+                            </span>
+                          </button>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/src/pageEditor/tabs/__snapshots__/MatchRulesSection.test.tsx.snap
+++ b/src/pageEditor/tabs/__snapshots__/MatchRulesSection.test.tsx.snap
@@ -188,356 +188,378 @@ exports[`MatchRulesSection render populated section 1`] = `
               class="list-group mb-2"
             >
               <li
-                class="list-group-item py-1"
+                class="list-group-item py-1 d-flex pl-1"
               >
+                <div>
+                  <button
+                    class="moveButton btn btn-link"
+                    disabled=""
+                    title="Move up"
+                    type="button"
+                  >
+                    <test-file-stub />
+                  </button>
+                  <button
+                    class="moveButton btn btn-link"
+                    disabled=""
+                    title="Move down"
+                    type="button"
+                  >
+                    <test-file-stub />
+                  </button>
+                </div>
                 <div
-                  class="formGroup mb-0 form-group"
+                  class="flex-grow-1"
                 >
                   <div
-                    class="mb-2 w-100 collapse"
+                    class="formGroup mb-0 form-group"
                   >
                     <div
-                      class="annotationPlaceholder"
-                    />
-                  </div>
-                  <div
-                    class="formField"
-                  >
-                    <div
-                      class="root"
+                      class="mb-2 w-100 collapse"
                     >
                       <div
-                        class="field"
+                        class="annotationPlaceholder"
+                      />
+                    </div>
+                    <div
+                      class="formField"
+                    >
+                      <div
+                        class="root"
                       >
-                        <div>
-                          <table
-                            class="mb-0 table table-sm"
-                          >
-                            <thead>
-                              <tr>
-                                <th
-                                  scope="col"
-                                >
-                                  Property name
-                                </th>
-                                <th
-                                  scope="col"
-                                >
-                                  Value
-                                </th>
-                              </tr>
-                            </thead>
-                            <tbody>
-                              <tr>
-                                <td>
-                                  <input
-                                    class="form-control"
-                                    data-testid="starterBrick.definition.isAvailable.urlPatterns.0.hostname-name"
-                                    readonly=""
-                                    type="text"
-                                    value="hostname"
-                                  />
-                                </td>
-                                <td>
-                                  <div
-                                    class="formGroup mb-0 form-group"
+                        <div
+                          class="field"
+                        >
+                          <div>
+                            <table
+                              class="mb-0 table table-sm"
+                            >
+                              <thead>
+                                <tr>
+                                  <th
+                                    scope="col"
                                   >
-                                    <div
-                                      class="mb-2 w-100 collapse"
-                                    >
-                                      <div
-                                        class="annotationPlaceholder"
-                                      />
-                                    </div>
-                                    <div
-                                      class="formField"
-                                    >
-                                      <div
-                                        class="root"
-                                      >
-                                        <div
-                                          class="field"
-                                        >
-                                          <input
-                                            class="form-control"
-                                            id="starterBrick.definition.isAvailable.urlPatterns.0.hostname"
-                                            name="starterBrick.definition.isAvailable.urlPatterns.0.hostname"
-                                            readonly=""
-                                            value=""
-                                          />
-                                        </div>
-                                        <div
-                                          class="dropdown dropdown"
-                                          data-test-selected="Exclude"
-                                          data-testid="toggle-starterBrick.definition.isAvailable.urlPatterns.0.hostname"
-                                        >
-                                          <button
-                                            aria-expanded="false"
-                                            aria-haspopup="true"
-                                            class="dropdown-toggle btn btn-link"
-                                            type="button"
-                                          >
-                                            <span
-                                              class="symbol"
-                                            >
-                                              <test-file-stub
-                                                classname="root"
-                                              />
-                                            </span>
-                                          </button>
-                                        </div>
-                                      </div>
-                                      <small
-                                        class="text-muted form-text"
-                                      >
-                                        <span>
-                                          Pattern to match the hostname part of a URL.
-                                        </span>
-                                      </small>
-                                    </div>
-                                  </div>
-                                </td>
-                              </tr>
-                              <tr>
-                                <td>
-                                  <input
-                                    class="form-control"
-                                    data-testid="starterBrick.definition.isAvailable.urlPatterns.0.pathname-name"
-                                    readonly=""
-                                    type="text"
-                                    value="pathname"
-                                  />
-                                </td>
-                                <td>
-                                  <div
-                                    class="formGroup mb-0 form-group"
+                                    Property name
+                                  </th>
+                                  <th
+                                    scope="col"
                                   >
+                                    Value
+                                  </th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                <tr>
+                                  <td>
+                                    <input
+                                      class="form-control"
+                                      data-testid="starterBrick.definition.isAvailable.urlPatterns.0.hostname-name"
+                                      readonly=""
+                                      type="text"
+                                      value="hostname"
+                                    />
+                                  </td>
+                                  <td>
                                     <div
-                                      class="mb-2 w-100 collapse"
+                                      class="formGroup mb-0 form-group"
                                     >
                                       <div
-                                        class="annotationPlaceholder"
-                                      />
-                                    </div>
-                                    <div
-                                      class="formField"
-                                    >
-                                      <div
-                                        class="root"
+                                        class="mb-2 w-100 collapse"
                                       >
                                         <div
-                                          class="field"
-                                        >
-                                          <input
-                                            class="form-control"
-                                            id="starterBrick.definition.isAvailable.urlPatterns.0.pathname"
-                                            name="starterBrick.definition.isAvailable.urlPatterns.0.pathname"
-                                            readonly=""
-                                            value=""
-                                          />
-                                        </div>
-                                        <div
-                                          class="dropdown dropdown"
-                                          data-test-selected="Exclude"
-                                          data-testid="toggle-starterBrick.definition.isAvailable.urlPatterns.0.pathname"
-                                        >
-                                          <button
-                                            aria-expanded="false"
-                                            aria-haspopup="true"
-                                            class="dropdown-toggle btn btn-link"
-                                            type="button"
-                                          >
-                                            <span
-                                              class="symbol"
-                                            >
-                                              <test-file-stub
-                                                classname="root"
-                                              />
-                                            </span>
-                                          </button>
-                                        </div>
+                                          class="annotationPlaceholder"
+                                        />
                                       </div>
-                                      <small
-                                        class="text-muted form-text"
-                                      >
-                                        <span>
-                                          Pattern to match the pathname part of a URL.
-                                        </span>
-                                      </small>
-                                    </div>
-                                  </div>
-                                </td>
-                              </tr>
-                              <tr>
-                                <td>
-                                  <input
-                                    class="form-control"
-                                    data-testid="starterBrick.definition.isAvailable.urlPatterns.0.hash-name"
-                                    readonly=""
-                                    type="text"
-                                    value="hash"
-                                  />
-                                </td>
-                                <td>
-                                  <div
-                                    class="formGroup mb-0 form-group"
-                                  >
-                                    <div
-                                      class="mb-2 w-100 collapse"
-                                    >
                                       <div
-                                        class="annotationPlaceholder"
-                                      />
-                                    </div>
-                                    <div
-                                      class="formField"
-                                    >
-                                      <div
-                                        class="root"
+                                        class="formField"
                                       >
                                         <div
-                                          class="field"
+                                          class="root"
                                         >
-                                          <textarea
-                                            class="form-control"
-                                            id="starterBrick.definition.isAvailable.urlPatterns.0.hash"
-                                            name="starterBrick.definition.isAvailable.urlPatterns.0.hash"
-                                            rows="1"
+                                          <div
+                                            class="field"
                                           >
-                                            /foo/
-                                          </textarea>
-                                        </div>
-                                        <div
-                                          class="dropdown dropdown"
-                                          data-test-selected="Text"
-                                          data-testid="toggle-starterBrick.definition.isAvailable.urlPatterns.0.hash"
-                                        >
-                                          <button
-                                            aria-expanded="false"
-                                            aria-haspopup="true"
-                                            class="dropdown-toggle btn btn-link"
-                                            type="button"
+                                            <input
+                                              class="form-control"
+                                              id="starterBrick.definition.isAvailable.urlPatterns.0.hostname"
+                                              name="starterBrick.definition.isAvailable.urlPatterns.0.hostname"
+                                              readonly=""
+                                              value=""
+                                            />
+                                          </div>
+                                          <div
+                                            class="dropdown dropdown"
+                                            data-test-selected="Exclude"
+                                            data-testid="toggle-starterBrick.definition.isAvailable.urlPatterns.0.hostname"
                                           >
-                                            <span
-                                              class="symbol"
+                                            <button
+                                              aria-expanded="false"
+                                              aria-haspopup="true"
+                                              class="dropdown-toggle btn btn-link"
+                                              type="button"
                                             >
-                                              <test-file-stub
-                                                classname="root"
-                                              />
-                                            </span>
-                                          </button>
+                                              <span
+                                                class="symbol"
+                                              >
+                                                <test-file-stub
+                                                  classname="root"
+                                                />
+                                              </span>
+                                            </button>
+                                          </div>
                                         </div>
+                                        <small
+                                          class="text-muted form-text"
+                                        >
+                                          <span>
+                                            Pattern to match the hostname part of a URL.
+                                          </span>
+                                        </small>
                                       </div>
-                                      <small
-                                        class="text-muted form-text"
-                                      >
-                                        <span>
-                                          Pattern to match the hash part of a URL.
-                                        </span>
-                                      </small>
                                     </div>
-                                  </div>
-                                </td>
-                              </tr>
-                              <tr>
-                                <td>
-                                  <input
-                                    class="form-control"
-                                    data-testid="starterBrick.definition.isAvailable.urlPatterns.0.search-name"
-                                    readonly=""
-                                    type="text"
-                                    value="search"
-                                  />
-                                </td>
-                                <td>
-                                  <div
-                                    class="formGroup mb-0 form-group"
-                                  >
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>
+                                    <input
+                                      class="form-control"
+                                      data-testid="starterBrick.definition.isAvailable.urlPatterns.0.pathname-name"
+                                      readonly=""
+                                      type="text"
+                                      value="pathname"
+                                    />
+                                  </td>
+                                  <td>
                                     <div
-                                      class="mb-2 w-100 collapse"
+                                      class="formGroup mb-0 form-group"
                                     >
                                       <div
-                                        class="annotationPlaceholder"
-                                      />
-                                    </div>
-                                    <div
-                                      class="formField"
-                                    >
-                                      <div
-                                        class="root"
+                                        class="mb-2 w-100 collapse"
                                       >
                                         <div
-                                          class="field"
-                                        >
-                                          <input
-                                            class="form-control"
-                                            id="starterBrick.definition.isAvailable.urlPatterns.0.search"
-                                            name="starterBrick.definition.isAvailable.urlPatterns.0.search"
-                                            readonly=""
-                                            value=""
-                                          />
-                                        </div>
+                                          class="annotationPlaceholder"
+                                        />
+                                      </div>
+                                      <div
+                                        class="formField"
+                                      >
                                         <div
-                                          class="dropdown dropdown"
-                                          data-test-selected="Exclude"
-                                          data-testid="toggle-starterBrick.definition.isAvailable.urlPatterns.0.search"
+                                          class="root"
                                         >
-                                          <button
-                                            aria-expanded="false"
-                                            aria-haspopup="true"
-                                            class="dropdown-toggle btn btn-link"
-                                            type="button"
+                                          <div
+                                            class="field"
                                           >
-                                            <span
-                                              class="symbol"
+                                            <input
+                                              class="form-control"
+                                              id="starterBrick.definition.isAvailable.urlPatterns.0.pathname"
+                                              name="starterBrick.definition.isAvailable.urlPatterns.0.pathname"
+                                              readonly=""
+                                              value=""
+                                            />
+                                          </div>
+                                          <div
+                                            class="dropdown dropdown"
+                                            data-test-selected="Exclude"
+                                            data-testid="toggle-starterBrick.definition.isAvailable.urlPatterns.0.pathname"
+                                          >
+                                            <button
+                                              aria-expanded="false"
+                                              aria-haspopup="true"
+                                              class="dropdown-toggle btn btn-link"
+                                              type="button"
                                             >
-                                              <test-file-stub
-                                                classname="root"
-                                              />
-                                            </span>
-                                          </button>
+                                              <span
+                                                class="symbol"
+                                              >
+                                                <test-file-stub
+                                                  classname="root"
+                                                />
+                                              </span>
+                                            </button>
+                                          </div>
                                         </div>
+                                        <small
+                                          class="text-muted form-text"
+                                        >
+                                          <span>
+                                            Pattern to match the pathname part of a URL.
+                                          </span>
+                                        </small>
                                       </div>
-                                      <small
-                                        class="text-muted form-text"
-                                      >
-                                        <span>
-                                          Pattern to match the search part of a URL.
-                                        </span>
-                                      </small>
                                     </div>
-                                  </div>
-                                </td>
-                              </tr>
-                            </tbody>
-                          </table>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>
+                                    <input
+                                      class="form-control"
+                                      data-testid="starterBrick.definition.isAvailable.urlPatterns.0.hash-name"
+                                      readonly=""
+                                      type="text"
+                                      value="hash"
+                                    />
+                                  </td>
+                                  <td>
+                                    <div
+                                      class="formGroup mb-0 form-group"
+                                    >
+                                      <div
+                                        class="mb-2 w-100 collapse"
+                                      >
+                                        <div
+                                          class="annotationPlaceholder"
+                                        />
+                                      </div>
+                                      <div
+                                        class="formField"
+                                      >
+                                        <div
+                                          class="root"
+                                        >
+                                          <div
+                                            class="field"
+                                          >
+                                            <textarea
+                                              class="form-control"
+                                              id="starterBrick.definition.isAvailable.urlPatterns.0.hash"
+                                              name="starterBrick.definition.isAvailable.urlPatterns.0.hash"
+                                              rows="1"
+                                            >
+                                              /foo/
+                                            </textarea>
+                                          </div>
+                                          <div
+                                            class="dropdown dropdown"
+                                            data-test-selected="Text"
+                                            data-testid="toggle-starterBrick.definition.isAvailable.urlPatterns.0.hash"
+                                          >
+                                            <button
+                                              aria-expanded="false"
+                                              aria-haspopup="true"
+                                              class="dropdown-toggle btn btn-link"
+                                              type="button"
+                                            >
+                                              <span
+                                                class="symbol"
+                                              >
+                                                <test-file-stub
+                                                  classname="root"
+                                                />
+                                              </span>
+                                            </button>
+                                          </div>
+                                        </div>
+                                        <small
+                                          class="text-muted form-text"
+                                        >
+                                          <span>
+                                            Pattern to match the hash part of a URL.
+                                          </span>
+                                        </small>
+                                      </div>
+                                    </div>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>
+                                    <input
+                                      class="form-control"
+                                      data-testid="starterBrick.definition.isAvailable.urlPatterns.0.search-name"
+                                      readonly=""
+                                      type="text"
+                                      value="search"
+                                    />
+                                  </td>
+                                  <td>
+                                    <div
+                                      class="formGroup mb-0 form-group"
+                                    >
+                                      <div
+                                        class="mb-2 w-100 collapse"
+                                      >
+                                        <div
+                                          class="annotationPlaceholder"
+                                        />
+                                      </div>
+                                      <div
+                                        class="formField"
+                                      >
+                                        <div
+                                          class="root"
+                                        >
+                                          <div
+                                            class="field"
+                                          >
+                                            <input
+                                              class="form-control"
+                                              id="starterBrick.definition.isAvailable.urlPatterns.0.search"
+                                              name="starterBrick.definition.isAvailable.urlPatterns.0.search"
+                                              readonly=""
+                                              value=""
+                                            />
+                                          </div>
+                                          <div
+                                            class="dropdown dropdown"
+                                            data-test-selected="Exclude"
+                                            data-testid="toggle-starterBrick.definition.isAvailable.urlPatterns.0.search"
+                                          >
+                                            <button
+                                              aria-expanded="false"
+                                              aria-haspopup="true"
+                                              class="dropdown-toggle btn btn-link"
+                                              type="button"
+                                            >
+                                              <span
+                                                class="symbol"
+                                              >
+                                                <test-file-stub
+                                                  classname="root"
+                                                />
+                                              </span>
+                                            </button>
+                                          </div>
+                                        </div>
+                                        <small
+                                          class="text-muted form-text"
+                                        >
+                                          <span>
+                                            Pattern to match the search part of a URL.
+                                          </span>
+                                        </small>
+                                      </div>
+                                    </div>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <button
+                              class="btn btn-primary"
+                              type="button"
+                            >
+                              Add Property
+                            </button>
+                          </div>
+                        </div>
+                        <div
+                          class="dropdown dropdown"
+                          data-test-selected="Object properties"
+                          data-testid="toggle-starterBrick.definition.isAvailable.urlPatterns.0"
+                        >
                           <button
-                            class="btn btn-primary"
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            class="dropdown-toggle btn btn-link"
                             type="button"
                           >
-                            Add Property
+                            <span
+                              class="symbol"
+                            >
+                              <test-file-stub
+                                classname="root"
+                              />
+                            </span>
                           </button>
                         </div>
-                      </div>
-                      <div
-                        class="dropdown dropdown"
-                        data-test-selected="Object properties"
-                        data-testid="toggle-starterBrick.definition.isAvailable.urlPatterns.0"
-                      >
-                        <button
-                          aria-expanded="false"
-                          aria-haspopup="true"
-                          class="dropdown-toggle btn btn-link"
-                          type="button"
-                        >
-                          <span
-                            class="symbol"
-                          >
-                            <test-file-stub
-                              classname="root"
-                            />
-                          </span>
-                        </button>
                       </div>
                     </div>
                   </div>
@@ -590,55 +612,77 @@ exports[`MatchRulesSection render populated section 1`] = `
               class="list-group mb-2"
             >
               <li
-                class="list-group-item py-1"
+                class="list-group-item py-1 d-flex pl-1"
               >
+                <div>
+                  <button
+                    class="moveButton btn btn-link"
+                    disabled=""
+                    title="Move up"
+                    type="button"
+                  >
+                    <test-file-stub />
+                  </button>
+                  <button
+                    class="moveButton btn btn-link"
+                    disabled=""
+                    title="Move down"
+                    type="button"
+                  >
+                    <test-file-stub />
+                  </button>
+                </div>
                 <div
-                  class="formGroup mb-0 form-group"
+                  class="flex-grow-1"
                 >
                   <div
-                    class="mb-2 w-100 collapse"
+                    class="formGroup mb-0 form-group"
                   >
                     <div
-                      class="annotationPlaceholder"
-                    />
-                  </div>
-                  <div
-                    class="formField"
-                  >
-                    <div
-                      class="root"
+                      class="mb-2 w-100 collapse"
                     >
                       <div
-                        class="field"
-                      >
-                        <textarea
-                          class="form-control"
-                          id="starterBrick.definition.isAvailable.selectors.0"
-                          name="starterBrick.definition.isAvailable.selectors.0"
-                          rows="1"
-                        >
-                          #foo
-                        </textarea>
-                      </div>
+                        class="annotationPlaceholder"
+                      />
+                    </div>
+                    <div
+                      class="formField"
+                    >
                       <div
-                        class="dropdown dropdown"
-                        data-test-selected="Text"
-                        data-testid="toggle-starterBrick.definition.isAvailable.selectors.0"
+                        class="root"
                       >
-                        <button
-                          aria-expanded="false"
-                          aria-haspopup="true"
-                          class="dropdown-toggle btn btn-link"
-                          type="button"
+                        <div
+                          class="field"
                         >
-                          <span
-                            class="symbol"
+                          <textarea
+                            class="form-control"
+                            id="starterBrick.definition.isAvailable.selectors.0"
+                            name="starterBrick.definition.isAvailable.selectors.0"
+                            rows="1"
                           >
-                            <test-file-stub
-                              classname="root"
-                            />
-                          </span>
-                        </button>
+                            #foo
+                          </textarea>
+                        </div>
+                        <div
+                          class="dropdown dropdown"
+                          data-test-selected="Text"
+                          data-testid="toggle-starterBrick.definition.isAvailable.selectors.0"
+                        >
+                          <button
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            class="dropdown-toggle btn btn-link"
+                            type="button"
+                          >
+                            <span
+                              class="symbol"
+                            >
+                              <test-file-stub
+                                classname="root"
+                              />
+                            </span>
+                          </button>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/src/pageEditor/tabs/trigger/__snapshots__/TriggerConfiguration.test.tsx.snap
+++ b/src/pageEditor/tabs/trigger/__snapshots__/TriggerConfiguration.test.tsx.snap
@@ -670,55 +670,77 @@ exports[`TriggerConfiguration renders custom event field with known event names 
           class="list-group mb-2"
         >
           <li
-            class="list-group-item py-1"
+            class="list-group-item py-1 d-flex pl-1"
           >
+            <div>
+              <button
+                class="moveButton btn btn-link"
+                disabled=""
+                title="Move up"
+                type="button"
+              >
+                <test-file-stub />
+              </button>
+              <button
+                class="moveButton btn btn-link"
+                disabled=""
+                title="Move down"
+                type="button"
+              >
+                <test-file-stub />
+              </button>
+            </div>
             <div
-              class="formGroup mb-0 form-group"
+              class="flex-grow-1"
             >
               <div
-                class="mb-2 w-100 collapse"
+                class="formGroup mb-0 form-group"
               >
                 <div
-                  class="annotationPlaceholder"
-                />
-              </div>
-              <div
-                class="formField"
-              >
-                <div
-                  class="root"
+                  class="mb-2 w-100 collapse"
                 >
                   <div
-                    class="field"
-                  >
-                    <textarea
-                      class="form-control"
-                      id="starterBrick.definition.isAvailable.matchPatterns.0"
-                      name="starterBrick.definition.isAvailable.matchPatterns.0"
-                      rows="1"
-                    >
-                      https://test.com/*
-                    </textarea>
-                  </div>
+                    class="annotationPlaceholder"
+                  />
+                </div>
+                <div
+                  class="formField"
+                >
                   <div
-                    class="dropdown dropdown"
-                    data-test-selected="Text"
-                    data-testid="toggle-starterBrick.definition.isAvailable.matchPatterns.0"
+                    class="root"
                   >
-                    <button
-                      aria-expanded="false"
-                      aria-haspopup="true"
-                      class="dropdown-toggle btn btn-link"
-                      type="button"
+                    <div
+                      class="field"
                     >
-                      <span
-                        class="symbol"
+                      <textarea
+                        class="form-control"
+                        id="starterBrick.definition.isAvailable.matchPatterns.0"
+                        name="starterBrick.definition.isAvailable.matchPatterns.0"
+                        rows="1"
                       >
-                        <test-file-stub
-                          classname="root"
-                        />
-                      </span>
-                    </button>
+                        https://test.com/*
+                      </textarea>
+                    </div>
+                    <div
+                      class="dropdown dropdown"
+                      data-test-selected="Text"
+                      data-testid="toggle-starterBrick.definition.isAvailable.matchPatterns.0"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-haspopup="true"
+                        class="dropdown-toggle btn btn-link"
+                        type="button"
+                      >
+                        <span
+                          class="symbol"
+                        >
+                          <test-file-stub
+                            classname="root"
+                          />
+                        </span>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## What does this PR do?

- Closes #8827
- Add support for re-ordering array items
- Modifies `ArrayWidget`, so works in Brick Configuration, Form Builder, etc.

## Remaining Work

- [x] Tweak padding/spacing. Icon baselines don't match with field type toggle

## Demo

![image](https://github.com/user-attachments/assets/45049837-745c-4ba5-b284-86aee526e7d6)

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
