### PR TITLE
#9039: restrict public marketplace activation

### DIFF
--- a/src/__mocks__/@/auth/featureFlagStorage.ts
+++ b/src/__mocks__/@/auth/featureFlagStorage.ts
@@ -46,7 +46,7 @@ export async function TEST_deleteFeatureFlagsCache(
 
 // Wrapped in jest.fn() so test file can check if it's using the mock or not.
 export const flagOn = jest.fn().mockImplementation(async (flag: string) => {
-  if (flags === null) {
+  if (flags == null) {
     flags = await fetchFeatureFlags();
   }
   return flags?.includes(flag) ?? false;
@@ -54,7 +54,7 @@ export const flagOn = jest.fn().mockImplementation(async (flag: string) => {
 
 // Wrapped in jest.fn() so test file can check if it's using the mock or not.
 export const restrict = jest.fn().mockImplementation(async (area: string) => {
-  if (flags === null) {
+  if (flags == null) {
     flags = await fetchFeatureFlags();
   }
   return flags?.includes(mapRestrictedFeatureToFeatureFlag(area)) ?? false;

--- a/src/__mocks__/@/auth/featureFlagStorage.ts
+++ b/src/__mocks__/@/auth/featureFlagStorage.ts
@@ -17,6 +17,7 @@
 
 // noinspection ES6PreferShortImport -- Override mock
 import { fetchFeatureFlags } from "../../../auth/featureFlagStorage";
+import { mapRestrictedFeatureToFeatureFlag } from "@/auth/featureFlags";
 
 let flags: string[] | null = null;
 
@@ -49,4 +50,12 @@ export const flagOn = jest.fn().mockImplementation(async (flag: string) => {
     flags = await fetchFeatureFlags();
   }
   return flags?.includes(flag) ?? false;
+});
+
+// Wrapped in jest.fn() so test file can check if it's using the mock or not.
+export const restrict = jest.fn().mockImplementation(async (area: string) => {
+  if (flags === null) {
+    flags = await fetchFeatureFlags();
+  }
+  return flags?.includes(mapRestrictedFeatureToFeatureFlag(area)) ?? false;
 });

--- a/src/activation/useActivateModWizard.test.tsx
+++ b/src/activation/useActivateModWizard.test.tsx
@@ -25,13 +25,17 @@ import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { propertiesToSchema } from "@/utils/schemaUtils";
 import { makeDatabasePreviewName } from "@/activation/modOptionsHelpers";
+import { useGetFeatureFlagsQuery } from "@/data/service/api";
+import {
+  mapRestrictedFeatureToFeatureFlag,
+  RestrictedFeatures,
+} from "@/auth/featureFlags";
+import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
 
 jest.mock("@/components/integrations/AuthWidget", () => {});
 jest.mock("react-redux");
 jest.mock("@/data/service/api", () => ({
-  useGetServiceAuthsQuery: jest.fn().mockReturnValue({
-    data: [],
-  }),
+  useGetFeatureFlagsQuery: jest.fn(() => valueToAsyncState([])),
 }));
 
 jest.mock("@/hooks/useDatabaseOptions", () => ({
@@ -158,5 +162,29 @@ describe("useActivateModWizard", () => {
     expect(result.current.data!.initialValues.optionsArgs).toEqual({
       [name]: databaseId,
     });
+  });
+
+  test("reject public marketplace activations", () => {
+    const modDefinition = defaultModDefinitionFactory({
+      sharing: sharingDefinitionFactory({
+        public: true,
+      }),
+    });
+
+    jest
+      .mocked(useGetFeatureFlagsQuery)
+      .mockReturnValue(
+        valueToAsyncState([
+          mapRestrictedFeatureToFeatureFlag(RestrictedFeatures.MARKETPLACE),
+        ]) as any,
+      );
+
+    const { result } = renderHook(() => useActivateModWizard(modDefinition));
+
+    const { isError, error } = result.current;
+    expect(isError).toBe(true);
+    expect(error).toMatchInlineSnapshot(
+      "[BusinessError: Your team's policy does not permit you to activate this mod. Contact your team admin for assistance]",
+    );
   });
 });

--- a/src/activation/useActivateModWizard.test.tsx
+++ b/src/activation/useActivateModWizard.test.tsx
@@ -31,6 +31,7 @@ import {
   RestrictedFeatures,
 } from "@/auth/featureFlags";
 import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
+import { BusinessError } from "@/errors/businessErrors";
 
 jest.mock("@/components/integrations/AuthWidget", () => {});
 jest.mock("react-redux");
@@ -183,8 +184,9 @@ describe("useActivateModWizard", () => {
 
     const { isError, error } = result.current;
     expect(isError).toBe(true);
-    expect(error).toMatchInlineSnapshot(
-      "[BusinessError: Your team's policy does not permit you to activate this mod. Contact your team admin for assistance]",
+    expect(error).toBeInstanceOf(BusinessError);
+    expect((error as BusinessError).message).toBe(
+      "Your team's policy does not permit you to activate this mod. Contact your team admin for assistance",
     );
   });
 });

--- a/src/activation/useOrganizationActivationPolicy.ts
+++ b/src/activation/useOrganizationActivationPolicy.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import useFlags, { type FlagHelpers } from "@/hooks/useFlags";
+import { type ModDefinition } from "@/types/modDefinitionTypes";
+import { RestrictedFeatures } from "@/auth/featureFlags";
+import { useSelector } from "react-redux";
+import { selectOrganizations } from "@/auth/authSelectors";
+import { type FetchableAsyncState } from "@/types/sliceTypes";
+import useMergeAsyncState from "@/hooks/useMergeAsyncState";
+
+export type OrganizationActivationPolicyResult = {
+  /**
+   * True if the user should be blocked from activating the mod definition.
+   */
+  block: boolean;
+};
+
+/**
+ * Returns true if the user should be blocked from activating the mod definition due to an organization policy
+ * @param modDefinition the mod definition
+ */
+function useOrganizationActivationPolicy(
+  modDefinition: ModDefinition,
+): FetchableAsyncState<OrganizationActivationPolicyResult> {
+  const organizations = useSelector(selectOrganizations);
+  const { state } = useFlags();
+
+  return useMergeAsyncState(state, ({ restrict }: FlagHelpers) => {
+    // Reject mods that are public for which the user is not a member of any organizations the mod is shared with
+    if (
+      restrict(RestrictedFeatures.MARKETPLACE) &&
+      modDefinition.sharing.public
+    ) {
+      const userOrganizations = new Set(organizations.map((x) => x.id));
+      return {
+        block: !modDefinition.sharing.organizations.some((x) =>
+          userOrganizations.has(x),
+        ),
+      };
+    }
+
+    return {
+      block: false,
+    };
+  });
+}
+
+export default useOrganizationActivationPolicy;

--- a/src/background/welcomeMods.ts
+++ b/src/background/welcomeMods.ts
@@ -62,6 +62,8 @@ import { getBuiltInIntegrationConfigs } from "@/background/getBuiltInIntegration
 import { StarterBrickTypes } from "@/types/starterBrickTypes";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import getModComponentsForMod from "@/mods/util/getModComponentsForMod";
+import { restrict } from "@/auth/featureFlagStorage";
+import { RestrictedFeatures } from "@/auth/featureFlags";
 
 // eslint-disable-next-line local-rules/persistBackgroundData -- no state; destructuring reducer and actions
 const { reducer: modComponentReducer, actions: modComponentActions } =
@@ -69,7 +71,7 @@ const { reducer: modComponentReducer, actions: modComponentActions } =
 // eslint-disable-next-line local-rules/persistBackgroundData -- no state; destructuring reduce and actions
 const { reducer: sidebarReducer, actions: sidebarActions } = sidebarSlice;
 
-const PLAYGROUND_URL = "https://www.pixiebrix.com/welcome";
+const WELCOME_URL = "https://www.pixiebrix.com/welcome";
 const MOD_ACTIVATION_DEBOUNCE_MS = 10_000;
 const MOD_ACTIVATION_MAX_MS = 60_000;
 
@@ -330,6 +332,14 @@ async function getWelcomeMods(): Promise<ModDefinition[]> {
 async function _activateWelcomeMods(): Promise<ActivateModsResult> {
   const welcomeMods = await getWelcomeMods();
 
+  if (await restrict(RestrictedFeatures.MARKETPLACE)) {
+    return {
+      welcomeModCount: welcomeMods.length,
+      error:
+        "Your team's policy does not permit you to activate marketplace mods. Contact your team admin for assistance",
+    };
+  }
+
   try {
     // Activating Welcome Mods and pulling the updates from remote registries to make sure
     // that all the bricks used in welcome mods are available
@@ -360,7 +370,7 @@ export const debouncedActivateWelcomeMods = debounce(
 
 function initWelcomeMods(): void {
   browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-    if (tab?.url?.startsWith(PLAYGROUND_URL)) {
+    if (tab?.url?.startsWith(WELCOME_URL)) {
       void debouncedActivateWelcomeMods();
     }
   });

--- a/src/hooks/useFlags.ts
+++ b/src/hooks/useFlags.ts
@@ -36,7 +36,7 @@ export type FlagHelpers = {
   flagOff: (flag: FeatureFlag) => boolean;
 };
 
-type HookResult = FlagHelpers & {
+type UseFlagsResult = FlagHelpers & {
   // The async state for use in deriving values that require valid flags. NOTE: the data is not serializable,
   // so the state might not work with any state helpers that require serializable data (e.g., due to cloning, Immer,
   // or Redux).
@@ -52,7 +52,7 @@ type HookResult = FlagHelpers & {
  *
  * @see flagOn
  */
-function useFlags(): HookResult {
+function useFlags(): UseFlagsResult {
   const queryState = useGetFeatureFlagsQuery();
   const { refetch } = queryState;
 

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -75,6 +75,7 @@
     "./activation/modOptionsHelpers.ts",
     "./activation/useActivateMod.ts",
     "./activation/useActivateModWizard.ts",
+    "./activation/useOrganizationActivationPolicy.ts",
     "./activation/wizardTypes.ts",
     "./analysis/AnalysisAnnotationsContext.ts",
     "./analysis/ReduxAnalysisManager.ts",

--- a/src/utils/asyncStateUtils.ts
+++ b/src/utils/asyncStateUtils.ts
@@ -232,9 +232,7 @@ export function valueToAsyncState<Value>(
 /**
  * Lift a known value to a FetchableAsyncState.
  */
-export function errorToAsyncState<Value>(
-  error: unknown,
-): FetchableAsyncState<Value> {
+export function errorToAsyncState<Value>(error: unknown): AsyncState<Value> {
   return {
     isError: true,
     error,
@@ -244,7 +242,6 @@ export function errorToAsyncState<Value>(
     isLoading: false,
     isFetching: false,
     isSuccess: false,
-    refetch: noop,
   };
 }
 

--- a/src/utils/asyncStateUtils.ts
+++ b/src/utils/asyncStateUtils.ts
@@ -232,7 +232,9 @@ export function valueToAsyncState<Value>(
 /**
  * Lift a known value to a FetchableAsyncState.
  */
-export function errorToAsyncState<Value>(error: unknown): AsyncState<Value> {
+export function errorToAsyncState<Value>(
+  error: unknown,
+): FetchableAsyncState<Value> {
   return {
     isError: true,
     error,
@@ -242,6 +244,7 @@ export function errorToAsyncState<Value>(error: unknown): AsyncState<Value> {
     isLoading: false,
     isFetching: false,
     isSuccess: false,
+    refetch: noop,
   };
 }
 


### PR DESCRIPTION
## What does this PR do?

- Closes #9039 
- Restricts public marketplace mod activation in activation wizard and welcome mods

## Discussion

- I just used the existing error handling because the situation should be uncommon so doesn't need a special UX

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
