### PR TITLE
#8860: show activated mod metadata in mod metadata form

### DIFF
--- a/src/components/AsyncStateGate.tsx
+++ b/src/components/AsyncStateGate.tsx
@@ -95,7 +95,7 @@ function AsyncStateGate<Data>(
     throw error;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- data can only be null/undefined if Data is explicitly set to be nullable
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- at this point, the data can only be null/undefined if Data is explicitly set to be nullable
   const dataResult = data as Data;
   return <>{children({ data: dataResult })}</>;
 }

--- a/src/components/AsyncStateGate.tsx
+++ b/src/components/AsyncStateGate.tsx
@@ -21,7 +21,6 @@ import { getErrorMessage } from "@/errors/errorHelpers";
 import { type AsyncState, type FetchableAsyncState } from "@/types/sliceTypes";
 import { Button } from "react-bootstrap";
 import { isFetchableAsyncState } from "@/utils/asyncStateUtils";
-import { assertNotNullish } from "@/utils/nullishUtils";
 
 /**
  *  A standard error display for use with AsyncStateGate
@@ -96,8 +95,9 @@ function AsyncStateGate<Data>(
     throw error;
   }
 
-  assertNotNullish(data, "data should be defined"); // Type-only check
-  return <>{children({ data })}</>;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- data can only be null/undefined if Data is explicitly set to be nullable
+  const dataResult = data as Data;
+  return <>{children({ data: dataResult })}</>;
 }
 
 export default AsyncStateGate;

--- a/src/pageEditor/tabs/MatchRulesSection.test.tsx
+++ b/src/pageEditor/tabs/MatchRulesSection.test.tsx
@@ -50,7 +50,6 @@ describe("MatchRulesSection", () => {
           ],
           selectors: ["#foo"],
         }),
-        setupRedux(dispatch) {},
       }).asFragment(),
     ).toMatchSnapshot();
   });

--- a/src/pageEditor/tabs/modMetadata/ModMetadataEditor.test.tsx
+++ b/src/pageEditor/tabs/modMetadata/ModMetadataEditor.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render } from "@/pageEditor/testHelpers";
+import React from "react";
+import ModMetadataEditor from "@/pageEditor/tabs/modMetadata/ModMetadataEditor";
+import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
+import { actions as editorActions } from "@/pageEditor/store/editor/editorSlice";
+import modComponentSlice from "@/store/modComponents/modComponentSlice";
+import {
+  activatedModComponentFactory,
+  modMetadataFactory,
+} from "@/testUtils/factories/modComponentFactories";
+import { type ModMetadata } from "@/types/modComponentTypes";
+import { screen } from "@testing-library/react";
+import { modDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { waitForEffect } from "@/testUtils/testHelpers";
+import { appApiMock } from "@/testUtils/appApiMock";
+
+beforeEach(() => {
+  appApiMock.reset();
+});
+
+describe("ModMetadataEditor", () => {
+  it("should render latest version", async () => {
+    const modMetadata: ModMetadata = modMetadataFactory();
+    const formState = formStateFactory({ formStateConfig: { modMetadata } });
+
+    const modComponent = activatedModComponentFactory({
+      _recipe: modMetadata,
+    });
+
+    appApiMock
+      .onGet("/api/registry/bricks/")
+      .reply(200, [modDefinitionFactory({ metadata: modMetadata })]);
+
+    render(<ModMetadataEditor />, {
+      setupRedux(dispatch) {
+        modComponentSlice.actions.UNSAFE_setModComponents([modComponent]);
+        dispatch(editorActions.addModComponentFormState(formState));
+        dispatch(editorActions.setActiveModId(formState.modMetadata!.id));
+      },
+    });
+
+    await waitForEffect();
+
+    expect(screen.getByLabelText("Name")).toHaveValue(modMetadata.name);
+    expect(screen.getByLabelText("Version")).toHaveValue(modMetadata.version);
+  });
+
+  it("should render if newer version", async () => {
+    const modMetadata: ModMetadata = modMetadataFactory();
+
+    const formState = formStateFactory({ formStateConfig: { modMetadata } });
+
+    const modComponent = activatedModComponentFactory({
+      _recipe: modMetadata,
+    });
+
+    appApiMock
+      .onGet("/api/registry/bricks/")
+      .reply(200, [modDefinitionFactory({ metadata: modMetadata })]);
+
+    render(<ModMetadataEditor />, {
+      setupRedux(dispatch) {
+        modComponentSlice.actions.UNSAFE_setModComponents([modComponent]);
+        dispatch(editorActions.addModComponentFormState(formState));
+        dispatch(editorActions.setActiveModId(formState.modMetadata!.id));
+      },
+    });
+
+    await waitForEffect();
+
+    expect(screen.getByText("re-activate the mod")).toBeInTheDocument();
+    expect(screen.getByLabelText("Version")).toHaveValue(modMetadata.version);
+  });
+});

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -1426,6 +1426,7 @@
     "./pageEditor/tabs/logs/NavItemBadge.tsx",
     "./pageEditor/tabs/logs/useLogsBadgeState.ts",
     "./pageEditor/tabs/modMetadata/ModMetadataEditor.tsx",
+    "./pageEditor/tabs/modMetadata/ModMetadataEditor.test.tsx",
     "./pageEditor/tabs/modOptionsDefinitions/ModOptionsDefinitionEditor.test.tsx",
     "./pageEditor/tabs/modOptionsDefinitions/ModOptionsDefinitionEditor.tsx",
     "./pageEditor/tabs/modOptionsValues/ModOptionsValuesEditor.test.tsx",

--- a/src/types/modComponentTypes.ts
+++ b/src/types/modComponentTypes.ts
@@ -45,8 +45,8 @@ import { isRegistryId, isUUID } from "@/types/helpers";
  * @see optionsSlice
  * @see ModComponentBase._recipe
  */
-// Don't export -- the use is clearer if it's always written as ModComponentBase[_recipe] property
-// XXX: Usage may be clearer, but the ergonomics of (ModMetadata | undefined) are terrible to handle with strict null checks
+// XXX: previously we didn't export because the usage was clearer as ModComponentBase[_recipe]. However, the ergonomics
+// of (ModMetadata | undefined) were base to handle with strict null checks
 export type ModMetadata = Metadata & {
   /**
    * `undefined` for mods that were activated prior to the field being added

--- a/src/types/modComponentTypes.ts
+++ b/src/types/modComponentTypes.ts
@@ -44,9 +44,10 @@ import { isRegistryId, isUUID } from "@/types/helpers";
  *
  * @see optionsSlice
  * @see ModComponentBase._recipe
+ * @see Metadata
  */
 // XXX: previously we didn't export because the usage was clearer as ModComponentBase[_recipe]. However, the ergonomics
-// of (ModMetadata | undefined) were base to handle with strict null checks
+// of (ModMetadata | undefined) were bad to handle with strict null checks
 export type ModMetadata = Metadata & {
   /**
    * `undefined` for mods that were activated prior to the field being added


### PR DESCRIPTION
## What does this PR do?

- Closes #8860
- Fixes bug where initial values in mod metadata form were being set to the latest metadata, not the metadata from the activated mod

## Demo

![image](https://github.com/user-attachments/assets/c42eb6ba-5178-4989-93b0-81820b62964c)

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
