### PR TITLE
#9095 Fix Mods page table filters (other than active)

### DIFF
--- a/src/extensionConsole/pages/mods/ModsPageSidebar.tsx
+++ b/src/extensionConsole/pages/mods/ModsPageSidebar.tsx
@@ -66,12 +66,12 @@ export const MODS_PAGE_TABS: ModTabsMap = {
   personal: {
     key: "Personal",
     tabTitle: "Personal Mods",
-    filters: [{ id: "sharing.source.label", value: "Personal" }],
+    filters: [{ id: "sharingSource.label", value: "Personal" }],
   },
   public: {
     key: "Public",
     tabTitle: "Public Mods",
-    filters: [{ id: "sharing.source.label", value: "Public" }],
+    filters: [{ id: "sharingSource.label", value: "Public" }],
   },
   getStarted: {
     key: "Get Started",

--- a/src/extensionConsole/pages/mods/listView/ListView.tsx
+++ b/src/extensionConsole/pages/mods/listView/ListView.tsx
@@ -51,7 +51,7 @@ const ListView: React.VoidFunctionComponent<ModsPageContentProps> = ({
   // Re-render the list when expandedRows changes.
   useEffect(() => {
     listRef.current?.resetAfterIndex(0);
-  }, [expandedRows, listRef]);
+  }, [expandedRows, listRef.current]);
 
   return (
     <ListGroup {...tableInstance.getTableProps()}>

--- a/src/extensionConsole/pages/mods/listView/ListView.tsx
+++ b/src/extensionConsole/pages/mods/listView/ListView.tsx
@@ -51,7 +51,7 @@ const ListView: React.VoidFunctionComponent<ModsPageContentProps> = ({
   // Re-render the list when expandedRows changes.
   useEffect(() => {
     listRef.current?.resetAfterIndex(0);
-  }, [expandedRows]);
+  }, [expandedRows, listRef]);
 
   return (
     <ListGroup {...tableInstance.getTableProps()}>

--- a/src/extensionConsole/pages/mods/listView/ListView.tsx
+++ b/src/extensionConsole/pages/mods/listView/ListView.tsx
@@ -51,7 +51,7 @@ const ListView: React.VoidFunctionComponent<ModsPageContentProps> = ({
   // Re-render the list when expandedRows changes.
   useEffect(() => {
     listRef.current?.resetAfterIndex(0);
-  }, [expandedRows, listRef.current]);
+  }, [expandedRows, listRef]);
 
   return (
     <ListGroup {...tableInstance.getTableProps()}>


### PR DESCRIPTION
## What does this PR do?

- Fixes the bug describe in #9095 

## Cursor Prompt

<img width="911" alt="image" src="https://github.com/user-attachments/assets/bdd91148-2b1d-4480-b5be-768c51219710">


For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
