### PR TITLE
#9087 Skip tests for pre-release e2e workflow on msedge/msedge-beta

### DIFF
--- a/end-to-end-tests/pageObjects/extensionsShortcutsPage.ts
+++ b/end-to-end-tests/pageObjects/extensionsShortcutsPage.ts
@@ -16,7 +16,11 @@
  */
 
 import { expect, type Page } from "@playwright/test";
-import { getModifierKey, getModifierSymbol } from "end-to-end-tests/utils";
+import {
+  getModifierKey,
+  getModifierSymbol,
+  isChrome,
+} from "end-to-end-tests/utils";
 import { BasePageObject } from "./basePageObject";
 import {
   type SupportedChannel,
@@ -67,11 +71,7 @@ export class ExtensionsShortcutsPage extends BasePageObject {
   async goto() {
     await this.page.goto(this.pageUrl);
 
-    if (
-      [SupportedChannels.CHROME, SupportedChannels.CHROME_BETA].includes(
-        this.chromiumChannel,
-      )
-    ) {
+    if (isChrome(this.chromiumChannel)) {
       await expect(
         this.getByRole("heading", { name: /PixieBrix/ }),
       ).toBeVisible();
@@ -85,11 +85,7 @@ export class ExtensionsShortcutsPage extends BasePageObject {
 
     const shortcut = await getShortcut(this.page);
 
-    if (
-      [SupportedChannels.CHROME, SupportedChannels.CHROME_BETA].includes(
-        this.chromiumChannel,
-      )
-    ) {
+    if (isChrome(this.chromiumChannel)) {
       await expect(this.page.getByPlaceholder(/shortcut set: /i)).toHaveValue(
         shortcut,
       );
@@ -126,11 +122,7 @@ export class ExtensionsShortcutsPage extends BasePageObject {
     const modifierKey = await getModifierKey(this.page);
     const shortcut = await getShortcut(this.page);
 
-    if (
-      [SupportedChannels.CHROME, SupportedChannels.CHROME_BETA].includes(
-        this.chromiumChannel,
-      )
-    ) {
+    if (isChrome(this.chromiumChannel)) {
       await expect(
         this.getByLabel(/Shortcut Toggle Quick Bar for PixieBrix/),
       ).toBeEmpty();

--- a/end-to-end-tests/pageObjects/extensionsShortcutsPage.ts
+++ b/end-to-end-tests/pageObjects/extensionsShortcutsPage.ts
@@ -20,30 +20,22 @@ import {
   getModifierKey,
   getModifierSymbol,
   isChrome,
+  isChromium,
+  isMsEdge,
 } from "end-to-end-tests/utils";
 import { BasePageObject } from "./basePageObject";
-import {
-  type SupportedChannel,
-  SupportedChannels,
-} from "../../playwright.config";
+import { type SupportedChannel } from "../../playwright.config";
 
 function getExtensionShortcutsUrl(chromiumChannel: SupportedChannel) {
-  switch (chromiumChannel) {
-    case SupportedChannels.CHROME:
-    case SupportedChannels.CHROME_BETA:
-    case SupportedChannels.CHROMIUM: {
-      return "chrome://extensions/shortcuts";
-    }
-
-    case SupportedChannels.MSEDGE:
-    case SupportedChannels.MSEDGE_BETA: {
-      return "edge://extensions/shortcuts";
-    }
-
-    default: {
-      throw new Error(`Unexpected channel: ${chromiumChannel}`);
-    }
+  if (isChrome(chromiumChannel) || isChromium(chromiumChannel)) {
+    return "chrome://extensions/shortcuts";
   }
+
+  if (isMsEdge(chromiumChannel)) {
+    return "edge://extensions/shortcuts";
+  }
+
+  throw new Error(`Unexpected channel: ${chromiumChannel}`);
 }
 
 async function getShortcut(page: Page): Promise<string> {

--- a/end-to-end-tests/tests/extensionConsole/activation.spec.ts
+++ b/end-to-end-tests/tests/extensionConsole/activation.spec.ts
@@ -24,6 +24,7 @@ import {
   clickAndWaitForNewPage,
   runModViaQuickBar,
   getBrowserOs,
+  isChrome,
 } from "../../utils";
 import path from "node:path";
 import { VALID_UUID_REGEX } from "@/types/stringTypes";
@@ -31,7 +32,6 @@ import { type Serializable } from "playwright-core/types/structs";
 import { SERVICE_URL } from "../../env";
 import { ExtensionsShortcutsPage } from "../../pageObjects/extensionsShortcutsPage";
 import { FloatingActionButton } from "../../pageObjects/floatingActionButton";
-import { SupportedChannels } from "../../../playwright.config";
 
 test("can activate a mod with no config options", async ({
   page,
@@ -182,12 +182,7 @@ test("activating a mod when the quickbar shortcut is not configured", async ({
     const os = await getBrowserOs(firstTab);
     // See https://github.com/pixiebrix/pixiebrix-extension/issues/6268
     /* eslint-disable playwright/no-conditional-in-test -- Existing bug where shortcut isn't set on Edge in Windows/Linux */
-    if (
-      os === "MacOS" ||
-      [SupportedChannels.CHROME, SupportedChannels.CHROME_BETA].includes(
-        chromiumChannel,
-      )
-    ) {
+    if (os === "MacOS" || isChrome(chromiumChannel)) {
       await shortcutsPage.clearQuickbarShortcut();
     }
   });

--- a/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts
@@ -24,7 +24,6 @@ import {
   isMsEdge,
   PRE_RELEASE_BROWSER_WORKFLOW_NAME,
 } from "../../utils";
-import { SupportedChannels } from "playwright.config";
 
 test("Add new starter brick", async ({
   page,
@@ -97,11 +96,7 @@ test("Add new starter brick", async ({
     ).toHaveValue("Sidebar Panel");
 
     /* eslint-disable playwright/no-conditional-in-test, playwright/no-conditional-expect -- Edge bug, see https://github.com/pixiebrix/pixiebrix-extension/issues/9011 */
-    if (
-      ![SupportedChannels.MSEDGE, SupportedChannels.MSEDGE_BETA].includes(
-        chromiumChannel,
-      )
-    ) {
+    if (!isMsEdge(chromiumChannel)) {
       const sidebarPage = await getSidebarPage(page, extensionId);
       await expect(sidebarPage.getByText("Example Document")).toBeVisible();
     }

--- a/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts
@@ -263,11 +263,10 @@ test("Add starter brick to mod", async ({
   });
 
   await test.step("Add Trigger starter brick to mod", async () => {
-    // FIXME: https://github.com/pixiebrix/pixiebrix-extension/issues/9125
-    test.skip(
+    test.fixme(
       process.env.GITHUB_WORKFLOW === PRE_RELEASE_BROWSER_WORKFLOW_NAME &&
         isMsEdge(chromiumChannel),
-      "Skipping test for MS Edge in pre-release workflow",
+      "Skipping test for MS Edge in pre-release workflow, see https://github.com/pixiebrix/pixiebrix-extension/issues/9125",
     );
 
     const modActionMenu = await openModActionMenu();

--- a/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts
@@ -19,7 +19,7 @@ import { test, expect } from "../../fixtures/testBase";
 
 // @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
 import { type Page, test as base } from "@playwright/test";
-import { getSidebarPage } from "../../utils";
+import { getSidebarPage, isMsEdge } from "../../utils";
 import { SupportedChannels } from "playwright.config";
 
 test("Add new starter brick", async ({
@@ -140,6 +140,7 @@ test("Add starter brick to mod", async ({
   newPageEditorPage,
   extensionId,
   verifyModDefinitionSnapshot,
+  chromiumChannel,
 }) => {
   await page.goto("/");
   const pageEditorPage = await newPageEditorPage(page.url());
@@ -258,6 +259,13 @@ test("Add starter brick to mod", async ({
   });
 
   await test.step("Add Trigger starter brick to mod", async () => {
+    // FIXME: https://github.com/pixiebrix/pixiebrix-extension/issues/9125
+    test.skip(
+      process.env.GITHUB_WORKFLOW === "e2e-test-pre-release-browsers" &&
+        isMsEdge(chromiumChannel),
+      "Skipping test for MS Edge in pre-release workflow",
+    );
+
     const modActionMenu = await openModActionMenu();
     await modActionMenu.addStarterBrick("Trigger");
 

--- a/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts
@@ -19,7 +19,11 @@ import { test, expect } from "../../fixtures/testBase";
 
 // @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
 import { type Page, test as base } from "@playwright/test";
-import { getSidebarPage, isMsEdge } from "../../utils";
+import {
+  getSidebarPage,
+  isMsEdge,
+  PRE_RELEASE_BROWSER_WORKFLOW_NAME,
+} from "../../utils";
 import { SupportedChannels } from "playwright.config";
 
 test("Add new starter brick", async ({
@@ -261,7 +265,7 @@ test("Add starter brick to mod", async ({
   await test.step("Add Trigger starter brick to mod", async () => {
     // FIXME: https://github.com/pixiebrix/pixiebrix-extension/issues/9125
     test.skip(
-      process.env.GITHUB_WORKFLOW === "e2e-test-pre-release-browsers" &&
+      process.env.GITHUB_WORKFLOW === PRE_RELEASE_BROWSER_WORKFLOW_NAME &&
         isMsEdge(chromiumChannel),
       "Skipping test for MS Edge in pre-release workflow",
     );

--- a/end-to-end-tests/tests/pageEditor/copyMod.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/copyMod.spec.ts
@@ -88,11 +88,10 @@ test("run a copied mod with a built-in integration", async ({
   verifyModDefinitionSnapshot,
   chromiumChannel,
 }) => {
-  // FIXME: https://github.com/pixiebrix/pixiebrix-extension/issues/9125
-  test.skip(
+  test.fixme(
     process.env.GITHUB_WORKFLOW === PRE_RELEASE_BROWSER_WORKFLOW_NAME &&
       isMsEdge(chromiumChannel),
-    "Skipping test for MS Edge in pre-release workflow",
+    "Skipping test for MS Edge in pre-release workflow, see https://github.com/pixiebrix/pixiebrix-extension/issues/9125",
   );
 
   let giphyRequestPostData: Serializable;

--- a/end-to-end-tests/tests/pageEditor/copyMod.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/copyMod.spec.ts
@@ -23,7 +23,11 @@ import { uuidv4 } from "@/types/helpers";
 import { type Serializable } from "playwright-core/types/structs";
 import path from "node:path";
 import { FloatingActionButton } from "end-to-end-tests/pageObjects/floatingActionButton";
-import { getSidebarPage, runModViaQuickBar } from "end-to-end-tests/utils";
+import {
+  getSidebarPage,
+  runModViaQuickBar,
+  isMsEdge,
+} from "end-to-end-tests/utils";
 import { VALID_UUID_REGEX } from "@/types/stringTypes";
 
 test("copying a mod that uses the PixieBrix API is copied correctly", async ({
@@ -81,7 +85,15 @@ test("run a copied mod with a built-in integration", async ({
   context,
   newPageEditorPage,
   verifyModDefinitionSnapshot,
+  chromiumChannel,
 }) => {
+  // FIXME: https://github.com/pixiebrix/pixiebrix-extension/issues/9125
+  test.skip(
+    process.env.GITHUB_WORKFLOW === "e2e-test-pre-release-browsers" &&
+      isMsEdge(chromiumChannel),
+    "Skipping test for MS Edge in pre-release workflow",
+  );
+
   let giphyRequestPostData: Serializable;
   // The giphy search request is proxied through the PixieBrix server, which is kicked off in the background/service
   // worker. Playwright experimentally supports mocking service worker requests, see

--- a/end-to-end-tests/tests/pageEditor/copyMod.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/copyMod.spec.ts
@@ -27,6 +27,7 @@ import {
   getSidebarPage,
   runModViaQuickBar,
   isMsEdge,
+  PRE_RELEASE_BROWSER_WORKFLOW_NAME,
 } from "end-to-end-tests/utils";
 import { VALID_UUID_REGEX } from "@/types/stringTypes";
 
@@ -89,7 +90,7 @@ test("run a copied mod with a built-in integration", async ({
 }) => {
   // FIXME: https://github.com/pixiebrix/pixiebrix-extension/issues/9125
   test.skip(
-    process.env.GITHUB_WORKFLOW === "e2e-test-pre-release-browsers" &&
+    process.env.GITHUB_WORKFLOW === PRE_RELEASE_BROWSER_WORKFLOW_NAME &&
       isMsEdge(chromiumChannel),
     "Skipping test for MS Edge in pre-release workflow",
   );

--- a/end-to-end-tests/tests/pageEditor/liveEditing.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/liveEditing.spec.ts
@@ -19,7 +19,7 @@ import { expect, test } from "../../fixtures/testBase";
 // @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
 import { test as base } from "@playwright/test";
 import { ActivateModPage } from "../../pageObjects/extensionConsole/modsPage";
-import { getSidebarPage, isSidebarOpen } from "../../utils";
+import { getSidebarPage, isMsEdge, isSidebarOpen } from "../../utils";
 
 test("live editing behavior", async ({
   page,
@@ -27,7 +27,15 @@ test("live editing behavior", async ({
   modDefinitionsMap,
   newPageEditorPage,
   verifyModDefinitionSnapshot,
+  chromiumChannel,
 }) => {
+  // FIXME: https://github.com/pixiebrix/pixiebrix-extension/issues/9125
+  test.skip(
+    process.env.GITHUB_WORKFLOW === "e2e-test-pre-release-browsers" &&
+      isMsEdge(chromiumChannel),
+    "Skipping test for MS Edge in pre-release workflow",
+  );
+
   await test.step("Activate test mod and navigate to testing site", async () => {
     const modId = "@e2e-testing/page-editor-live-editing-test";
     const activationPage = new ActivateModPage(page, extensionId, modId);

--- a/end-to-end-tests/tests/pageEditor/liveEditing.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/liveEditing.spec.ts
@@ -34,11 +34,10 @@ test("live editing behavior", async ({
   verifyModDefinitionSnapshot,
   chromiumChannel,
 }) => {
-  // FIXME: https://github.com/pixiebrix/pixiebrix-extension/issues/9125
-  test.skip(
+  test.fixme(
     process.env.GITHUB_WORKFLOW === PRE_RELEASE_BROWSER_WORKFLOW_NAME &&
       isMsEdge(chromiumChannel),
-    "Skipping test for MS Edge in pre-release workflow",
+    "Skipping test for MS Edge in pre-release workflow, see https://github.com/pixiebrix/pixiebrix-extension/issues/9125",
   );
 
   await test.step("Activate test mod and navigate to testing site", async () => {

--- a/end-to-end-tests/tests/pageEditor/liveEditing.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/liveEditing.spec.ts
@@ -19,7 +19,12 @@ import { expect, test } from "../../fixtures/testBase";
 // @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
 import { test as base } from "@playwright/test";
 import { ActivateModPage } from "../../pageObjects/extensionConsole/modsPage";
-import { getSidebarPage, isMsEdge, isSidebarOpen } from "../../utils";
+import {
+  getSidebarPage,
+  isMsEdge,
+  isSidebarOpen,
+  PRE_RELEASE_BROWSER_WORKFLOW_NAME,
+} from "../../utils";
 
 test("live editing behavior", async ({
   page,
@@ -31,7 +36,7 @@ test("live editing behavior", async ({
 }) => {
   // FIXME: https://github.com/pixiebrix/pixiebrix-extension/issues/9125
   test.skip(
-    process.env.GITHUB_WORKFLOW === "e2e-test-pre-release-browsers" &&
+    process.env.GITHUB_WORKFLOW === PRE_RELEASE_BROWSER_WORKFLOW_NAME &&
       isMsEdge(chromiumChannel),
     "Skipping test for MS Edge in pre-release workflow",
   );

--- a/end-to-end-tests/tests/regressions/sidebarLinks.spec.ts
+++ b/end-to-end-tests/tests/regressions/sidebarLinks.spec.ts
@@ -86,11 +86,10 @@ test("#8206: clicking links from the sidebar doesn't crash browser", async ({
   chromiumChannel,
   baseURL,
 }) => {
-  // FIXME: https://github.com/pixiebrix/pixiebrix-extension/issues/9125
-  test.skip(
+  test.fixme(
     process.env.GITHUB_WORKFLOW === PRE_RELEASE_BROWSER_WORKFLOW_NAME &&
       isMsEdge(chromiumChannel),
-    "Skipping test for MS Edge in pre-release workflow",
+    "Skipping test for MS Edge in pre-release workflow, see https://github.com/pixiebrix/pixiebrix-extension/issues/9125",
   );
 
   const browserOSName = await getBrowserOs(page);

--- a/end-to-end-tests/tests/regressions/sidebarLinks.spec.ts
+++ b/end-to-end-tests/tests/regressions/sidebarLinks.spec.ts
@@ -29,6 +29,7 @@ import {
   getBrowserOs,
   getSidebarPage,
   isMsEdge,
+  PRE_RELEASE_BROWSER_WORKFLOW_NAME,
 } from "../../utils";
 import { getBaseExtensionConsoleUrl } from "../../pageObjects/constants";
 import { SupportedChannels } from "../../../playwright.config";
@@ -87,7 +88,7 @@ test("#8206: clicking links from the sidebar doesn't crash browser", async ({
 }) => {
   // FIXME: https://github.com/pixiebrix/pixiebrix-extension/issues/9125
   test.skip(
-    process.env.GITHUB_WORKFLOW === "e2e-test-pre-release-browsers" &&
+    process.env.GITHUB_WORKFLOW === PRE_RELEASE_BROWSER_WORKFLOW_NAME &&
       isMsEdge(chromiumChannel),
     "Skipping test for MS Edge in pre-release workflow",
   );

--- a/end-to-end-tests/tests/regressions/sidebarLinks.spec.ts
+++ b/end-to-end-tests/tests/regressions/sidebarLinks.spec.ts
@@ -80,6 +80,19 @@ test("#8206: clicking links from the sidebar doesn't crash browser", async ({
   chromiumChannel,
   baseURL,
 }) => {
+  // FIXME: https://github.com/pixiebrix/pixiebrix-extension/issues/9125
+  // eslint-disable-next-line playwright/no-conditional-in-test -- see above
+  if (
+    // eslint-disable-next-line playwright/no-conditional-in-test -- see above
+    process.env.GITHUB_WORKFLOW === "e2e-test-pre-release-browsers" &&
+    [SupportedChannels.MSEDGE, SupportedChannels.MSEDGE_BETA].includes(
+      chromiumChannel,
+    )
+  ) {
+    test.skip();
+    return;
+  }
+
   const browserOSName = await getBrowserOs(page);
   const modId = "@pixies/test/sidebar-links";
   const modActivationPage = new ActivateModPage(page, extensionId, modId);

--- a/end-to-end-tests/tests/regressions/sidebarLinks.spec.ts
+++ b/end-to-end-tests/tests/regressions/sidebarLinks.spec.ts
@@ -86,15 +86,11 @@ test("#8206: clicking links from the sidebar doesn't crash browser", async ({
   baseURL,
 }) => {
   // FIXME: https://github.com/pixiebrix/pixiebrix-extension/issues/9125
-  // eslint-disable-next-line playwright/no-conditional-in-test -- see above
-  if (
-    // eslint-disable-next-line playwright/no-conditional-in-test -- see above
+  test.skip(
     process.env.GITHUB_WORKFLOW === "e2e-test-pre-release-browsers" &&
-    isMsEdge(chromiumChannel)
-  ) {
-    test.skip();
-    return;
-  }
+      isMsEdge(chromiumChannel),
+    "Skipping test for MS Edge in pre-release workflow",
+  );
 
   const browserOSName = await getBrowserOs(page);
   const modId = "@pixies/test/sidebar-links";

--- a/end-to-end-tests/tests/regressions/sidebarLinks.spec.ts
+++ b/end-to-end-tests/tests/regressions/sidebarLinks.spec.ts
@@ -24,7 +24,12 @@ import {
   // @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
   test as base,
 } from "@playwright/test";
-import { ensureVisibility, getBrowserOs, getSidebarPage } from "../../utils";
+import {
+  ensureVisibility,
+  getBrowserOs,
+  getSidebarPage,
+  isMsEdge,
+} from "../../utils";
 import { getBaseExtensionConsoleUrl } from "../../pageObjects/constants";
 import { SupportedChannels } from "../../../playwright.config";
 
@@ -85,9 +90,7 @@ test("#8206: clicking links from the sidebar doesn't crash browser", async ({
   if (
     // eslint-disable-next-line playwright/no-conditional-in-test -- see above
     process.env.GITHUB_WORKFLOW === "e2e-test-pre-release-browsers" &&
-    [SupportedChannels.MSEDGE, SupportedChannels.MSEDGE_BETA].includes(
-      chromiumChannel,
-    )
+    isMsEdge(chromiumChannel)
   ) {
     test.skip();
     return;
@@ -136,12 +139,7 @@ test("#8206: clicking links from the sidebar doesn't crash browser", async ({
 
   await test.step("Clicking markdown text link", async () => {
     /* eslint-disable playwright/no-conditional-in-test -- msedge and linux bug that causes the sidebar to close on clicking a link */
-    if (
-      browserOSName === "Linux" ||
-      [SupportedChannels.MSEDGE, SupportedChannels.MSEDGE_BETA].includes(
-        chromiumChannel,
-      )
-    ) {
+    if (browserOSName === "Linux" || isMsEdge(chromiumChannel)) {
       sideBarPage = await reopenSidebar(page, extensionId);
     }
     /* eslint-enable playwright/no-conditional-in-test */
@@ -156,12 +154,7 @@ test("#8206: clicking links from the sidebar doesn't crash browser", async ({
 
   await test.step("Clicking react bootstrap link", async () => {
     /* eslint-disable playwright/no-conditional-in-test -- msedge/linux bug */
-    if (
-      browserOSName === "Linux" ||
-      [SupportedChannels.MSEDGE, SupportedChannels.MSEDGE_BETA].includes(
-        chromiumChannel,
-      )
-    ) {
+    if (browserOSName === "Linux" || isMsEdge(chromiumChannel)) {
       sideBarPage = await reopenSidebar(page, extensionId);
     }
     /* eslint-enable playwright/no-conditional-in-test */
@@ -176,12 +169,7 @@ test("#8206: clicking links from the sidebar doesn't crash browser", async ({
 
   await test.step("Clicking html renderer link", async () => {
     /* eslint-disable playwright/no-conditional-in-test -- msedge/linux bug */
-    if (
-      browserOSName === "Linux" ||
-      [SupportedChannels.MSEDGE, SupportedChannels.MSEDGE_BETA].includes(
-        chromiumChannel,
-      )
-    ) {
+    if (browserOSName === "Linux" || isMsEdge(chromiumChannel)) {
       sideBarPage = await reopenSidebar(page, extensionId);
     }
     /* eslint-enable playwright/no-conditional-in-test */
@@ -196,12 +184,7 @@ test("#8206: clicking links from the sidebar doesn't crash browser", async ({
 
   await test.step("Clicking embedded form link", async () => {
     /* eslint-disable playwright/no-conditional-in-test -- msedge/linux bug */
-    if (
-      browserOSName === "Linux" ||
-      [SupportedChannels.MSEDGE, SupportedChannels.MSEDGE_BETA].includes(
-        chromiumChannel,
-      )
-    ) {
+    if (browserOSName === "Linux" || isMsEdge(chromiumChannel)) {
       sideBarPage = await reopenSidebar(page, extensionId);
     }
     /* eslint-enable playwright/no-conditional-in-test */

--- a/end-to-end-tests/tests/regressions/sidebarLinks.spec.ts
+++ b/end-to-end-tests/tests/regressions/sidebarLinks.spec.ts
@@ -32,7 +32,7 @@ import {
   PRE_RELEASE_BROWSER_WORKFLOW_NAME,
 } from "../../utils";
 import { getBaseExtensionConsoleUrl } from "../../pageObjects/constants";
-import { SupportedChannels } from "../../../playwright.config";
+import { type SupportedChannel } from "../../../playwright.config";
 
 async function openSidebar(page: Page, extensionId: string) {
   // The mod contains a trigger to open the sidebar on h1. If the sidePanel is already open, it's a NOP
@@ -57,14 +57,10 @@ async function reopenSidebar(page: Page, extensionId: string) {
 async function clickLinkInSidebarAndWaitForPage(
   context: BrowserContext,
   locator: Locator,
-  chromiumChannel: string,
+  chromiumChannel: SupportedChannel,
 ) {
   const pagePromise = context.waitForEvent("page");
-  if (
-    [SupportedChannels.MSEDGE, SupportedChannels.MSEDGE_BETA].includes(
-      chromiumChannel,
-    )
-  ) {
+  if (isMsEdge(chromiumChannel)) {
     // On MS Edge, opening a new tab closes the sidebar. The click steps fail because MS Edge closes the sidebar when the new tab is opened
     //  Error: locator.click: Target page, context or browser has been closed.
     // Even though it errors, the link is still opened in a new tab.
@@ -116,11 +112,7 @@ test("#8206: clicking links from the sidebar doesn't crash browser", async ({
     );
 
     // eslint-disable-next-line playwright/no-conditional-in-test -- msedge bug
-    if (
-      [SupportedChannels.MSEDGE, SupportedChannels.MSEDGE_BETA].includes(
-        chromiumChannel,
-      )
-    ) {
+    if (isMsEdge(chromiumChannel)) {
       // Another msedge bug causes the browser to fail to open the extension console page from the sidebar until you refresh the page.
       //   "Error: This script should only be loaded in a browser extension."
       await extensionConsolePage.reload();
@@ -197,12 +189,7 @@ test("#8206: clicking links from the sidebar doesn't crash browser", async ({
   // https://github.com/microsoft/MicrosoftEdge-Extensions/issues/145
   // For some reason this also happens in Chrome/Linux in the CI github workflow.
   /* eslint-disable playwright/no-conditional-in-test -- see above comment */
-  if (
-    browserOSName !== "Linux" &&
-    ![SupportedChannels.MSEDGE, SupportedChannels.MSEDGE_BETA].includes(
-      chromiumChannel,
-    )
-  ) {
+  if (browserOSName !== "Linux" && !isMsEdge(chromiumChannel)) {
     await test.step("Clicking link in IFrame", async () => {
       // PixieBrix uses 2 layers of frames to get around the host page CSP. Test page has 2 layers
       const pixiebrixFrame = sideBarPage.frameLocator("iframe").first();

--- a/end-to-end-tests/tests/regressions/welcomeStarterBricks.spec.ts
+++ b/end-to-end-tests/tests/regressions/welcomeStarterBricks.spec.ts
@@ -19,12 +19,20 @@ import { test, expect } from "../../fixtures/testBase";
 // @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
 import { test as base } from "@playwright/test";
 import { ActivateModPage } from "../../pageObjects/extensionConsole/modsPage";
-import { getSidebarPage, runModViaQuickBar } from "../../utils";
+import { getSidebarPage, runModViaQuickBar, isMsEdge } from "../../utils";
 
 test("#8740: can view the starter mods on the pixiebrix.com/welcome page", async ({
   page,
   extensionId,
+  chromiumChannel,
 }) => {
+  // FIXME: https://github.com/pixiebrix/pixiebrix-extension/issues/9125
+  test.skip(
+    process.env.GITHUB_WORKFLOW === "e2e-test-pre-release-browsers" &&
+      isMsEdge(chromiumChannel),
+    "Skipping test for MS Edge in pre-release workflow",
+  );
+
   const modId = "@e2e-testing/open-sidebar-via-quickbar";
   const modActivationPage = new ActivateModPage(page, extensionId, modId);
   await modActivationPage.goto();

--- a/end-to-end-tests/tests/regressions/welcomeStarterBricks.spec.ts
+++ b/end-to-end-tests/tests/regressions/welcomeStarterBricks.spec.ts
@@ -31,11 +31,10 @@ test("#8740: can view the starter mods on the pixiebrix.com/welcome page", async
   extensionId,
   chromiumChannel,
 }) => {
-  // FIXME: https://github.com/pixiebrix/pixiebrix-extension/issues/9125
-  test.skip(
+  test.fixme(
     process.env.GITHUB_WORKFLOW === PRE_RELEASE_BROWSER_WORKFLOW_NAME &&
       isMsEdge(chromiumChannel),
-    "Skipping test for MS Edge in pre-release workflow",
+    "Skipping test for MS Edge in pre-release workflow, see https://github.com/pixiebrix/pixiebrix-extension/issues/9125",
   );
 
   const modId = "@e2e-testing/open-sidebar-via-quickbar";

--- a/end-to-end-tests/tests/regressions/welcomeStarterBricks.spec.ts
+++ b/end-to-end-tests/tests/regressions/welcomeStarterBricks.spec.ts
@@ -19,7 +19,12 @@ import { test, expect } from "../../fixtures/testBase";
 // @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
 import { test as base } from "@playwright/test";
 import { ActivateModPage } from "../../pageObjects/extensionConsole/modsPage";
-import { getSidebarPage, runModViaQuickBar, isMsEdge } from "../../utils";
+import {
+  getSidebarPage,
+  runModViaQuickBar,
+  isMsEdge,
+  PRE_RELEASE_BROWSER_WORKFLOW_NAME,
+} from "../../utils";
 
 test("#8740: can view the starter mods on the pixiebrix.com/welcome page", async ({
   page,
@@ -28,7 +33,7 @@ test("#8740: can view the starter mods on the pixiebrix.com/welcome page", async
 }) => {
   // FIXME: https://github.com/pixiebrix/pixiebrix-extension/issues/9125
   test.skip(
-    process.env.GITHUB_WORKFLOW === "e2e-test-pre-release-browsers" &&
+    process.env.GITHUB_WORKFLOW === PRE_RELEASE_BROWSER_WORKFLOW_NAME &&
       isMsEdge(chromiumChannel),
     "Skipping test for MS Edge in pre-release workflow",
   );

--- a/end-to-end-tests/tests/runtime/sidebar/sidebarAuth.spec.ts
+++ b/end-to-end-tests/tests/runtime/sidebar/sidebarAuth.spec.ts
@@ -20,8 +20,7 @@ import { test, expect } from "../../../fixtures/testBase";
 import { type Page, test as base } from "@playwright/test";
 import { getBaseExtensionConsoleUrl } from "../../../pageObjects/constants";
 import { ActivateModPage } from "../../../pageObjects/extensionConsole/modsPage";
-import { getSidebarPage, runModViaQuickBar } from "../../../utils";
-import { SupportedChannels } from "../../../../playwright.config";
+import { getSidebarPage, isMsEdge, runModViaQuickBar } from "../../../utils";
 
 test("Connect action in partner auth sidebar takes user to the Extension Console", async ({
   page,
@@ -71,11 +70,7 @@ test("Connect action in partner auth sidebar takes user to the Extension Console
   const extensionConsolePage = await consolePagePromise;
 
   // eslint-disable-next-line playwright/no-conditional-in-test -- msedge bug
-  if (
-    [SupportedChannels.MSEDGE, SupportedChannels.MSEDGE_BETA].includes(
-      chromiumChannel,
-    )
-  ) {
+  if (isMsEdge(chromiumChannel)) {
     // Another msedge bug causes the browser to fail to open the extension console page from the sidebar until you refresh the page.
     //   "Error: This script should only be loaded in a browser extension."
     await extensionConsolePage.reload();

--- a/end-to-end-tests/utils.ts
+++ b/end-to-end-tests/utils.ts
@@ -25,6 +25,8 @@ import {
 import { TOTP } from "otpauth";
 import { type SupportedChannel, SupportedChannels } from "../playwright.config";
 
+export const PRE_RELEASE_BROWSER_WORKFLOW_NAME = "Pre-release Browsers";
+
 type AxeResults = Awaited<ReturnType<typeof AxeBuilder.prototype.analyze>>;
 
 function criticalViolationsFromAxeResults(

--- a/end-to-end-tests/utils.ts
+++ b/end-to-end-tests/utils.ts
@@ -248,7 +248,3 @@ export function isChrome(chromiumChannel: SupportedChannel): boolean {
     chromiumChannel,
   );
 }
-
-export function isChromium(chromiumChannel: SupportedChannel): boolean {
-  return chromiumChannel === SupportedChannels.CHROMIUM;
-}

--- a/end-to-end-tests/utils.ts
+++ b/end-to-end-tests/utils.ts
@@ -248,3 +248,7 @@ export function isChrome(chromiumChannel: SupportedChannel): boolean {
     chromiumChannel,
   );
 }
+
+export function isChromium(chromiumChannel: SupportedChannel): boolean {
+  return chromiumChannel === SupportedChannels.CHROMIUM;
+}

--- a/end-to-end-tests/utils.ts
+++ b/end-to-end-tests/utils.ts
@@ -23,6 +23,7 @@ import {
   type BrowserContext,
 } from "@playwright/test";
 import { TOTP } from "otpauth";
+import { type SupportedChannel, SupportedChannels } from "../playwright.config";
 
 type AxeResults = Awaited<ReturnType<typeof AxeBuilder.prototype.analyze>>;
 
@@ -232,4 +233,20 @@ export function generateOTP(secret: string) {
   });
 
   return totp.generate();
+}
+
+export function isMsEdge(chromiumChannel: SupportedChannel): boolean {
+  return [SupportedChannels.MSEDGE, SupportedChannels.MSEDGE_BETA].includes(
+    chromiumChannel,
+  );
+}
+
+export function isChrome(chromiumChannel: SupportedChannel): boolean {
+  return [SupportedChannels.CHROME, SupportedChannels.CHROME_BETA].includes(
+    chromiumChannel,
+  );
+}
+
+export function isChromium(chromiumChannel: SupportedChannel): boolean {
+  return chromiumChannel === SupportedChannels.CHROMIUM;
 }


### PR DESCRIPTION
## What does this PR do?

- Part of #9087
- Temporarily skip the list of tests that are failing on the pre-release browser workflow for some reason. Follow-up ticket to investigate and fix is here: https://github.com/pixiebrix/pixiebrix-extension/issues/9125
