### PR TITLE
#8587: Fix bad logging MessageContext

### DIFF
--- a/end-to-end-tests/pageObjects/pageEditor/modEditorPane.ts
+++ b/end-to-end-tests/pageObjects/pageEditor/modEditorPane.ts
@@ -17,6 +17,7 @@
 
 import { BasePageObject } from "../basePageObject";
 import { ConfigurationForm } from "./configurationForm";
+import { expect } from "@playwright/test";
 
 class MetadataConfigurationForm extends ConfigurationForm {
   modId = this.getByRole("textbox", { name: "Mod ID" });
@@ -35,6 +36,23 @@ class InputConfigurationForm extends ConfigurationForm {
   addNewFieldButton = this.getByRole("button", { name: "Add new field" });
 }
 
+class LogsTableRow extends BasePageObject {
+  timestamp = this.getByRole("cell").nth(1);
+  level = this.getByRole("cell").nth(2);
+  label = this.getByRole("cell").nth(3);
+  brickId = this.getByRole("cell").nth(4);
+  message = this.getByRole("cell").nth(5);
+}
+
+class LogsPane extends BasePageObject {
+  logsTable = this.getByRole("table");
+
+  async getLogsTableRows() {
+    const rowElements = await this.logsTable.locator("tbody tr").all();
+    return rowElements.map((row) => new LogsTableRow(row));
+  }
+}
+
 export class ModEditorPane extends BasePageObject {
   editMetadataTab = this.getByRole("tab", { name: "Edit" });
   editMetadataTabPanel = new MetadataConfigurationForm(
@@ -49,6 +67,15 @@ export class ModEditorPane extends BasePageObject {
       hasText: "Mod Input Options",
     }),
   );
+
+  logsTab = this.getByRole("tab", { name: "Logs" });
+  async getLogsTabPanel() {
+    const logsTabPanel = this.getByRole("tabpanel").filter({
+      hasText: "Message/Error",
+    });
+    await expect(logsTabPanel).toBeVisible();
+    return new LogsPane(logsTabPanel);
+  }
 
   inputFormTab = this.getByRole("tab", { name: "Input Form" });
   inputFormTabPanel = new InputConfigurationForm(

--- a/end-to-end-tests/tests/pageEditor/logsPane.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/logsPane.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { test, expect } from "../../fixtures/testBase";
+import { ActivateModPage } from "../../pageObjects/extensionConsole/modsPage";
+// @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
+import { test as base } from "@playwright/test";
+
+test("can view error logs", async ({
+  page,
+  extensionId,
+  newPageEditorPage,
+}) => {
+  const modId = "@e2e-testing/error-trigger";
+  const modName = "Error trigger";
+  const modActivationPage = new ActivateModPage(page, extensionId, modId);
+
+  await modActivationPage.goto();
+  await modActivationPage.clickActivateAndWaitForModsPageRedirect();
+
+  await page.goto("/");
+
+  const pageEditorPage = await newPageEditorPage(page.url());
+  await pageEditorPage.modListingPanel.getModListItemByName(modName).click();
+  await pageEditorPage.modEditorPane.logsTab.click();
+  const logsTabPane = await pageEditorPage.modEditorPane.getLogsTabPanel();
+  const logs = await logsTabPane.getLogsTableRows();
+  expect(logs).toHaveLength(1);
+
+  const log = logs[0];
+  await expect(log.timestamp).toBeVisible();
+  await expect(log.level).toHaveText("ERROR");
+  await expect(log.label).toHaveText("Raise business error");
+  await expect(log.brickId).toHaveText("@pixiebrix/error");
+  await expect(log.message).toHaveText("Test error");
+});

--- a/src/components/logViewer/LogCard.tsx
+++ b/src/components/logViewer/LogCard.tsx
@@ -38,12 +38,16 @@ const LogCard: React.FunctionComponent<OwnProps> = ({
   const [level, setLevel] = useState<MessageLevel>(initialLevel);
   const [page, setPage] = useState(0);
 
-  const { isLoading } = useSelector(selectLogs);
+  const { isLoading, isError, error } = useSelector(selectLogs);
   const dispatch = useDispatch();
   const refreshEntries = () => dispatch(logActions.refreshEntries());
   const clearAvailableEntries = () => dispatch(logActions.clear());
 
   const logs = useLogEntriesView({ level, page, perPage });
+
+  if (isError) {
+    throw error;
+  }
 
   if (isLoading) {
     return (

--- a/src/components/logViewer/LogCard.tsx
+++ b/src/components/logViewer/LogCard.tsx
@@ -25,6 +25,7 @@ import useLogEntriesView from "@/components/logViewer/useLogEntriesView";
 import { useDispatch, useSelector } from "react-redux";
 import { selectLogs } from "./logSelectors";
 import { logActions } from "./logSlice";
+import { ErrorDisplay } from "@/layout/ErrorDisplay";
 
 type OwnProps = {
   initialLevel?: MessageLevel;
@@ -46,7 +47,11 @@ const LogCard: React.FunctionComponent<OwnProps> = ({
   const logs = useLogEntriesView({ level, page, perPage });
 
   if (isError) {
-    throw error;
+    return (
+      <Card.Body>
+        <ErrorDisplay error={error} />
+      </Card.Body>
+    );
   }
 
   if (isLoading) {

--- a/src/components/logViewer/logViewerTypes.ts
+++ b/src/components/logViewer/logViewerTypes.ts
@@ -38,6 +38,10 @@ export type LogState = {
    * Indicates the progress of the first loading from storage for the active context
    */
   isLoading: boolean;
+
+  isError: boolean;
+
+  error: unknown;
 };
 
 export type LogRootState = {

--- a/src/extensionConsole/pages/mods/modals/modLogsModal/ModLogsModal.tsx
+++ b/src/extensionConsole/pages/mods/modals/modLogsModal/ModLogsModal.tsx
@@ -31,7 +31,7 @@ const ModLogsModal: React.FunctionComponent = () => {
 
   const closeModal = () => {
     dispatch(modModalsSlice.actions.closeModal());
-    dispatch(logActions.setContext(null));
+    dispatch(logActions.setContext({ messageContext: null }));
   };
 
   const showLogsContext = useSelector(selectShowLogsContext);
@@ -40,7 +40,9 @@ const ModLogsModal: React.FunctionComponent = () => {
       return;
     }
 
-    dispatch(logActions.setContext(showLogsContext.messageContext));
+    dispatch(
+      logActions.setContext({ messageContext: showLogsContext.messageContext }),
+    );
   }, [showLogsContext, dispatch]);
 
   return (

--- a/src/extensionConsole/pages/packageEditor/useLogContext.ts
+++ b/src/extensionConsole/pages/packageEditor/useLogContext.ts
@@ -80,7 +80,7 @@ function useLogContext(config: string | null) {
       }
     }
 
-    dispatch(logActions.setContext(messageContext));
+    dispatch(logActions.setContext({ messageContext }));
   }, [debouncedConfig, dispatch]);
 }
 

--- a/src/pageEditor/panes/EditorPane.tsx
+++ b/src/pageEditor/panes/EditorPane.tsx
@@ -34,7 +34,6 @@ import {
   selectEditorUpdateKey,
 } from "@/pageEditor/store/editor/editorSelectors";
 import IntegrationsSliceModIntegrationsContextAdapter from "@/integrations/store/IntegrationsSliceModIntegrationsContextAdapter";
-import { type MessageContext } from "@/types/loggerTypes";
 
 // CHANGE_DETECT_DELAY_MILLIS should be low enough so that sidebar gets updated in a reasonable amount of time, but
 // high enough that there isn't an entry lag in the page editor
@@ -58,13 +57,13 @@ const EditorPaneContent: React.VoidFunctionComponent<{
 
   useEffect(() => {
     // TODO: Why wasn't this throwing a type error?
-    const messageContext: MessageContext = {
+    const messageContext = {
       modComponentId: modComponentFormState.uuid,
       modId: modComponentFormState.modMetadata
         ? modComponentFormState.modMetadata.id
         : undefined,
     };
-    dispatch(logActions.setContext(messageContext));
+    dispatch(logActions.setContext({ messageContext }));
   }, [modComponentFormState.uuid, modComponentFormState.modMetadata, dispatch]);
 
   return (

--- a/src/pageEditor/panes/EditorPane.tsx
+++ b/src/pageEditor/panes/EditorPane.tsx
@@ -56,7 +56,6 @@ const EditorPaneContent: React.VoidFunctionComponent<{
   );
 
   useEffect(() => {
-    // TODO: Why wasn't this throwing a type error?
     const messageContext = {
       modComponentId: modComponentFormState.uuid,
       modId: modComponentFormState.modMetadata

--- a/src/pageEditor/panes/EditorPane.tsx
+++ b/src/pageEditor/panes/EditorPane.tsx
@@ -34,6 +34,7 @@ import {
   selectEditorUpdateKey,
 } from "@/pageEditor/store/editor/editorSelectors";
 import IntegrationsSliceModIntegrationsContextAdapter from "@/integrations/store/IntegrationsSliceModIntegrationsContextAdapter";
+import { type MessageContext } from "@/types/loggerTypes";
 
 // CHANGE_DETECT_DELAY_MILLIS should be low enough so that sidebar gets updated in a reasonable amount of time, but
 // high enough that there isn't an entry lag in the page editor
@@ -56,9 +57,10 @@ const EditorPaneContent: React.VoidFunctionComponent<{
   );
 
   useEffect(() => {
-    const messageContext = {
-      extensionId: modComponentFormState.uuid,
-      blueprintId: modComponentFormState.modMetadata
+    // TODO: Why wasn't this throwing a type error?
+    const messageContext: MessageContext = {
+      modComponentId: modComponentFormState.uuid,
+      modId: modComponentFormState.modMetadata
         ? modComponentFormState.modMetadata.id
         : undefined,
     };

--- a/src/pageEditor/panes/ModEditorPane.tsx
+++ b/src/pageEditor/panes/ModEditorPane.tsx
@@ -49,7 +49,7 @@ const ModEditorPane: React.VFC = () => {
           modId: activeModId,
         }
       : {};
-    dispatch(logActions.setContext(messageContext));
+    dispatch(logActions.setContext({ messageContext }));
   }, [dispatch, activeModId]);
 
   const [unreadLogsCount, logsBadgeVariant] = useLogsBadgeState();

--- a/src/types/loggerTypes.ts
+++ b/src/types/loggerTypes.ts
@@ -20,7 +20,7 @@ import { type RegistryId, type SemVerString } from "@/types/registryTypes";
 import { type ContextName } from "webext-detect";
 
 /**
- * Log event metadata for the extensions internal logging infrastructure.
+ * Log event metadata for the mod component's internal logging infrastructure.
  * @see Logger
  */
 export type MessageContext = {

--- a/src/types/loggerTypes.ts
+++ b/src/types/loggerTypes.ts
@@ -20,7 +20,7 @@ import { type RegistryId, type SemVerString } from "@/types/registryTypes";
 import { type ContextName } from "webext-detect";
 
 /**
- * Log event metadata for the mod component's internal logging infrastructure.
+ * Log event metadata for the extension's internal logging infrastructure.
  * @see Logger
  */
 export type MessageContext = {


### PR DESCRIPTION
## What does this PR do?

- Closes #8587 
- Fixes a bad MessageContext state pushed to the store in EditorPane
- [x] TODO: add `isError` and `error` to `logSlice` to stop swallowing errors when polling logs
- [x] TODO: add and e2e test for viewing the Logs tab in the Page Editor
- [x] TODO: why isn't Typescript checking the shape passed to `logActions.setContext`?

## Demo

https://www.loom.com/share/018fd74069ef4e6298124ab912983cf8