### PR TITLE
Update mod options form tab name to match form builder

### DIFF
--- a/src/pageEditor/tabs/modOptionsDefinitions/ModOptionsDefinitionEditor.tsx
+++ b/src/pageEditor/tabs/modOptionsDefinitions/ModOptionsDefinitionEditor.tsx
@@ -46,6 +46,8 @@ import { useOptionalModDefinition } from "@/modDefinitions/modDefinitionHooks";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import { type Schema } from "@/types/schemaTypes";
 import { emptyModOptionsDefinitionFactory } from "@/utils/modUtils";
+import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
+import DataTabPane from "@/pageEditor/tabs/editTab/dataPanel/DataTabPane";
 
 const fieldTypes = [
   ...FORM_FIELD_TYPE_OPTIONS.filter(
@@ -87,23 +89,21 @@ const Preview: React.VFC<{
   activeField: string | null;
   setActiveField: (field: string) => void;
 }> = ({ optionsDefinition, activeField, setActiveField }) => (
-  <Tab.Container activeKey="preview">
+  <Tab.Container activeKey={DataPanelTabKey.Design}>
     <Nav variant="tabs">
       <Nav.Item className={dataPanelStyles.tabNav}>
-        <Nav.Link eventKey="preview">Preview</Nav.Link>
+        <Nav.Link eventKey={DataPanelTabKey.Design}>Design</Nav.Link>
       </Nav.Item>
     </Nav>
 
     <Tab.Content className={dataPanelStyles.tabContent}>
-      <Tab.Pane eventKey="preview" className={dataPanelStyles.tabPane}>
-        <ErrorBoundary>
-          <FormPreview
-            rjsfSchema={optionsDefinition}
-            activeField={activeField}
-            setActiveField={setActiveField}
-          />
-        </ErrorBoundary>
-      </Tab.Pane>
+      <DataTabPane eventKey={DataPanelTabKey.Design}>
+        <FormPreview
+          rjsfSchema={optionsDefinition}
+          activeField={activeField}
+          setActiveField={setActiveField}
+        />
+      </DataTabPane>
     </Tab.Content>
   </Tab.Container>
 );


### PR DESCRIPTION
## What does this PR do?

- Renames "Preview" tab name to "Design" in Mod Options form in Page Editor for consistency with the data panel
- FLUP to https://github.com/pixiebrix/pixiebrix-extension/pull/8895

## Discussion

- Not required for 2.0.7, but low risk if we want to pull it in

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
