### PR TITLE
8954: sidebar starter brick validation analysis visitor

### DIFF
--- a/src/analysis/analysisVisitors/sidebarStarterBrickAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/sidebarStarterBrickAnalysis.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { sidebarPanelFormStateFactory } from "@/testUtils/factories/pageEditorFactories";
+import SidebarStarterBrickAnalysis from "@/analysis/analysisVisitors/sidebarStarterBrickAnalysis";
+
+describe("SidebarStarterBrickAnalysis", () => {
+  it("accepts a valid sidebar starter brick", async () => {
+    const formState = sidebarPanelFormStateFactory();
+    const analysis = new SidebarStarterBrickAnalysis();
+    await analysis.run(formState);
+    expect(analysis.getAnnotations()).toHaveLength(0);
+  });
+
+  it("returns a warning when the sidebar starter brick has an empty tab title", async () => {
+    const formState = sidebarPanelFormStateFactory({
+      modComponent: { heading: "", brickPipeline: [] },
+    });
+    const analysis = new SidebarStarterBrickAnalysis();
+    await analysis.run(formState);
+    expect(analysis.getAnnotations()).toHaveLength(1);
+    expect(analysis.getAnnotations()[0]).toEqual({
+      analysisId: "sidebarStarterBrick",
+      message: "Tab Title is required",
+      position: { path: "modComponent.heading" },
+      type: "warning",
+    });
+  });
+});

--- a/src/analysis/analysisVisitors/sidebarStarterBrickAnalysis.ts
+++ b/src/analysis/analysisVisitors/sidebarStarterBrickAnalysis.ts
@@ -17,8 +17,8 @@
 
 import { AnalysisVisitorWithResolvedBricksABC } from "@/analysis/analysisVisitors/baseAnalysisVisitors";
 import {
-  ModComponentFormState,
-  SidebarFormState,
+  type ModComponentFormState,
+  type SidebarFormState,
 } from "@/pageEditor/starterBricks/formStateTypes";
 import { AnnotationType } from "@/types/annotationTypes";
 import { StarterBrickTypes } from "@/types/starterBrickTypes";

--- a/src/analysis/analysisVisitors/sidebarStarterBrickAnalysis.ts
+++ b/src/analysis/analysisVisitors/sidebarStarterBrickAnalysis.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { AnalysisVisitorWithResolvedBricksABC } from "@/analysis/analysisVisitors/baseAnalysisVisitors";
+import {
+  ModComponentFormState,
+  SidebarFormState,
+} from "@/pageEditor/starterBricks/formStateTypes";
+import { AnnotationType } from "@/types/annotationTypes";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
+
+class SidebarStarterBrickAnalysis extends AnalysisVisitorWithResolvedBricksABC {
+  override id = "sidebarStarterBrick";
+
+  override visitStarterBrick(
+    starterBrick: ModComponentFormState["starterBrick"],
+  ): void {
+    if (starterBrick.definition.type === StarterBrickTypes.SIDEBAR_PANEL) {
+      const starterBrickFormState = this.formState as SidebarFormState;
+      // Ideally we could just use the brick inputSchema to perform the required field validation more generally across all bricks, but this is difficult because
+      // 1. The inputSchema is not easily referenced (we would need to fetch the starter brick package from the registry to reference the schema, or modify the formState to include the schema)
+      // 2. the inputSchema does not align exactly with the actual form state. For example, the sidebar schema requires
+      //   a `body` field, but the form state excludes this field. See:
+      // (https://github.com/pixiebrix/pixiebrix-extension/blob/fc58da4c50083c723050c3653935197834f28382/src/starterBricks/sidebar/sidebarStarterBrick.ts#L105)
+      // (https://github.com/pixiebrix/pixiebrix-extension/blob/c633539ead2e5c9d4ec7610c1e16c12a04e4a0a2/src/pageEditor/starterBricks/formStateTypes.ts#L97)
+      if (
+        starterBrickFormState.modComponent.heading == null ||
+        starterBrickFormState.modComponent.heading === ""
+      ) {
+        this.annotations.push({
+          position: { path: "modComponent.heading" },
+          message: "Tab Title is required",
+          analysisId: this.id,
+          type: AnnotationType.Warning,
+        });
+      }
+    }
+  }
+}
+
+export default SidebarStarterBrickAnalysis;

--- a/src/pageEditor/panes/EditorPane.test.tsx
+++ b/src/pageEditor/panes/EditorPane.test.tsx
@@ -158,23 +158,28 @@ const getPlainFormState = (): ModComponentFormState =>
 
 const getSidebarPanelPlainFormState = (): ModComponentFormState =>
   formStateFactory({
-    brickPipeline: [
-      brickConfigFactory({
-        id: echoBrick.id,
-        outputKey: "echoOutput" as OutputKey,
-        config: defaultBrickConfig(echoBrick.inputSchema),
+    formStateConfig: {
+      modComponent: {
+        heading: "Test Heading",
+        brickPipeline: [
+          brickConfigFactory({
+            id: echoBrick.id,
+            outputKey: "echoOutput" as OutputKey,
+            config: defaultBrickConfig(echoBrick.inputSchema),
+          }),
+          brickConfigFactory({
+            id: teapotBrick.id,
+            outputKey: "teapotOutput" as OutputKey,
+            config: defaultBrickConfig(teapotBrick.inputSchema),
+          }),
+        ],
+      },
+      starterBrick: starterBrickDefinitionFactory({
+        definition: starterBrickDefinitionPropFactory({
+          type: StarterBrickTypes.SIDEBAR_PANEL,
+        }),
       }),
-      brickConfigFactory({
-        id: teapotBrick.id,
-        outputKey: "teapotOutput" as OutputKey,
-        config: defaultBrickConfig(teapotBrick.inputSchema),
-      }),
-    ],
-    starterBrick: starterBrickDefinitionFactory({
-      definition: starterBrickDefinitionPropFactory({
-        type: StarterBrickTypes.SIDEBAR_PANEL,
-      }),
-    }),
+    },
   });
 
 const getFormStateWithSubPipelines = (): ModComponentFormState =>

--- a/src/pageEditor/store/analysisManager.ts
+++ b/src/pageEditor/store/analysisManager.ts
@@ -51,6 +51,7 @@ import SelectorAnalysis from "@/analysis/analysisVisitors/selectorAnalysis";
 import ConditionAnalysis from "@/analysis/analysisVisitors/conditionAnalysis";
 import { StateNamespaces } from "@/platform/state/stateTypes";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import SidebarStarterBrickAnalysis from "@/analysis/analysisVisitors/sidebarStarterBrickAnalysis";
 
 const runtimeActions = runtimeSlice.actions;
 
@@ -106,6 +107,16 @@ const nodeListMutationActions = [
 // The first analysis registered will be the first to run.
 // When multiple actions (e.g. typing) trigger analysis, the later analysis have more chances to get aborted.
 // Try to put the faster analysis first, and the slower ones at the end.
+
+pageEditorAnalysisManager.registerAnalysisEffect(
+  () => new SidebarStarterBrickAnalysis(),
+  {
+    matcher: isAnyOf(
+      editorActions.syncModComponentFormState,
+      ...nodeListMutationActions,
+    ),
+  },
+);
 
 pageEditorAnalysisManager.registerAnalysisEffect(
   (

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -81,6 +81,8 @@
     "./analysis/analysisVisitors/requestPermissionAnalysis.ts",
     "./analysis/analysisVisitors/selectorAnalysis.test.ts",
     "./analysis/analysisVisitors/selectorAnalysis.ts",
+    "./analysis/analysisVisitors/sidebarStarterBrickAnalysis.test.ts",
+    "./analysis/analysisVisitors/sidebarStarterBrickAnalysis.ts",
     "./analysis/analysisVisitors/templateAnalysis.test.ts",
     "./analysis/analysisVisitors/templateAnalysis.ts",
     "./analysis/analysisVisitors/traceAnalysis.ts",


### PR DESCRIPTION
Closes #8954 

This PR introduces a new analysis, `SidebarStarterBrickAnalysis`, which checks for required fields in the sidebar starter brick. It also includes tests to verify the functionality of this new class. The `analysisManager` has been updated to register this new analysis effect. 

## Discussion
I would have liked to have created a more general `RequiredFieldsAnalysis`, checking a brick's inputSchema against its config, but this was difficult for a few reasons as I noted in the inline comment block.
  1. The inputSchema is not easily referenced (we would need to fetch the starter brick package from the background registry to reference the schema, or modify the formState to include the schema). 
  2. The inputSchema does not align exactly with the actual form state. For example, the sidebar schema requires a `body` field, but the form state excludes this field. See: [sidebar starter brick inputSchema](https://github.com/pixiebrix/pixiebrix-extension/blob/fc58da4c50083c723050c3653935197834f28382/src/starterBricks/sidebar/sidebarStarterBrick.ts#L105), [sidebar modComponentState](https://github.com/pixiebrix/pixiebrix-extension/blob/c633539ead2e5c9d4ec7610c1e16c12a04e4a0a2/src/pageEditor/starterBricks/formStateTypes.ts#L97)
  3. (not as familiar in how to explain this point, so please feel free to clarify) The modComponentState config includes nunjucks templates which would need to be rendered before they could be checked against the schema.