### PR TITLE
#9087 Wait for built-in integration before activating mod in e2e test

### DIFF
--- a/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
+++ b/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
@@ -170,6 +170,12 @@ export class ActivateModPage extends BasePageObject {
     });
   }
 
+  async getIntegrationConfigField(index: number) {
+    return this.getByTestId(
+      `integration-auth-selector-integrationDependencies.${index}.configId`,
+    );
+  }
+
   async selectIntegrationOption(integrationIndex: number, option: string) {
     await this.page
       .getByTestId(

--- a/end-to-end-tests/tests/extensionConsole/activation.spec.ts
+++ b/end-to-end-tests/tests/extensionConsole/activation.spec.ts
@@ -95,6 +95,7 @@ test("can activate a mod with built-in integration", async ({
 
   const floatingActionButton = new FloatingActionButton(page);
   const button = await floatingActionButton.getActionButton();
+
   // Ensure the QuickBar is ready
   await expect(button).toBeVisible();
 

--- a/end-to-end-tests/tests/pageEditor/copyMod.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/copyMod.spec.ts
@@ -115,6 +115,11 @@ test("run a copied mod with a built-in integration", async ({
       sourceModId,
     );
     await modActivationPage.goto();
+    await expect(
+      modActivationPage
+        .locator(".form-group")
+        .filter({ hasText: /^GIPHY — ✨ Built-in$/ }),
+    ).toBeVisible();
     await modActivationPage.clickActivateAndWaitForModsPageRedirect();
 
     await verifyModDefinitionSnapshot({

--- a/end-to-end-tests/tests/pageEditor/copyMod.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/copyMod.spec.ts
@@ -115,11 +115,9 @@ test("run a copied mod with a built-in integration", async ({
       sourceModId,
     );
     await modActivationPage.goto();
-    await expect(
-      modActivationPage
-        .locator(".form-group")
-        .filter({ hasText: /^GIPHY — ✨ Built-in$/ }),
-    ).toBeVisible();
+    const integrationConfiguration =
+      await modActivationPage.getIntegrationConfigField(0);
+    await expect(integrationConfiguration).toHaveText("GIPHY — ✨ Built-in");
     await modActivationPage.clickActivateAndWaitForModsPageRedirect();
 
     await verifyModDefinitionSnapshot({


### PR DESCRIPTION
## What does this PR do?

- Part of #9087
- Noticed a race with some of the flaky tests where the test runner would click the activation button before the form was pre-populated with the built-in integration
- The proper way to fix would be to disable the button before the form is valid, but I found that to be non-trivial
- This does not address all of #9087