### PR TITLE
#8924: Override styling on EllipsisMenu

### DIFF
--- a/src/components/ellipsisMenu/EllipsisMenu.module.scss
+++ b/src/components/ellipsisMenu/EllipsisMenu.module.scss
@@ -34,3 +34,8 @@
     background-color: #dae0e5;
   }
 }
+
+.menuItem {
+  font-size: 16px;
+  padding: 4px 24px;
+}

--- a/src/components/ellipsisMenu/EllipsisMenu.tsx
+++ b/src/components/ellipsisMenu/EllipsisMenu.tsx
@@ -107,7 +107,7 @@ const EllipsisMenu: React.FunctionComponent<EllipsisMenuProps> = ({
           <MenuItem
             key={item.title}
             href={item.href}
-            className={item.className}
+            className={cx(styles.menuItem, item.className)}
             disabled={item.disabled}
             target="_blank"
             rel="noopener noreferrer"
@@ -118,7 +118,7 @@ const EllipsisMenu: React.FunctionComponent<EllipsisMenuProps> = ({
           <MenuItem
             key={item.title}
             onClick={item.action ?? undefined}
-            className={item.className}
+            className={cx(styles.menuItem, item.className)}
             disabled={item.disabled}
           >
             {item.icon}&nbsp;{item.title}


### PR DESCRIPTION
## What does this PR do?

- Closes #8924 
- Makes the styling on EllipsisMenu consistent with our bootstrap dropdown menus

## Discussion

- I don't agree with this approach of implementing this via CSS module (it's not future-proof); I would have implemented this by tweaking the global theme. But going with this approach for now for speed & since other approaches I can think of would be equally-gross

## Demo

<img width="549" alt="Screenshot 2024-07-29 at 12 12 51 PM" src="https://github.com/user-attachments/assets/38472261-8436-43c3-9bf5-4e73ff2baa71">
