### PR TITLE
#9028: flag to force sidebar RUM recording during onboarding

### DIFF
--- a/src/auth/featureFlags.ts
+++ b/src/auth/featureFlags.ts
@@ -47,6 +47,12 @@ export const FeatureFlags = {
   RUM_SESSION_RECORDING: "telemetry-performance",
 
   /**
+   * Force recording the sidebar session replay during PixieBrix onboarding.
+   */
+  ONBOARDING_SIDEBAR_FORCE_SESSION_REPLAY:
+    "onboarding-sidebar-force-session-replay",
+
+  /**
    * Turn on local navigation tracing for debugging navigation/page load bugs.
    */
   NAVIGATION_TRACE: "navigation-trace",

--- a/src/telemetry/performance.ts
+++ b/src/telemetry/performance.ts
@@ -31,8 +31,12 @@ import { FeatureFlags } from "@/auth/featureFlags";
 /**
  * Initialize Datadog Real User Monitoring (RUM) for performance monitoring. This should be called once per page load, before
  * any user interactions or network requests are made.
+ *
+ * @param sessionReplaySampleRate The percentage of sessions to record for session replay. Default is 20%.
  */
-export async function initPerformanceMonitoring(): Promise<void> {
+export async function initPerformanceMonitoring({
+  sessionReplaySampleRate = 20,
+}: { sessionReplaySampleRate?: number } = {}): Promise<void> {
   const environment = process.env.ENVIRONMENT;
   const applicationId = process.env.DATADOG_APPLICATION_ID;
   const clientToken = process.env.DATADOG_CLIENT_TOKEN;
@@ -77,7 +81,7 @@ export async function initPerformanceMonitoring(): Promise<void> {
     env: environment,
     version: cleanDatadogVersionName(version_name),
     sessionSampleRate: 100,
-    sessionReplaySampleRate: 20,
+    sessionReplaySampleRate,
     trackUserInteractions: true,
     trackResources: true,
     trackLongTasks: true,

--- a/src/utils/urlUtils.ts
+++ b/src/utils/urlUtils.ts
@@ -141,7 +141,7 @@ export function assertProtocolUrl(
   }
 }
 
-export function isPixieBrixDomain(url: string | null): boolean {
+export function isPixieBrixDomain(url: Nullishable<string>): boolean {
   if (url == null) {
     return false;
   }


### PR DESCRIPTION
## What does this PR do?

- Closes #9028
- Stacked on https://github.com/pixiebrix/pixiebrix-extension/pull/9018 (review that PR first)

## Remaining Work

- [x] Rebase with main

## Discussion

- See discussion of checking for PixieBrix domain vs. attempting to be more precise about if the sidebar is in the onboarding flow
- If the user redirects the tab to another page, it will still be recorded. Behavior is OK because UI recordings are masked: https://github.com/pixiebrix/pixiebrix-extension/blob/4b6f2ed5e81e8941e69f4e9606f16a3cf128d0a1/src/telemetry/performance.ts#L88-L88

## Post Deploy Actions

- [x] Enable `onboarding-sidebar-force-session-replay` flag for all users

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
