### PR TITLE
#9093 force session replay recording in sidebar welcome page

### DIFF
--- a/src/sidebar/ConnectedSidebar.test.tsx
+++ b/src/sidebar/ConnectedSidebar.test.tsx
@@ -33,8 +33,15 @@ import {
 import { appApiMock } from "@/testUtils/appApiMock";
 import { valueToAsyncState } from "@/utils/asyncStateUtils";
 import { API_PATHS } from "@/data/service/urlPaths";
+import { getConnectedTabIdForSidebarTopFrame } from "@/sidebar/connectedTarget";
+import sidebarSlice from "@/store/sidebar/sidebarSlice";
+import { datadogRum } from "@datadog/browser-rum";
 
 jest.mock("@/auth/useLinkState");
+jest.mock("@datadog/browser-rum", () => ({
+  datadogRum: { addAction: jest.fn(), setGlobalContextProperty: jest.fn() },
+}));
+jest.mock("@/sidebar/connectedTarget");
 
 // Needed until https://github.com/RickyMarou/jest-webextension-mock/issues/5 is implemented
 browser.webNavigation.onBeforeNavigate = {
@@ -111,20 +118,51 @@ describe("SidebarApp", () => {
 
   it("registers the navigation listener", async () => {
     await mockAuthenticatedMeApiResponse();
-    const { unmount } = render(
+    const { unmount, getReduxStore } = render(
       <MemoryRouter>
         <ConnectedSidebar />
       </MemoryRouter>,
       {
-        setupRedux(dispatch) {
+        setupRedux(dispatch, { store }) {
           dispatch(authActions.setAuth(authStateFactory()));
+          jest.spyOn(store, "dispatch");
         },
       },
     );
+    jest.mocked(getConnectedTabIdForSidebarTopFrame).mockReturnValue(4);
 
     expect(
       browser.webNavigation.onBeforeNavigate.addListener,
     ).toHaveBeenCalledWith(expect.any(Function));
+
+    const listener = jest.mocked(
+      browser.webNavigation.onBeforeNavigate.addListener,
+    ).mock.calls[0]![0];
+
+    const mockDetails = {
+      frameId: 0,
+      tabId: 4,
+      documentLifecycle: "active",
+      url: "http://example.com",
+      parentFrameId: 0,
+      timeStamp: 0,
+    };
+
+    listener(mockDetails);
+
+    const { dispatch } = getReduxStore();
+
+    expect(dispatch).toHaveBeenCalledWith(
+      sidebarSlice.actions.invalidatePanels(),
+    );
+    expect(datadogRum.addAction).toHaveBeenCalledWith(
+      "connectedTabNavigation",
+      { url: "http://example.com" },
+    );
+    expect(datadogRum.setGlobalContextProperty).toHaveBeenCalledWith(
+      "connectedTabUrl",
+      "http://example.com",
+    );
 
     unmount();
 

--- a/src/sidebar/ConnectedSidebar.test.tsx
+++ b/src/sidebar/ConnectedSidebar.test.tsx
@@ -67,6 +67,7 @@ describe("SidebarApp", () => {
     appApiMock.onGet(API_PATHS.MOD_COMPONENTS_ALL).reply(200, []);
 
     useLinkStateMock.mockReturnValue(valueToAsyncState(true));
+    jest.mocked(browser.webNavigation.onBeforeNavigate.addListener).mockReset();
   });
 
   test("renders not connected", async () => {

--- a/src/sidebar/ConnectedSidebar.tsx
+++ b/src/sidebar/ConnectedSidebar.tsx
@@ -58,6 +58,8 @@ import {
   validateModComponentRef,
 } from "@/types/modComponentTypes";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import { CONNECTED_TAB_URL_PERFORMANCE_KEY } from "@/sidebar/telemetryConstants";
+import { datadogRum } from "@datadog/browser-rum";
 
 /**
  * Listeners to update the Sidebar's Redux state upon receiving messages from the contentScript.
@@ -124,7 +126,7 @@ const ConnectedSidebar: React.VFC = () => {
     const navigationListener = (
       details: chrome.webNavigation.WebNavigationFramedCallbackDetails,
     ) => {
-      const { frameId, tabId, documentLifecycle } = details;
+      const { frameId, tabId, documentLifecycle, url } = details;
       const connectedTabId = getConnectedTabIdForSidebarTopFrame();
       if (
         documentLifecycle === "active" &&
@@ -133,6 +135,11 @@ const ConnectedSidebar: React.VFC = () => {
       ) {
         console.log("navigationListener:connectedTabId", connectedTabId);
         dispatch(sidebarSlice.actions.invalidatePanels());
+        datadogRum.addAction("connectedTabNavigation", { url });
+        datadogRum.setGlobalContextProperty(
+          CONNECTED_TAB_URL_PERFORMANCE_KEY,
+          url,
+        );
       }
     };
 

--- a/src/sidebar/telemetryConstants.ts
+++ b/src/sidebar/telemetryConstants.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export const CONNECTED_TAB_URL_PERFORMANCE_KEY = "connectedTabUrl";

--- a/src/telemetry/performance.test.ts
+++ b/src/telemetry/performance.test.ts
@@ -45,48 +45,85 @@ describe("initPerformanceMonitoring", () => {
     expect(datadogRum.init).not.toHaveBeenCalled();
   });
 
-  it("should initialize performance monitoring", async () => {
-    jest.mocked(getDNT).mockResolvedValue(false);
-    jest.mocked(flagOn).mockResolvedValue(true);
-    process.env.DATADOG_APPLICATION_ID = "applicationId";
-    process.env.DATADOG_CLIENT_TOKEN = "clientToken";
-    process.env.ENVIRONMENT = "local";
-    jest.mocked(getBaseURL).mockResolvedValue("https://example.com");
-    browser.runtime.getManifest = jest
-      .fn()
-      .mockReturnValue({ version_name: "1.8.8-alpha+293128" });
-    jest.mocked(readAuthData).mockResolvedValue({
-      user: "634b1b49-4382-4292-87f4-d25c6a1db3d7",
-      organizationId: "24a7c934-a531-49d8-a15d-cdf0baa54146",
-    } as any);
-
-    await initPerformanceMonitoring();
-
-    expect(datadogRum.init).toHaveBeenCalledWith({
-      applicationId: "applicationId",
-      clientToken: "clientToken",
-      site: "datadoghq.com",
-      service: "pixiebrix-browser-extension",
-      env: "local",
-      version: expect.any(String),
-      sessionSampleRate: 100,
-      sessionReplaySampleRate: 20,
-      trackUserInteractions: true,
-      trackResources: true,
-      trackLongTasks: true,
-      defaultPrivacyLevel: "mask",
-      allowedTracingUrls: ["https://example.com"],
-      allowFallbackToLocalStorage: true,
+  describe("given the required initialization conditions", () => {
+    beforeEach(() => {
+      jest.mocked(getDNT).mockResolvedValue(false);
+      jest.mocked(flagOn).mockResolvedValue(true);
+      process.env.DATADOG_APPLICATION_ID = "applicationId";
+      process.env.DATADOG_CLIENT_TOKEN = "clientToken";
+      process.env.ENVIRONMENT = "local";
+      jest.mocked(getBaseURL).mockResolvedValue("https://example.com");
+      browser.runtime.getManifest = jest
+        .fn()
+        .mockReturnValue({ version_name: "1.8.8-alpha+293128" });
+      jest.mocked(readAuthData).mockResolvedValue({
+        user: "634b1b49-4382-4292-87f4-d25c6a1db3d7",
+        organizationId: "24a7c934-a531-49d8-a15d-cdf0baa54146",
+      } as any);
     });
-    expect(datadogRum.setGlobalContextProperty).toHaveBeenCalledWith(
-      "code_version",
-      process.env.SOURCE_VERSION,
-    );
-    expect(datadogRum.setUser).toHaveBeenCalledWith({
-      email: undefined,
-      id: "634b1b49-4382-4292-87f4-d25c6a1db3d7",
-      organizationId: "24a7c934-a531-49d8-a15d-cdf0baa54146",
+
+    it("should initialize performance monitoring", async () => {
+      await initPerformanceMonitoring({
+        additionalGlobalContext: { connectedTabUrl: "google.com" },
+      });
+
+      expect(datadogRum.init).toHaveBeenCalledWith({
+        applicationId: "applicationId",
+        clientToken: "clientToken",
+        site: "datadoghq.com",
+        service: "pixiebrix-browser-extension",
+        env: "local",
+        version: expect.any(String),
+        sessionSampleRate: 100,
+        sessionReplaySampleRate: 20,
+        trackUserInteractions: true,
+        trackResources: true,
+        trackLongTasks: true,
+        defaultPrivacyLevel: "mask",
+        allowedTracingUrls: ["https://example.com"],
+        allowFallbackToLocalStorage: true,
+      });
+      expect(datadogRum.setGlobalContext).toHaveBeenCalledWith({
+        code_version: process.env.SOURCE_VERSION,
+        connectedTabUrl: "google.com",
+      });
+      expect(datadogRum.setUser).toHaveBeenCalledWith({
+        email: undefined,
+        id: "634b1b49-4382-4292-87f4-d25c6a1db3d7",
+        organizationId: "24a7c934-a531-49d8-a15d-cdf0baa54146",
+      });
     });
-    expect(datadogRum.startSessionReplayRecording).toHaveBeenCalled();
+
+    it("should force session replay recording when sessionSampleRate is set to 100", async () => {
+      await initPerformanceMonitoring({ sessionReplaySampleRate: 100 });
+
+      expect(datadogRum.init).toHaveBeenCalledWith({
+        applicationId: "applicationId",
+        clientToken: "clientToken",
+        site: "datadoghq.com",
+        service: "pixiebrix-browser-extension",
+        env: "local",
+        version: expect.any(String),
+        sessionSampleRate: 100,
+        sessionReplaySampleRate: 100,
+        trackUserInteractions: true,
+        trackResources: true,
+        trackLongTasks: true,
+        defaultPrivacyLevel: "mask",
+        allowedTracingUrls: ["https://example.com"],
+        allowFallbackToLocalStorage: true,
+      });
+      expect(datadogRum.setGlobalContext).toHaveBeenCalledWith({
+        code_version: process.env.SOURCE_VERSION,
+      });
+      expect(datadogRum.setUser).toHaveBeenCalledWith({
+        email: undefined,
+        id: "634b1b49-4382-4292-87f4-d25c6a1db3d7",
+        organizationId: "24a7c934-a531-49d8-a15d-cdf0baa54146",
+      });
+      expect(datadogRum.startSessionReplayRecording).toHaveBeenCalledWith({
+        force: true,
+      });
+    });
   });
 });


### PR DESCRIPTION
## What does this PR do?

- Fixes #9093

This change also includes adding more global context to sidebar rum events, noting what the connected url for the sidebar and when navigation events occur.

## Demo

I didn't record a demo, but just to note I did verify that recordings are forced to start on a fresh session when opening the sidebar on the welcome, even after having previously opened an extension console page (thus having already started the session recording)

Check out this datadog session I recorded in testing for this behavior + the new context props
https://app.datadoghq.com/rum/sessions?query=%40type%3Asession%20%40application.id%3Ac343faf6-bbdf-4a12-8793-40af69f75b69%20%40usr.email%3Aeduardo%2Btest%40pixiebrix.com&agg_m=count&agg_m_source=base&agg_t=count&cols=&event=AgAAAZHHxFulrXSX7gAAAAAAAAAYAAAAAEFaSEh4RnVsQUFDdkdYeXFkS3RLWi1IMAAAACQAAAAAMDE5MWM3YzUtNWFhNS00ZDgxLWEzYjAtZGFlNGZhNGRhYjkz&fromUser=false&p_tab=replay&track=rum&from_ts=1725547094403&to_ts=1725633494403&live=true

## Checklist

- [X] Added jest or playwright tests and/or storybook stories

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
