### PR TITLE
fix slack notifications

### DIFF
--- a/.github/workflows/e2e-test-pre-release-browsers.yml
+++ b/.github/workflows/e2e-test-pre-release-browsers.yml
@@ -18,7 +18,7 @@ jobs:
   slack-notification:
     needs: end-to-end-tests
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ job.status == 'failure' }}
     steps:
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
## What does this PR do?

- Only send slack notifications when the pre-release e2e tests fail



For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
