### PR TITLE
#8962: scope label width CSS to fix visual regression

### DIFF
--- a/src/components/jsonTree/JsonTree.tsx
+++ b/src/components/jsonTree/JsonTree.tsx
@@ -97,6 +97,11 @@ export type JsonTreeProps = JsonTreeOrigProps & {
    * Change listener for the expanded state
    */
   onExpandedStateChange?: (nextExpandedState: TreeExpandedState) => void;
+
+  /**
+   * Optional additional class name
+   */
+  className?: string;
 };
 
 function normalize(value: Primitive): string {
@@ -189,6 +194,7 @@ const JsonTree: React.FunctionComponent<JsonTreeProps> = ({
   data,
   initialExpandedState = emptyObject,
   onExpandedStateChange,
+  className,
   ...restProps
 }) => {
   const [query, setQuery] = useState(initialSearchQuery);
@@ -258,7 +264,7 @@ const JsonTree: React.FunctionComponent<JsonTreeProps> = ({
   const labelText = query ? `Search Results: ${query}` : label;
 
   return (
-    <div className={styles.root}>
+    <div className={cx(styles.root, className)}>
       {searchable && (
         <FieldTemplate
           value={query}

--- a/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
@@ -1381,7 +1381,7 @@ exports[`renders a mod component with sub pipeline 1`] = `
                     </div>
                     <div>
                       <div
-                        class="root"
+                        class="root dataTabRoot"
                       >
                         <div
                           class="formGroup form-group"

--- a/src/pageEditor/tabs/editTab/dataPanel/DataTabJsonTree.module.scss
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataTabJsonTree.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2024 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -15,33 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-@import "../DataTabJsonTree.module.scss";
+// Fit "View" and "Search" labels
+$label-width: 65px;
 
-.viewToggle {
-  display: flex;
-  gap: 1em;
-  font-size: 80%;
-
-  // Signify the user can click on the label to change the mode
-  :global(.form-check),
-  input[type="radio"],
-  label[title] {
-    cursor: pointer;
+// Use root instead of dataTabRoot to distinguish in snapshots
+.dataTabRoot {
+  // Override the default form layout, which has min-width 100px for labels
+  :global(.form-group .form-label) {
+    width: $label-width;
+    min-width: unset;
   }
-}
-
-.formGroup {
-  :global(.form-label + div) {
-    align-content: center;
-  }
-
-  :global {
-    // Override the default form layout, which has min-width 100px for labels
-    .form-label {
-      width: $label-width;
-      min-width: unset;
-    }
-  }
-
-  margin-bottom: 0;
 }

--- a/src/pageEditor/tabs/editTab/dataPanel/DataTabJsonTree.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataTabJsonTree.tsx
@@ -26,6 +26,8 @@ import { type Except } from "type-fest";
 import { type DataPanelTabKey } from "./dataPanelTypes";
 import { actions } from "@/pageEditor/store/editor/editorSlice";
 import { type RootState } from "@/pageEditor/store/editor/pageEditorTypes";
+import cx from "classnames";
+import styles from "./DataTabJsonTree.module.scss";
 
 type DataTabJsonTreeProps = Except<
   JsonTreeProps,
@@ -37,6 +39,9 @@ type DataTabJsonTreeProps = Except<
   tabKey: DataPanelTabKey;
 };
 
+/**
+ * JSON tree connected to the Page Editor Redux store.
+ */
 const DataTabJsonTree: React.FunctionComponent<DataTabJsonTreeProps> = ({
   tabKey,
   ...jsonTreeProps
@@ -75,6 +80,7 @@ const DataTabJsonTree: React.FunctionComponent<DataTabJsonTreeProps> = ({
   return (
     <JsonTree
       {...jsonTreeProps}
+      className={cx(jsonTreeProps.className, styles.dataTabRoot)}
       initialSearchQuery={query}
       onSearchQueryChange={setQuery}
       initialExpandedState={treeExpandedState}

--- a/src/pageEditor/tabs/editTab/dataPanel/__snapshots__/BrickDataPanel.test.tsx.snap
+++ b/src/pageEditor/tabs/editTab/dataPanel/__snapshots__/BrickDataPanel.test.tsx.snap
@@ -187,7 +187,7 @@ exports[`BrickDataPanel renders with form state and trace data 1`] = `
             </div>
           </div>
           <div
-            class="root"
+            class="root dataTabRoot"
           >
             <div
               class="formGroup form-group"

--- a/src/pageEditor/tabs/editTab/dataPanel/__snapshots__/DataTabJsonTree.test.tsx.snap
+++ b/src/pageEditor/tabs/editTab/dataPanel/__snapshots__/DataTabJsonTree.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders the DataTabJsonTree component 1`] = `
 <DocumentFragment>
   <div
-    class="root"
+    class="root dataTabRoot"
   >
     <ul
       style="border: 0px; padding: 0px; margin: 0.5em 0px 0.5em 0.125em; list-style: none; background-color: rgb(255, 255, 255);"

--- a/src/pageEditor/tabs/editTab/dataPanel/__snapshots__/StarterBrickDataPanel.test.tsx.snap
+++ b/src/pageEditor/tabs/editTab/dataPanel/__snapshots__/StarterBrickDataPanel.test.tsx.snap
@@ -173,7 +173,7 @@ exports[`StarterBrickDataPanel renders with form state and trace data 1`] = `
           </div>
         </div>
         <div
-          class="root"
+          class="root dataTabRoot"
         >
           <div
             class="formGroup form-group"

--- a/src/pageEditor/tabs/editTab/dataPanel/dataPanelTabs.module.scss
+++ b/src/pageEditor/tabs/editTab/dataPanel/dataPanelTabs.module.scss
@@ -27,11 +27,4 @@
 
 .tabPane {
   padding-top: 1rem;
-
-  // Override the default form layout, which has min-width 100px for labels
-  :global(.form-group .form-label) {
-    // Fit "View" and "Search" labels
-    width: 65px;
-    min-width: unset;
-  }
 }


### PR DESCRIPTION
## What does this PR do?

- Closes #8962

## Demo

<img width="443" alt="image" src="https://github.com/user-attachments/assets/8e97f736-5a77-4e37-92d7-0aeb72029f70">

<img width="375" alt="image" src="https://github.com/user-attachments/assets/fa0a5c36-6fa0-40d2-bd8e-efd9f2d9815f">


For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
