### PR TITLE
#8526: fallback button starter brick on invalid template

### DIFF
--- a/src/runtime/renderers.test.ts
+++ b/src/runtime/renderers.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { engineRenderer } from "@/runtime/renderers";
+
+describe("renderers", () => {
+  describe("mustache", () => {
+    const mustache = engineRenderer("mustache", {});
+
+    it.each([null, undefined])("returns blank for: %s", async (value) => {
+      await expect(mustache(value, {})).resolves.toBe("");
+    });
+  });
+
+  describe("nunjucks", () => {
+    const nunjucks = engineRenderer("nunjucks", {});
+
+    it.each([null, undefined])("returns blank for: %s", async (value) => {
+      await expect(nunjucks(value, {})).resolves.toBe("");
+    });
+  });
+
+  describe("handlebars", () => {
+    const handlebars = engineRenderer("handlebars", {});
+
+    it.each([null, undefined])("returns blank for: %s", async (value) => {
+      await expect(handlebars(value, {})).resolves.toBe("");
+    });
+  });
+
+  describe("var", () => {
+    const varExpr = engineRenderer("var", {});
+
+    it.each([null, undefined])(
+      "passes through value for: %s",
+      async (value) => {
+        await expect(varExpr(value, {})).resolves.toBe(value);
+      },
+    );
+  });
+});

--- a/src/runtime/renderers.test.ts
+++ b/src/runtime/renderers.test.ts
@@ -19,7 +19,7 @@ import { engineRenderer } from "@/runtime/renderers";
 
 describe("renderers", () => {
   describe("mustache", () => {
-    const mustache = engineRenderer("mustache", {});
+    const mustache = engineRenderer("mustache", {})!;
 
     it.each([null, undefined])("returns blank for: %s", async (value) => {
       await expect(mustache(value, {})).resolves.toBe("");
@@ -27,7 +27,7 @@ describe("renderers", () => {
   });
 
   describe("nunjucks", () => {
-    const nunjucks = engineRenderer("nunjucks", {});
+    const nunjucks = engineRenderer("nunjucks", {})!;
 
     it.each([null, undefined])("returns blank for: %s", async (value) => {
       await expect(nunjucks(value, {})).resolves.toBe("");
@@ -35,7 +35,7 @@ describe("renderers", () => {
   });
 
   describe("handlebars", () => {
-    const handlebars = engineRenderer("handlebars", {});
+    const handlebars = engineRenderer("handlebars", {})!;
 
     it.each([null, undefined])("returns blank for: %s", async (value) => {
       await expect(handlebars(value, {})).resolves.toBe("");
@@ -43,7 +43,7 @@ describe("renderers", () => {
   });
 
   describe("var", () => {
-    const varExpr = engineRenderer("var", {});
+    const varExpr = engineRenderer("var", {})!;
 
     it.each([null, undefined])(
       "passes through value for: %s",

--- a/src/runtime/renderers.ts
+++ b/src/runtime/renderers.ts
@@ -118,6 +118,7 @@ export function engineRenderer(
     case "var": {
       return async (template, ctxt) => {
         if (template == null) {
+          // XXX: consider converting to null because undefined is not a valid JSON value?
           return template;
         }
 

--- a/src/runtime/renderers.ts
+++ b/src/runtime/renderers.ts
@@ -23,12 +23,16 @@ import { type JsonObject } from "type-fest";
 import { containsTemplateExpression } from "@/utils/expressionUtils";
 // XXX: should this be using the platform from reducePipeline?
 import { getPlatform } from "@/platform/platformContext";
+import { assertNotNullish, type Nullishable } from "@/utils/nullishUtils";
 
 export type AsyncTemplateRenderer = (
-  template: string,
+  template: Nullishable<string>,
   context: unknown,
 ) => Promise<unknown>;
-export type TemplateRenderer = (template: string, context: unknown) => unknown;
+export type TemplateRenderer = (
+  template: Nullishable<string>,
+  context: unknown,
+) => unknown;
 
 export type RendererOptions = {
   autoescape?: boolean | null;
@@ -40,15 +44,19 @@ export function engineRenderer(
 ): AsyncTemplateRenderer | null {
   const autoescape = options.autoescape ?? true;
 
-  if (templateEngine == null) {
-    throw new Error("templateEngine is required");
-  }
+  // Defensive check
+  assertNotNullish(templateEngine, "templateEngine is required");
 
   switch (templateEngine.toLowerCase()) {
     case "mustache": {
       // Mustache can run directly (not in sandbox) because it doesn't use eval or Function constructor
-      return async (template, ctxt) =>
-        Mustache.render(
+      return async (template, ctxt) => {
+        if (template == null) {
+          // Avoid crashing on nullish
+          return "";
+        }
+
+        return Mustache.render(
           template,
           ctxt,
           {},
@@ -57,17 +65,23 @@ export function engineRenderer(
             escape: autoescape ? undefined : identity,
           },
         );
+      };
     }
 
     case "nunjucks": {
       return async (template, ctxt) => {
+        if (template == null) {
+          // Avoid crashing on nullish
+          return "";
+        }
+
         if (!containsTemplateExpression(template)) {
           // Avoid trip to sandbox for literal values
           return template;
         }
 
         // Convert top level data from kebab case to snake case in order to be valid identifiers
-        const snakeCased = mapKeys(ctxt as UnknownObject, (value, key) =>
+        const snakeCased = mapKeys(ctxt as UnknownObject, (_value, key) =>
           key.replaceAll("-", "_"),
         );
 
@@ -82,6 +96,11 @@ export function engineRenderer(
 
     case "handlebars": {
       return async (template, ctxt) => {
+        if (template == null) {
+          // Avoid crashing on nullish
+          return "";
+        }
+
         if (!containsTemplateExpression(template)) {
           // Avoid trip to sandbox for literal values
           return template;
@@ -98,6 +117,10 @@ export function engineRenderer(
 
     case "var": {
       return async (template, ctxt) => {
+        if (template == null) {
+          return template;
+        }
+
         // `var` can run directly (not in sandbox) because it doesn't use eval or Function constructor
         const value = getPropByPath(ctxt as UnknownObject, template);
         if (value && typeof value === "object" && "__service" in value) {

--- a/src/starterBricks/button/buttonStarterBrick.test.ts
+++ b/src/starterBricks/button/buttonStarterBrick.test.ts
@@ -161,6 +161,31 @@ describe("buttonStarterBrick", () => {
     starterBrick.uninstall();
   });
 
+  it("handles invalid html", async () => {
+    document.body.innerHTML = getDocument("<div></div>").body.innerHTML;
+    const starterBrick = fromJS(
+      getPlatform(),
+      starterBrickFactory({
+        template: "foo",
+      })(),
+    );
+
+    const modComponent = modComponentFactory({
+      extensionPointId: starterBrick.id,
+    });
+
+    starterBrick.registerModComponent(modComponent);
+
+    await starterBrick.install();
+    await starterBrick.runModComponents({ reason: RunReason.MANUAL });
+
+    expect(document.body.innerHTML).toBe(
+      `<div data-pb-extension-point="${starterBrick.id}"><button data-pb-uuid="${modComponent.id}">Invalid Template</button></div>`,
+    );
+
+    starterBrick.uninstall();
+  });
+
   it("can use targetMode: eventTarget", async () => {
     document.body.innerHTML = getDocument("<div></div>").body.innerHTML;
     const starterBrick = fromJS(

--- a/src/starterBricks/button/buttonStarterBrick.ts
+++ b/src/starterBricks/button/buttonStarterBrick.ts
@@ -75,7 +75,7 @@ import {
 import { type UUID } from "@/types/stringTypes";
 import { type Reader } from "@/types/bricks/readerTypes";
 import initialize from "@/vendors/jQueryInitialize";
-import { $safeFind } from "@/utils/domUtils";
+import { $safeFind, isSingleHtmlElementString } from "@/utils/domUtils";
 import makeIntegrationContextFromDependencies from "@/integrations/util/makeIntegrationContextFromDependencies";
 import { ReusableAbortController, onAbort } from "abort-utils";
 import {
@@ -953,7 +953,18 @@ export class RemoteButtonStarterBrick extends ButtonStarterBrickABC {
     unsanitizedHTML: string,
     modComponent: HydratedModComponent<ButtonStarterBrickConfig>,
   ): JQuery {
-    const sanitizedHTML = sanitize(unsanitizedHTML);
+    let sanitizedHTML = "<button>Invalid Template</button>";
+
+    try {
+      // Try to avoid crash: https://github.com/pixiebrix/pixiebrix-extension/issues/8526
+      // Sanitize will exclude any custom elements
+      const sanitized = sanitize(unsanitizedHTML);
+      if (isSingleHtmlElementString(sanitized)) {
+        sanitizedHTML = sanitized;
+      }
+    } catch {
+      // NOP
+    }
 
     let $root: JQuery;
 

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -1514,6 +1514,7 @@
     "./runtime/pipelineTests/templateEngine.test.ts",
     "./runtime/pipelineTests/trace.test.ts",
     "./runtime/reducePipeline.ts",
+    "./runtime/renderers.test.ts",
     "./runtime/renderers.ts",
     "./runtime/runtimeTypes.ts",
     "./runtime/runtimeUtils.test.ts",

--- a/src/utils/domUtils.test.ts
+++ b/src/utils/domUtils.test.ts
@@ -17,6 +17,7 @@
 
 import {
   isNativeCssSelector,
+  isSingleHtmlElementString,
   isValidSelector,
   runOnDocumentVisible,
 } from "@/utils/domUtils";
@@ -118,5 +119,23 @@ describe("isValidSelector", () => {
 
   it.each(["!foo"])("returns false for invalid selector: %s", (selector) => {
     expect(isValidSelector(selector)).toBeFalse();
+  });
+});
+
+describe("isSingleHtmlElementString", () => {
+  it("returns true for single element", () => {
+    expect(isSingleHtmlElementString("<div></div>")).toBeTrue();
+  });
+  it("returns false for two elements", () => {
+    expect(isSingleHtmlElementString("<div></div><div></div>")).toBeFalse();
+  });
+  it("returns false for whitespace", () => {
+    expect(isSingleHtmlElementString(" ")).toBeFalse();
+  });
+  it("returns false for text", () => {
+    expect(isSingleHtmlElementString("foo")).toBeFalse();
+  });
+  it("allows custom tag", () => {
+    expect(isSingleHtmlElementString("<foo></foo>")).toBeTrue();
   });
 });

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -265,3 +265,13 @@ export function isValidSelector(selector: string): boolean {
     throw error;
   }
 }
+
+/**
+ * Return true if the value is a single HTML element string.
+ */
+export function isSingleHtmlElementString(value: string): boolean {
+  const doc = new DOMParser().parseFromString(value, "text/html");
+  // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#node.element_node
+  const nodes = [...doc.body.childNodes];
+  return nodes.length === 1 && nodes[0]?.nodeType === Node.ELEMENT_NODE;
+}


### PR DESCRIPTION
## What does this PR do?

- Closes #8526 
- Modifies renderers to return blank if nullish template provided
- I was unable to replicate the browser crash, so this is just trying to avoid the likely cause

## Discussion

- Related to https://github.com/pixiebrix/pixiebrix-extension/pull/8981
- The configs produced by the Page Editor are not validated, and the Page Editor removes empty values so the nullness annotations on the definition types might are not accurate: https://github.com/pixiebrix/pixiebrix-extension/blob/a7603b8f1ebf43762d3adeb4befebbcc58866784/src/pageEditor/starterBricks/base.ts#L377-L377

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
