### PR TITLE
#9105: make getState and setState async

### DIFF
--- a/src/bricks/effects/assignModVariable.test.ts
+++ b/src/bricks/effects/assignModVariable.test.ts
@@ -55,12 +55,12 @@ describe("@pixiebrix/state/assign", () => {
       brickOptions,
     );
 
-    expect(
+    await expect(
       getPlatform().state.getState({
         namespace: StateNamespaces.MOD,
         modComponentRef,
       }),
-    ).toEqual({ foo: { bar: 42 } });
+    ).resolves.toEqual({ foo: { bar: 42 } });
   });
 
   test("null is valid input", async () => {
@@ -88,12 +88,12 @@ describe("@pixiebrix/state/assign", () => {
       brickOptions,
     );
 
-    expect(
+    await expect(
       getPlatform().state.getState({
         namespace: StateNamespaces.MOD,
         modComponentRef,
       }),
-    ).toEqual({ foo: null });
+    ).resolves.toEqual({ foo: null });
   });
 
   test("only sets variable", async () => {
@@ -107,12 +107,12 @@ describe("@pixiebrix/state/assign", () => {
       brickOptions,
     );
 
-    expect(
+    await expect(
       getPlatform().state.getState({
         namespace: StateNamespaces.MOD,
         modComponentRef,
       }),
-    ).toEqual({ foo: 42, bar: 0 });
+    ).resolves.toEqual({ foo: 42, bar: 0 });
   });
 
   it("returns mod variables", async () => {

--- a/src/bricks/effects/assignModVariable.test.ts
+++ b/src/bricks/effects/assignModVariable.test.ts
@@ -34,8 +34,8 @@ const brickOptions = brickOptionsFactory({
   meta: runMetadataFactory({ modComponentRef }),
 });
 
-beforeEach(() => {
-  getPlatform().state.setState({
+beforeEach(async () => {
+  await getPlatform().state.setState({
     namespace: StateNamespaces.MOD,
     modComponentRef,
     mergeStrategy: MergeStrategies.REPLACE,

--- a/src/bricks/effects/assignModVariable.ts
+++ b/src/bricks/effects/assignModVariable.ts
@@ -92,7 +92,7 @@ class AssignModVariable extends EffectABC {
     }>,
     { meta: { modComponentRef }, platform }: BrickOptions,
   ): Promise<void> {
-    platform.state.setState({
+    await platform.state.setState({
       namespace: StateNamespaces.MOD,
       data: { [variableName]: value },
       mergeStrategy: MergeStrategies.SHALLOW,

--- a/src/bricks/renderers/customForm.test.tsx
+++ b/src/bricks/renderers/customForm.test.tsx
@@ -45,8 +45,8 @@ const brick = new CustomFormRenderer();
 
 // CustomForm uses @/contentScript/messenger/api instead of the platform API
 jest.mock("@/contentScript/messenger/api", () => ({
-  getPageState: jest.fn((_: Target, args: any) => getState(args)),
-  setPageState: jest.fn((_: Target, args: any) => setState(args)),
+  getPageState: jest.fn(async (_: Target, args: any) => getState(args)),
+  setPageState: jest.fn(async (_: Target, args: any) => setState(args)),
 }));
 
 // I couldn't get shadow-dom-testing-library working
@@ -349,12 +349,12 @@ describe("CustomFormRenderer", () => {
 
       expect(runPipelineMock).toHaveBeenCalledOnce();
 
-      expect(
+      await expect(
         getState({
           namespace: StateNamespaces.MOD,
           modComponentRef: options.meta.modComponentRef,
         }),
-      ).toStrictEqual({
+      ).resolves.toStrictEqual({
         name: value,
       });
 

--- a/src/bricks/transformers/controlFlow/WithAsyncModVariable.test.ts
+++ b/src/bricks/transformers/controlFlow/WithAsyncModVariable.test.ts
@@ -57,8 +57,8 @@ const makeAsyncModVariablePipeline = (
 
 const modComponentRef = modComponentRefFactory();
 
-function expectPageState(expectedState: UnknownObject): void {
-  const pageState = getPlatform().state.getState({
+async function expectPageState(expectedState: UnknownObject): Promise<void> {
+  const pageState = await getPlatform().state.getState({
     namespace: StateNamespaces.MOD,
     modComponentRef,
   });
@@ -70,9 +70,9 @@ describe("WithAsyncModVariable", () => {
   let deferred: DeferredPromise<void>;
   let asyncEchoBrick: DeferredEchoBrick;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // Reset the page state to avoid interference between tests
-    getPlatform().state.setState({
+    await getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: {},
       modComponentRef,
@@ -104,7 +104,7 @@ describe("WithAsyncModVariable", () => {
       requestId: expect.toBeString(),
     });
 
-    expectPageState({
+    await expectPageState({
       foo: {
         // Initializes loading state
         isLoading: true,
@@ -113,7 +113,7 @@ describe("WithAsyncModVariable", () => {
         isError: false,
         currentData: null,
         data: null,
-        requestId: null,
+        requestId: expect.toBeString(),
         error: null,
       },
     });
@@ -135,7 +135,7 @@ describe("WithAsyncModVariable", () => {
       requestId: expect.toBeString(),
     });
 
-    expectPageState({
+    await expectPageState({
       foo: {
         isLoading: false,
         isFetching: false,
@@ -165,7 +165,7 @@ describe("WithAsyncModVariable", () => {
       requestId: expect.toBeString(),
     });
 
-    expectPageState({
+    await expectPageState({
       foo: expect.objectContaining({
         isLoading: false,
         isFetching: false,
@@ -224,7 +224,7 @@ describe("WithAsyncModVariable", () => {
     );
 
     // Neither are resolved, should be in loading state
-    expectPageState({
+    await expectPageState({
       foo: {
         isLoading: true,
         isFetching: true,
@@ -232,7 +232,7 @@ describe("WithAsyncModVariable", () => {
         isError: false,
         currentData: null,
         data: null,
-        requestId: null,
+        requestId: expect.toBeString(),
         error: null,
       },
     });
@@ -241,7 +241,7 @@ describe("WithAsyncModVariable", () => {
     await tick();
 
     // State should update to be the second request, even though the first request is not completed
-    expectPageState({
+    await expectPageState({
       foo: {
         isLoading: false,
         isFetching: false,
@@ -259,7 +259,7 @@ describe("WithAsyncModVariable", () => {
     await tick();
 
     // State should not update, because the result from the first call is stale
-    expectPageState({
+    await expectPageState({
       foo: {
         isLoading: false,
         isFetching: false,

--- a/src/bricks/transformers/controlFlow/WithAsyncModVariable.ts
+++ b/src/bricks/transformers/controlFlow/WithAsyncModVariable.ts
@@ -227,7 +227,7 @@ export class WithAsyncModVariable extends TransformerABC {
         isError: false,
         currentData: null,
         data: null,
-        requestId: uuidv4(),
+        requestId,
         error: null,
       });
     } else {
@@ -235,7 +235,7 @@ export class WithAsyncModVariable extends TransformerABC {
         // Preserve the previous data/error, if any. Due to get/setState being async, it's possible that
         // the state could have been deleted since the getState call. Therefore, pass a full state object
         ...currentVariable,
-        requestId: uuidv4(),
+        requestId,
         isFetching: true,
         currentData: null,
       });

--- a/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
+++ b/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
@@ -351,7 +351,7 @@ describe("DisplayTemporaryInfo", () => {
     ).toStrictEqual([{ "@input": {}, "@mod": {}, "@options": {} }]);
     expect(jest.mocked(showTemporarySidebarPanel)).toHaveBeenCalled();
 
-    getPlatform().state.setState({
+    await getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { foo: 42 },
       mergeStrategy: MergeStrategies.REPLACE,

--- a/src/contentScript/pageEditor/runBrickPreview.ts
+++ b/src/contentScript/pageEditor/runBrickPreview.ts
@@ -52,7 +52,7 @@ export async function runBrickPreview({
   }
 
   const state: IntermediateState = {
-    context: extendModVariableContext(context, {
+    context: await extendModVariableContext(context, {
       modComponentRef,
       update: true,
       options: versionOptions,

--- a/src/contentScript/pipelineProtocol/runMapArgs.ts
+++ b/src/contentScript/pipelineProtocol/runMapArgs.ts
@@ -53,7 +53,8 @@ export async function runMapArgs({
   };
 }): Promise<unknown> {
   expectContext("contentScript");
-  const extendedContext = extendModVariableContext(context, {
+
+  const extendedContext = await extendModVariableContext(context, {
     modComponentRef,
     options,
     // The mod variable is only update when running a brick in a pipeline. It's not updated for `defer` expressions,

--- a/src/contentScript/stateController.test.ts
+++ b/src/contentScript/stateController.test.ts
@@ -24,14 +24,14 @@ import {
 } from "@/platform/state/stateTypes";
 
 describe("pageState", () => {
-  it("deep merge triggers event", () => {
+  it("deep merge triggers event", async () => {
     const listener = jest.fn();
 
     document.addEventListener(STATE_CHANGE_JS_EVENT_TYPE, listener);
 
     const modComponentRef = modComponentRefFactory();
 
-    setState({
+    await setState({
       namespace: StateNamespaces.MOD,
       data: { foo: { bar: "baz" } },
       mergeStrategy: MergeStrategies.DEEP,
@@ -41,14 +41,14 @@ describe("pageState", () => {
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
-  it("deep merges async state", () => {
+  it("deep merges async state", async () => {
     const listener = jest.fn();
 
     document.addEventListener(STATE_CHANGE_JS_EVENT_TYPE, listener);
 
     const modComponentRef = modComponentRefFactory();
 
-    setState({
+    await setState({
       namespace: StateNamespaces.MOD,
       data: {
         asyncState: { isFetching: false, data: "foo", currentData: "foo" },
@@ -57,7 +57,7 @@ describe("pageState", () => {
       modComponentRef,
     });
 
-    const updatedState = setState({
+    const updatedState = await setState({
       namespace: StateNamespaces.MOD,
       data: { asyncState: { isFetching: true, currentData: null } },
       mergeStrategy: MergeStrategies.DEEP,

--- a/src/contentScript/stateController.ts
+++ b/src/contentScript/stateController.ts
@@ -99,16 +99,16 @@ function dispatchStateChangeEventOnChange({
   }
 }
 
-export function setState({
+export async function setState({
   namespace,
+  modComponentRef,
   data,
   mergeStrategy,
-  modComponentRef,
 }: {
   namespace: StateNamespace;
+  modComponentRef: Except<ModComponentRef, "starterBrickId">;
   data: JsonObject;
   mergeStrategy: MergeStrategy;
-  modComponentRef: Except<ModComponentRef, "starterBrickId">;
 }) {
   assertPlatformCapability("state");
 
@@ -159,13 +159,13 @@ export function setState({
   }
 }
 
-export function getState({
+export async function getState({
   namespace,
   modComponentRef: { modComponentId, modId },
 }: {
   namespace: StateNamespace;
   modComponentRef: Except<ModComponentRef, "starterBrickId">;
-}): JsonObject {
+}): Promise<JsonObject> {
   assertPlatformCapability("state");
 
   switch (namespace) {

--- a/src/extensionConsole/pages/mods/ModsPage.tsx
+++ b/src/extensionConsole/pages/mods/ModsPage.tsx
@@ -41,12 +41,6 @@ const ModsPage: React.FunctionComponent = () => {
   // Note: We only need to show a loading indicator until mods are loaded
   const { isLoading, error: modsError } = useAllModDefinitions();
 
-  const test = useGetMarketplaceListingsQuery(undefined, {
-    refetchOnMountOrArgChange: true,
-  });
-
-  console.log("TEST", { ...test });
-
   const { error: listingsError } = useGetMarketplaceListingsQuery(undefined, {
     refetchOnMountOrArgChange: true,
   });

--- a/src/extensionConsole/pages/mods/ModsPage.tsx
+++ b/src/extensionConsole/pages/mods/ModsPage.tsx
@@ -41,6 +41,12 @@ const ModsPage: React.FunctionComponent = () => {
   // Note: We only need to show a loading indicator until mods are loaded
   const { isLoading, error: modsError } = useAllModDefinitions();
 
+  const test = useGetMarketplaceListingsQuery(undefined, {
+    refetchOnMountOrArgChange: true,
+  });
+
+  console.log("TEST", { ...test });
+
   const { error: listingsError } = useGetMarketplaceListingsQuery(undefined, {
     refetchOnMountOrArgChange: true,
   });

--- a/src/platform/platformTypes/stateProtocol.ts
+++ b/src/platform/platformTypes/stateProtocol.ts
@@ -32,19 +32,23 @@ import type { ModComponentRef } from "@/types/modComponentTypes";
 export type StateProtocol = {
   /**
    * Get the current state.
+   *
+   * @since 2.1.2 asynchronous
    */
   getState(args: {
     namespace: StateNamespace;
     modComponentRef: Except<ModComponentRef, "starterBrickId">;
-  }): JsonObject;
+  }): Promise<JsonObject>;
 
   /**
-   * Set the current state.
+   * Set the state for a given namespace.
+   *
+   * @since 2.1.2 asynchronous
    */
   setState(args: {
     namespace: StateNamespace;
+    modComponentRef: Except<ModComponentRef, "starterBrickId">;
     data: JsonObject;
     mergeStrategy: MergeStrategy;
-    modComponentRef: Except<ModComponentRef, "starterBrickId">;
-  }): JsonObject;
+  }): Promise<JsonObject>;
 };

--- a/src/runtime/extendModVariableContext.test.ts
+++ b/src/runtime/extendModVariableContext.test.ts
@@ -29,8 +29,8 @@ import { MergeStrategies, StateNamespaces } from "@/platform/state/stateTypes";
 import { getPlatform } from "@/platform/platformContext";
 
 describe("createModVariableProxy", () => {
-  beforeEach(() => {
-    getPlatform().state.setState({
+  beforeEach(async () => {
+    await getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: {},
       modComponentRef: standaloneModComponentRefFactory(),
@@ -38,25 +38,25 @@ describe("createModVariableProxy", () => {
     });
   });
 
-  it("reads from blank page state", () => {
-    const ctxt = extendModVariableContext({} as UnknownObject, {
+  it("reads from blank page state", async () => {
+    const ctxt = await extendModVariableContext({} as UnknownObject, {
       modComponentRef: standaloneModComponentRefFactory(),
       options: apiVersionOptions("v3"),
     });
     expect(contextAsPlainObject(ctxt)).toEqual({ "@mod": {} });
   });
 
-  it("reads from page state", () => {
+  it("reads from page state", async () => {
     const modComponentRef = standaloneModComponentRefFactory();
 
-    getPlatform().state.setState({
+    await getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { foo: 42 },
       modComponentRef,
       mergeStrategy: MergeStrategies.REPLACE,
     });
 
-    const ctxt = extendModVariableContext(
+    const ctxt = await extendModVariableContext(
       {},
       { modComponentRef, options: apiVersionOptions("v3") },
     );
@@ -66,10 +66,10 @@ describe("createModVariableProxy", () => {
 
   it.each(["v1", "v2"])(
     "doesn't extend for old runtime version: %s",
-    (version: ApiVersion) => {
+    async (version: ApiVersion) => {
       const modComponentRef = standaloneModComponentRefFactory();
 
-      const ctxt = extendModVariableContext(
+      const ctxt = await extendModVariableContext(
         {},
         { modComponentRef, options: apiVersionOptions(version) },
       );
@@ -78,20 +78,20 @@ describe("createModVariableProxy", () => {
     },
   );
 
-  it("does not overwrite existing state", () => {
+  it("does not overwrite existing state", async () => {
     const modComponentRef = standaloneModComponentRefFactory();
 
-    const ctxt = extendModVariableContext(
+    const ctxt = await extendModVariableContext(
       { "@mod": "foo" },
       { modComponentRef, options: apiVersionOptions("v3") },
     );
     expect(ctxt["@mod"]).toBe("foo");
   });
 
-  it("sets symbol", () => {
+  it("sets symbol", async () => {
     const modComponentRef = standaloneModComponentRefFactory();
 
-    const ctxt = extendModVariableContext(
+    const ctxt = await extendModVariableContext(
       {},
       { modComponentRef, options: apiVersionOptions("v3") },
     );
@@ -104,22 +104,22 @@ describe("createModVariableProxy", () => {
     expect(isModVariableContext({})).toBe(false);
   });
 
-  it("do not update by default", () => {
+  it("do not update by default", async () => {
     const modComponentRef = standaloneModComponentRefFactory();
 
-    const ctxt1 = extendModVariableContext(
+    const ctxt1 = await extendModVariableContext(
       {},
       { modComponentRef, options: apiVersionOptions("v3") },
     );
 
-    getPlatform().state.setState({
+    await getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { foo: 42 },
       modComponentRef: standaloneModComponentRefFactory(),
       mergeStrategy: MergeStrategies.REPLACE,
     });
 
-    const ctxt2 = extendModVariableContext(ctxt1, {
+    const ctxt2 = await extendModVariableContext(ctxt1, {
       modComponentRef: standaloneModComponentRefFactory(),
       options: apiVersionOptions("v3"),
     });
@@ -127,22 +127,22 @@ describe("createModVariableProxy", () => {
     expect(ctxt2).toBe(ctxt1);
   });
 
-  it("update if update flag is set", () => {
+  it("update if update flag is set", async () => {
     const modComponentRef = modComponentRefFactory();
 
-    const ctxt1 = extendModVariableContext(
+    const ctxt1 = await extendModVariableContext(
       {},
       { modComponentRef, options: apiVersionOptions("v3") },
     );
 
-    getPlatform().state.setState({
+    await getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { foo: 42 },
       modComponentRef,
       mergeStrategy: MergeStrategies.REPLACE,
     });
 
-    const ctxt2 = extendModVariableContext(ctxt1, {
+    const ctxt2 = await extendModVariableContext(ctxt1, {
       modComponentRef: modComponentRefFactory({ modId: modComponentRef.modId }),
       update: true,
       options: apiVersionOptions("v3"),

--- a/src/runtime/extendModVariableContext.ts
+++ b/src/runtime/extendModVariableContext.ts
@@ -89,7 +89,7 @@ export function contextAsPlainObject<T extends UnknownObject = UnknownObject>(
     [MOD_VARIABLE_REFERENCE]: pickBy(
       // eslint-disable-next-line security/detect-object-injection -- constant
       (context as ExtendedContext)[MOD_VARIABLE_REFERENCE] ?? {},
-      (value, key) => key !== MOD_VARIABLE_TAG,
+      (_, key) => key !== MOD_VARIABLE_TAG,
     ),
   };
 }
@@ -102,7 +102,9 @@ export function contextAsPlainObject<T extends UnknownObject = UnknownObject>(
  * @param update If true, the mod variable will be updated with the latest state
  * @param options The runtime version API options
  */
-function extendModVariableContext<T extends UnknownObject = UnknownObject>(
+async function extendModVariableContext<
+  T extends UnknownObject = UnknownObject,
+>(
   originalContext: T,
   {
     modComponentRef,
@@ -113,7 +115,7 @@ function extendModVariableContext<T extends UnknownObject = UnknownObject>(
     update?: boolean;
     options: Pick<ApiVersionOptions, "extendModVariable">;
   },
-): ExtendedContext<T> {
+): Promise<ExtendedContext<T>> {
   assertPlatformCapability("state");
 
   // For backward compatability, don't overwrite for older versions of the runtime. It should generally be safe, but
@@ -138,7 +140,7 @@ function extendModVariableContext<T extends UnknownObject = UnknownObject>(
   // Eagerly grab the state. It's fast/synchronous since it's in memory in the same JS context.
   // Previously, we had considered using a proxy to lazily load the state. However, eagerly reading is simpler.
   // Additionally, in the future to pass the context to the sandbox we'd have to always load the state anyway.
-  const modState = getPlatform().state.getState({
+  const modState = await getPlatform().state.getState({
     namespace: StateNamespaces.MOD,
     modComponentRef,
   });

--- a/src/runtime/pipelineTests/modVariableContext.test.ts
+++ b/src/runtime/pipelineTests/modVariableContext.test.ts
@@ -37,7 +37,7 @@ describe("modVariableContext", () => {
   test("use mod variable in variable condition", async () => {
     const options = reduceOptionsFactory("v3");
 
-    getPlatform().state.setState({
+    await getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { run: true },
       mergeStrategy: MergeStrategies.REPLACE,
@@ -91,7 +91,7 @@ describe("modVariableContext", () => {
   test("mod variable appears in context", async () => {
     const options = reduceOptionsFactory("v3");
 
-    getPlatform().state.setState({
+    await getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { name: "Bob" },
       mergeStrategy: MergeStrategies.REPLACE,
@@ -119,7 +119,7 @@ describe("modVariableContext", () => {
   test("use mod variable in nunjucks body", async () => {
     const options = reduceOptionsFactory("v3");
 
-    getPlatform().state.setState({
+    await getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { name: "Bob" },
       mergeStrategy: MergeStrategies.REPLACE,
@@ -145,7 +145,7 @@ describe("modVariableContext", () => {
   test("use mod variable in variable body", async () => {
     const options = reduceOptionsFactory("v3");
 
-    getPlatform().state.setState({
+    await getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { name: "Bob" },
       mergeStrategy: MergeStrategies.REPLACE,

--- a/src/runtime/pipelineTests/modVariableContext.test.ts
+++ b/src/runtime/pipelineTests/modVariableContext.test.ts
@@ -64,7 +64,7 @@ describe("modVariableContext", () => {
   test("use mod variable in nunjucks condition", async () => {
     const options = reduceOptionsFactory("v3");
 
-    getPlatform().state.setState({
+    await getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: { run: true },
       mergeStrategy: MergeStrategies.REPLACE,

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -1007,7 +1007,8 @@ export async function reducePipeline(
       index,
       isLastBrick: index === pipelineArray.length - 1,
       previousOutput: output,
-      context: extendModVariableContext(localVariableContext, {
+      // eslint-disable-next-line no-await-in-loop -- relies on effect of the previous iteration
+      context: await extendModVariableContext(localVariableContext, {
         modComponentRef: partialOptions.modComponentRef,
         options,
         // Mod variable is updated when each block is run
@@ -1080,7 +1081,8 @@ async function reducePipelineExpression(
       isLastBrick: index === pipeline.length - 1,
       previousOutput: legacyOutput,
       // Assume @input and @options are present
-      context: extendModVariableContext(context as BrickArgsContext, {
+      // eslint-disable-next-line no-await-in-loop -- relies on effect of the previous iteration
+      context: await extendModVariableContext(context as BrickArgsContext, {
         modComponentRef: options.modComponentRef,
         options,
         // Update mod variable when each block is run

--- a/src/starterBricks/sidebar/sidebarStarterBrick.test.ts
+++ b/src/starterBricks/sidebar/sidebarStarterBrick.test.ts
@@ -187,7 +187,7 @@ describe("sidebarExtension", () => {
 
     expect(rootReader.readCount).toBe(0);
 
-    getPlatform().state.setState({
+    await getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: {},
       mergeStrategy: MergeStrategies.REPLACE,
@@ -209,7 +209,7 @@ describe("sidebarExtension", () => {
     // Runs because statechange mods also run on manual
     expect(rootReader.readCount).toBe(1);
 
-    getPlatform().state.setState({
+    await getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       // Data needs to be different than previous to trigger a state change event
       data: { foo: 42 },
@@ -225,7 +225,7 @@ describe("sidebarExtension", () => {
     expect(rootReader.readCount).toBe(2);
 
     // Should ignore state change from other mod
-    getPlatform().state.setState({
+    await getPlatform().state.setState({
       namespace: StateNamespaces.MOD,
       data: {},
       mergeStrategy: MergeStrategies.REPLACE,
@@ -273,7 +273,8 @@ describe("sidebarExtension", () => {
     expect(rootReader.readCount).toBe(1);
 
     for (let i = 0; i < 10; i++) {
-      getPlatform().state.setState({
+      // eslint-disable-next-line no-await-in-loop -- test code
+      await getPlatform().state.setState({
         namespace: StateNamespaces.MOD,
         data: { foo: i },
         mergeStrategy: MergeStrategies.REPLACE,


### PR DESCRIPTION
## What does this PR do?

- Part of #9105 
- FLUP to https://github.com/pixiebrix/pixiebrix-extension/pull/9120
- Makes the getState/setState methods async in anticipation of https://github.com/pixiebrix/pixiebrix-extension/pull/9106

## Discussion

- The main consideration is that page state could be updated between get + set calls. So WithAsyncModVariable's logic needed to be rewritten to ensure a valid async state shape

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
