### PR TITLE
#9105: move state controller to content script

### DIFF
--- a/src/bricks/effects/assignModVariable.test.ts
+++ b/src/bricks/effects/assignModVariable.test.ts
@@ -17,7 +17,6 @@
 
 import AssignModVariable from "@/bricks/effects/assignModVariable";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import { getState, setState } from "@/platform/state/stateController";
 import { validateBrickInputOutput } from "@/validators/schemaValidator";
 import {
   brickOptionsFactory,
@@ -25,6 +24,7 @@ import {
 } from "@/testUtils/factories/runtimeFactories";
 import { modComponentRefFactory } from "@/testUtils/factories/modComponentFactories";
 import { MergeStrategies, StateNamespaces } from "@/platform/state/stateTypes";
+import { getPlatform } from "@/platform/platformContext";
 
 const brick = new AssignModVariable();
 
@@ -35,7 +35,7 @@ const brickOptions = brickOptionsFactory({
 });
 
 beforeEach(() => {
-  setState({
+  getPlatform().state.setState({
     namespace: StateNamespaces.MOD,
     modComponentRef,
     mergeStrategy: MergeStrategies.REPLACE,
@@ -56,7 +56,7 @@ describe("@pixiebrix/state/assign", () => {
     );
 
     expect(
-      getState({
+      getPlatform().state.getState({
         namespace: StateNamespaces.MOD,
         modComponentRef,
       }),
@@ -89,7 +89,7 @@ describe("@pixiebrix/state/assign", () => {
     );
 
     expect(
-      getState({
+      getPlatform().state.getState({
         namespace: StateNamespaces.MOD,
         modComponentRef,
       }),
@@ -108,7 +108,7 @@ describe("@pixiebrix/state/assign", () => {
     );
 
     expect(
-      getState({
+      getPlatform().state.getState({
         namespace: StateNamespaces.MOD,
         modComponentRef,
       }),

--- a/src/bricks/effects/assignModVariable.ts
+++ b/src/bricks/effects/assignModVariable.ts
@@ -2,7 +2,6 @@ import { type Schema } from "@/types/schemaTypes";
 import { validateRegistryId } from "@/types/helpers";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type JsonObject, type JsonPrimitive } from "type-fest";
-import { setState } from "@/platform/state/stateController";
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { type BrickConfig } from "@/bricks/types";
 import { castTextLiteralOrThrow } from "@/utils/expressionUtils";
@@ -91,9 +90,9 @@ class AssignModVariable extends EffectABC {
       // Input is validated, so we know value is a JsonPrimitive or JsonObject
       value: JsonPrimitive | JsonObject;
     }>,
-    { meta: { modComponentRef } }: BrickOptions,
+    { meta: { modComponentRef }, platform }: BrickOptions,
   ): Promise<void> {
-    setState({
+    platform.state.setState({
       namespace: StateNamespaces.MOD,
       data: { [variableName]: value },
       mergeStrategy: MergeStrategies.SHALLOW,

--- a/src/bricks/effects/pageState.test.ts
+++ b/src/bricks/effects/pageState.test.ts
@@ -19,7 +19,7 @@ import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 import { toExpression } from "@/utils/expressionUtils";
 import { GetPageState, SetPageState } from "@/bricks/effects/pageState";
-import { TEST_resetState } from "@/platform/state/stateController";
+import { TEST_resetState } from "@/contentScript/stateController";
 import { MergeStrategies, StateNamespaces } from "@/platform/state/stateTypes";
 
 beforeEach(() => {

--- a/src/bricks/renderers/customForm.test.tsx
+++ b/src/bricks/renderers/customForm.test.tsx
@@ -37,7 +37,7 @@ import {
   TEST_resetState,
   getState,
   setState,
-} from "@/platform/state/stateController";
+} from "@/contentScript/stateController";
 import type { Target } from "@/types/messengerTypes";
 import { StateNamespaces } from "@/platform/state/stateTypes";
 

--- a/src/bricks/transformers/controlFlow/WithAsyncModVariable.test.ts
+++ b/src/bricks/transformers/controlFlow/WithAsyncModVariable.test.ts
@@ -23,7 +23,6 @@ import {
 } from "@/runtime/pipelineTests/pipelineTestHelpers";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import brickRegistry from "@/bricks/registry";
-import { getState, setState } from "@/platform/state/stateController";
 import pDefer, { type DeferredPromise } from "p-defer";
 import { tick } from "@/starterBricks/starterBrickTestUtils";
 import { type Brick } from "@/types/brickTypes";
@@ -33,6 +32,7 @@ import { toExpression } from "@/utils/expressionUtils";
 import { modComponentRefFactory } from "@/testUtils/factories/modComponentFactories";
 import { reduceOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 import { MergeStrategies, StateNamespaces } from "@/platform/state/stateTypes";
+import { getPlatform } from "@/platform/platformContext";
 
 const withAsyncModVariableBrick = new WithAsyncModVariable();
 
@@ -58,7 +58,7 @@ const makeAsyncModVariablePipeline = (
 const modComponentRef = modComponentRefFactory();
 
 function expectPageState(expectedState: UnknownObject): void {
-  const pageState = getState({
+  const pageState = getPlatform().state.getState({
     namespace: StateNamespaces.MOD,
     modComponentRef,
   });
@@ -72,7 +72,7 @@ describe("WithAsyncModVariable", () => {
 
   beforeEach(() => {
     // Reset the page state to avoid interference between tests
-    setState({
+    getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: {},
       modComponentRef,

--- a/src/bricks/transformers/controlFlow/WithAsyncModVariable.ts
+++ b/src/bricks/transformers/controlFlow/WithAsyncModVariable.ts
@@ -18,7 +18,6 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { uuidv4, validateRegistryId } from "@/types/helpers";
 import { type Schema } from "@/types/schemaTypes";
-import { getState, setState } from "@/platform/state/stateController";
 import {
   type BrickArgs,
   type BrickOptions,
@@ -173,7 +172,7 @@ export class WithAsyncModVariable extends TransformerABC {
       body: PipelineExpression;
       stateKey: string;
     }>,
-    { meta: { modComponentRef }, runPipeline }: BrickOptions,
+    { meta: { modComponentRef }, runPipeline, platform }: BrickOptions,
   ) {
     const requestId = uuidv4();
 
@@ -189,7 +188,7 @@ export class WithAsyncModVariable extends TransformerABC {
     const isCurrentNonce = () => modVariableNonces.get(stateKey) === requestId;
 
     const setModVariable = (data: JsonObject, strategy: "put" | "patch") => {
-      setState({
+      platform.state.setState({
         // Store as Mod Variable
         namespace: StateNamespaces.MOD,
         data: {
@@ -206,7 +205,7 @@ export class WithAsyncModVariable extends TransformerABC {
     modVariableNonces.set(stateKey, requestId);
 
     // Get/set page state calls are synchronous from the content script, so safe to call sequentially
-    const currentState = getState({
+    const currentState = platform.state.getState({
       namespace: StateNamespaces.MOD,
       modComponentRef,
     });

--- a/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
+++ b/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
@@ -47,7 +47,6 @@ import ConsoleLogger from "@/utils/ConsoleLogger";
 import { tick } from "@/starterBricks/starterBrickTestUtils";
 import pDefer from "p-defer";
 import { type RendererErrorPayload } from "@/types/rendererTypes";
-import { setState } from "@/platform/state/stateController";
 import { contextAsPlainObject } from "@/runtime/extendModVariableContext";
 import { unary } from "lodash";
 import { toExpression } from "@/utils/expressionUtils";
@@ -65,6 +64,7 @@ import {
   StateNamespaces,
 } from "@/platform/state/stateTypes";
 import { RefreshTriggers } from "@/platform/panels/panelTypes";
+import { getPlatform } from "@/platform/platformContext";
 
 jest.mock("@/contentScript/modalDom");
 jest.mock("@/contentScript/sidebarController");
@@ -351,7 +351,7 @@ describe("DisplayTemporaryInfo", () => {
     ).toStrictEqual([{ "@input": {}, "@mod": {}, "@options": {} }]);
     expect(jest.mocked(showTemporarySidebarPanel)).toHaveBeenCalled();
 
-    setState({
+    getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { foo: 42 },
       mergeStrategy: MergeStrategies.REPLACE,

--- a/src/contentScript/contentScriptPlatform.ts
+++ b/src/contentScript/contentScriptPlatform.ts
@@ -27,7 +27,7 @@ import {
   traces,
   uninstallContextMenu,
 } from "@/background/messenger/api";
-import { getState, setState } from "@/platform/state/stateController";
+import { getState, setState } from "@/contentScript/stateController";
 import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
 import { expectContext } from "@/utils/expectContext";
 import type { PlatformCapability } from "@/platform/capabilities";

--- a/src/contentScript/messenger/registration.ts
+++ b/src/contentScript/messenger/registration.ts
@@ -33,7 +33,7 @@ import {
 import { getProcesses, initRobot } from "@/contentScript/uipath";
 import { checkAvailable } from "@/bricks/available";
 import notify from "@/utils/notify";
-import { getState, setState } from "@/platform/state/stateController";
+import { getState, setState } from "@/contentScript/stateController";
 import {
   cancelTemporaryPanels,
   getPanelDefinition,

--- a/src/contentScript/stateController.test.ts
+++ b/src/contentScript/stateController.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { setState } from "@/platform/state/stateController";
+import { setState } from "@/contentScript/stateController";
 import { modComponentRefFactory } from "@/testUtils/factories/modComponentFactories";
 import {
   MergeStrategies,

--- a/src/contentScript/stateController.ts
+++ b/src/contentScript/stateController.ts
@@ -32,11 +32,13 @@ import {
   StateNamespaces,
 } from "@/platform/state/stateTypes";
 
+// eslint-disable-next-line local-rules/persistBackgroundData -- content script
 const privateState = new Map<UUID, JsonObject>();
 
 /**
  * The mod page state or null for shared page state.
  */
+// eslint-disable-next-line local-rules/persistBackgroundData -- content script
 const modState = new Map<RegistryId | null, JsonObject>();
 
 function mergeState(

--- a/src/platform/platformTypes/stateProtocol.ts
+++ b/src/platform/platformTypes/stateProtocol.ts
@@ -15,7 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import type { getState, setState } from "@/platform/state/stateController";
+import type {
+  MergeStrategy,
+  StateNamespace,
+} from "@/platform/state/stateTypes";
+import type { Except, JsonObject } from "type-fest";
+import type { ModComponentRef } from "@/types/modComponentTypes";
 
 /**
  * The variable store/state for the platform.
@@ -28,10 +33,18 @@ export type StateProtocol = {
   /**
    * Get the current state.
    */
-  getState: typeof getState;
+  getState(args: {
+    namespace: StateNamespace;
+    modComponentRef: Except<ModComponentRef, "starterBrickId">;
+  }): JsonObject;
 
   /**
    * Set the current state.
    */
-  setState: typeof setState;
+  setState(args: {
+    namespace: StateNamespace;
+    data: JsonObject;
+    mergeStrategy: MergeStrategy;
+    modComponentRef: Except<ModComponentRef, "starterBrickId">;
+  }): JsonObject;
 };

--- a/src/runtime/extendModVariableContext.test.ts
+++ b/src/runtime/extendModVariableContext.test.ts
@@ -19,7 +19,6 @@ import extendModVariableContext, {
   contextAsPlainObject,
   isModVariableContext,
 } from "@/runtime/extendModVariableContext";
-import { setState } from "@/platform/state/stateController";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { type ApiVersion } from "@/types/runtimeTypes";
 import {
@@ -27,10 +26,11 @@ import {
   standaloneModComponentRefFactory,
 } from "@/testUtils/factories/modComponentFactories";
 import { MergeStrategies, StateNamespaces } from "@/platform/state/stateTypes";
+import { getPlatform } from "@/platform/platformContext";
 
 describe("createModVariableProxy", () => {
   beforeEach(() => {
-    setState({
+    getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: {},
       modComponentRef: standaloneModComponentRefFactory(),
@@ -49,7 +49,7 @@ describe("createModVariableProxy", () => {
   it("reads from page state", () => {
     const modComponentRef = standaloneModComponentRefFactory();
 
-    setState({
+    getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { foo: 42 },
       modComponentRef,
@@ -112,7 +112,7 @@ describe("createModVariableProxy", () => {
       { modComponentRef, options: apiVersionOptions("v3") },
     );
 
-    setState({
+    getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { foo: 42 },
       modComponentRef: standaloneModComponentRefFactory(),
@@ -135,7 +135,7 @@ describe("createModVariableProxy", () => {
       { modComponentRef, options: apiVersionOptions("v3") },
     );
 
-    setState({
+    getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { foo: 42 },
       modComponentRef,

--- a/src/runtime/extendModVariableContext.ts
+++ b/src/runtime/extendModVariableContext.ts
@@ -15,13 +15,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { getState } from "@/platform/state/stateController";
 import apiVersionOptions, {
   type ApiVersionOptions,
 } from "@/runtime/apiVersionOptions";
 import { pickBy } from "lodash";
 import { type ApiVersion } from "@/types/runtimeTypes";
-import { assertPlatformCapability } from "@/platform/platformContext";
+import {
+  assertPlatformCapability,
+  getPlatform,
+} from "@/platform/platformContext";
 import { type ModComponentRef } from "@/types/modComponentTypes";
 import { type Except } from "type-fest";
 import { StateNamespaces } from "@/platform/state/stateTypes";
@@ -136,7 +138,7 @@ function extendModVariableContext<T extends UnknownObject = UnknownObject>(
   // Eagerly grab the state. It's fast/synchronous since it's in memory in the same JS context.
   // Previously, we had considered using a proxy to lazily load the state. However, eagerly reading is simpler.
   // Additionally, in the future to pass the context to the sandbox we'd have to always load the state anyway.
-  const modState = getState({
+  const modState = getPlatform().state.getState({
     namespace: StateNamespaces.MOD,
     modComponentRef,
   });

--- a/src/runtime/pipelineTests/modVariableContext.test.ts
+++ b/src/runtime/pipelineTests/modVariableContext.test.ts
@@ -21,12 +21,12 @@ import {
   echoBrick,
   simpleInput,
 } from "@/runtime/pipelineTests/pipelineTestHelpers";
-import { setState } from "@/platform/state/stateController";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import { contextAsPlainObject } from "@/runtime/extendModVariableContext";
 import { toExpression } from "@/utils/expressionUtils";
 import { reduceOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 import { MergeStrategies, StateNamespaces } from "@/platform/state/stateTypes";
+import { getPlatform } from "@/platform/platformContext";
 
 beforeEach(() => {
   brickRegistry.clear();
@@ -37,7 +37,7 @@ describe("modVariableContext", () => {
   test("use mod variable in variable condition", async () => {
     const options = reduceOptionsFactory("v3");
 
-    setState({
+    getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { run: true },
       mergeStrategy: MergeStrategies.REPLACE,
@@ -64,7 +64,7 @@ describe("modVariableContext", () => {
   test("use mod variable in nunjucks condition", async () => {
     const options = reduceOptionsFactory("v3");
 
-    setState({
+    getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { run: true },
       mergeStrategy: MergeStrategies.REPLACE,
@@ -91,7 +91,7 @@ describe("modVariableContext", () => {
   test("mod variable appears in context", async () => {
     const options = reduceOptionsFactory("v3");
 
-    setState({
+    getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { name: "Bob" },
       mergeStrategy: MergeStrategies.REPLACE,
@@ -119,7 +119,7 @@ describe("modVariableContext", () => {
   test("use mod variable in nunjucks body", async () => {
     const options = reduceOptionsFactory("v3");
 
-    setState({
+    getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { name: "Bob" },
       mergeStrategy: MergeStrategies.REPLACE,
@@ -145,7 +145,7 @@ describe("modVariableContext", () => {
   test("use mod variable in variable body", async () => {
     const options = reduceOptionsFactory("v3");
 
-    setState({
+    getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { name: "Bob" },
       mergeStrategy: MergeStrategies.REPLACE,

--- a/src/starterBricks/sidebar/sidebarStarterBrick.test.ts
+++ b/src/starterBricks/sidebar/sidebarStarterBrick.test.ts
@@ -29,7 +29,6 @@ import {
   isSidePanelOpen,
   sidebarShowEvents,
 } from "@/contentScript/sidebarController";
-import { setState } from "@/platform/state/stateController";
 import {
   modComponentRefFactory,
   modMetadataFactory,
@@ -188,7 +187,7 @@ describe("sidebarExtension", () => {
 
     expect(rootReader.readCount).toBe(0);
 
-    setState({
+    getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: {},
       mergeStrategy: MergeStrategies.REPLACE,
@@ -210,7 +209,7 @@ describe("sidebarExtension", () => {
     // Runs because statechange mods also run on manual
     expect(rootReader.readCount).toBe(1);
 
-    setState({
+    getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       // Data needs to be different than previous to trigger a state change event
       data: { foo: 42 },
@@ -226,7 +225,7 @@ describe("sidebarExtension", () => {
     expect(rootReader.readCount).toBe(2);
 
     // Should ignore state change from other mod
-    setState({
+    getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: {},
       mergeStrategy: MergeStrategies.REPLACE,
@@ -274,7 +273,7 @@ describe("sidebarExtension", () => {
     expect(rootReader.readCount).toBe(1);
 
     for (let i = 0; i < 10; i++) {
-      setState({
+      getPlatform().state.setState({
         namespace: StateNamespaces.MOD,
         data: { foo: i },
         mergeStrategy: MergeStrategies.REPLACE,


### PR DESCRIPTION
## What does this PR do?

- Part of #9105
- Move state controller to content script folder in anticipation of content script-specific logic coming out of https://github.com/pixiebrix/pixiebrix-extension/pull/9106

## Discussion

- Tests use the content script platform by default

## Future Work

- Make get/set async

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
