### PR TITLE
Bug fix - Navigate to mods tab when extension token is cleared

### DIFF
--- a/src/auth/RequireAuth.tsx
+++ b/src/auth/RequireAuth.tsx
@@ -42,9 +42,7 @@ type RequireAuthProps = {
    */
   ignoreApiError?: boolean;
   /**
-   * The current page location, exposed as a prop so that react-router can override the window location if needed.
-   *
-   * Using a "shim" type because we don't want to pull in react-router here just for the location type.
+   * The current page location, exposed as a prop so that react-router can override the window location if needed
    */
   location?: Location;
 };

--- a/src/auth/RequireAuth.tsx
+++ b/src/auth/RequireAuth.tsx
@@ -31,6 +31,7 @@ import { type AxiosError } from "axios";
 import useRequiredPartnerAuth from "@/auth/useRequiredPartnerAuth";
 import useLinkState from "@/auth/useLinkState";
 import { type Me } from "@/data/model/Me";
+import { type Location } from "history";
 
 type RequireAuthProps = {
   /** Rendered in case of 401 response */
@@ -40,6 +41,12 @@ type RequireAuthProps = {
    * or PixieBrix service degradation.
    */
   ignoreApiError?: boolean;
+  /**
+   * The current page location, exposed as a prop so that react-router can override the window location if needed.
+   *
+   * Using a "shim" type because we don't want to pull in react-router here just for the location type.
+   */
+  location?: Location;
 };
 
 /**
@@ -127,11 +134,12 @@ const RequireAuth: React.FC<RequireAuthProps> = ({
   children,
   LoginPage,
   ignoreApiError = false,
+  location = window.location,
 }) => {
   // This is a very simplified version of what otherwise useRouteMatch from react-router would do.
-  // We don't want to pull the Router in the Page Editor app.
-  const isSettingsPage = location.hash.startsWith("#/settings");
-  const isStartPage = location.hash.startsWith("#/start");
+  // We don't want to pull the Router into the Page Editor app when it uses this component.
+  const isSettingsPage = location.pathname.startsWith("/settings");
+  const isStartPage = location.pathname.startsWith("/start");
 
   const {
     isAccountUnlinked,

--- a/src/extensionConsole/App.tsx
+++ b/src/extensionConsole/App.tsx
@@ -55,6 +55,7 @@ import { DeploymentsProvider } from "@/extensionConsole/pages/deployments/Deploy
 import DatabaseUnresponsiveBanner from "@/components/DatabaseUnresponsiveBanner";
 import ActivateModPage from "@/extensionConsole/pages/activateMod/ActivateModPage";
 import { RestrictedFeatures } from "@/auth/featureFlags";
+import { useLocation } from "react-router";
 
 // Register the built-in bricks
 registerEditors();
@@ -135,13 +136,15 @@ const Layout = () => {
     isLoading: themeIsLoading,
   } = useTheme();
 
+  const location = useLocation();
+
   return (
     <div>
       {!themeIsLoading && <Navbar logo={logo} />}
       <Container fluid className="page-body-wrapper">
         {/* It is guaranteed that under RequireAuth the user has a valid API token (either PixieBrix token or partner JWT). */}
         <ErrorBoundary ErrorComponent={IDBErrorDisplay}>
-          <RequireAuth LoginPage={SetupPage}>
+          <RequireAuth LoginPage={SetupPage} location={location}>
             <AuthenticatedContent />
           </RequireAuth>
         </ErrorBoundary>

--- a/src/extensionConsole/pages/settings/AdvancedSettings.tsx
+++ b/src/extensionConsole/pages/settings/AdvancedSettings.tsx
@@ -37,10 +37,7 @@ import { isEmpty } from "lodash";
 import { util as apiUtil } from "@/data/service/api";
 import useDiagnostics from "@/extensionConsole/pages/settings/useDiagnostics";
 import AsyncButton from "@/components/AsyncButton";
-import {
-  getExtensionConsoleUrl,
-  reloadIfNewVersionIsReady,
-} from "@/utils/extensionUtils";
+import { reloadIfNewVersionIsReady } from "@/utils/extensionUtils";
 import { DEFAULT_SERVICE_URL } from "@/urlConstants";
 import { PIXIEBRIX_INTEGRATION_ID } from "@/integrations/constants";
 import { refreshPartnerAuthentication } from "@/background/messenger/api";
@@ -64,19 +61,8 @@ const AdvancedSettings: React.FunctionComponent = () => {
     notify.success(
       "Cleared the browser extension token. Visit the web app to set it again",
     );
-    // The RequireAuth gate component checks for auth changes when it renders, but
-    // it also currently lives above react-router in the component tree, so it doesn't
-    // implicitly re-render when the react-router hash location changes. It also checks
-    // the current location on render, and doesn't show if the user is on the settings
-    // page.
-    //
-    // In order to force the linking screen to show when the Clear Token button is
-    // clicked, we need to force the entire component tree (including RequireAuth)
-    // to re-render, and the location when it renders cannot be the settings page.
-    //
-    // So, we assign window location directly to the mods page URL, instead of
-    // using the react-router api to change only the hash route.
-    location.assign(getExtensionConsoleUrl("mods"));
+    // Reload to force content scripts and service worker to reload
+    location.reload();
   }, []);
 
   const clearTokens = useUserAction(


### PR DESCRIPTION
## What does this PR do?

- Follow up to #9047
- Attempting to fix the broken rainforest tests involved with clearing the token
- We'll still need to update the rainforest test because it won't be necessary anymore to click the mods tab


For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
