### PR TITLE
#9091: Create user deployment UI

### DIFF
--- a/src/activation/PersonalDeploymentField.tsx
+++ b/src/activation/PersonalDeploymentField.tsx
@@ -19,7 +19,7 @@ import React from "react";
 import BooleanWidget from "@/components/fields/schemaFields/widgets/BooleanWidget";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 
-const SynchronizeBody: React.FunctionComponent = () => (
+const PersonalDeploymentField: React.FunctionComponent = () => (
   <ConnectedFieldTemplate
     name="personalDeployment"
     title="Sync across personal devices"
@@ -29,4 +29,4 @@ const SynchronizeBody: React.FunctionComponent = () => (
   />
 );
 
-export default SynchronizeBody;
+export default PersonalDeploymentField;

--- a/src/activation/SynchronizeBody.tsx
+++ b/src/activation/SynchronizeBody.tsx
@@ -15,9 +15,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-describe("ActivateMultipleModsPanel", () => {
-  // eslint-disable-next-line jest/expect-expect -- Tests are in other files
-  test("tests are in other file", () => {
-    // Tests are in the ActivateModPanel.test.tsx file to avoid duplicate mocking/setup logic
-  });
-});
+import React from "react";
+import BooleanWidget from "@/components/fields/schemaFields/widgets/BooleanWidget";
+import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
+
+const SynchronizeBody: React.FunctionComponent = () => {
+  return (
+    <ConnectedFieldTemplate
+      name="personalDeployment"
+      title="Sync across personal devices"
+      as={BooleanWidget}
+      label="Sync across personal devices"
+      description="Toggle on to sync the mod across all your devices and browser profiles with the PixieBrix extension installed"
+    />
+  );
+};
+
+export default SynchronizeBody;

--- a/src/activation/SynchronizeBody.tsx
+++ b/src/activation/SynchronizeBody.tsx
@@ -19,16 +19,14 @@ import React from "react";
 import BooleanWidget from "@/components/fields/schemaFields/widgets/BooleanWidget";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 
-const SynchronizeBody: React.FunctionComponent = () => {
-  return (
-    <ConnectedFieldTemplate
-      name="personalDeployment"
-      title="Sync across personal devices"
-      as={BooleanWidget}
-      label="Sync across personal devices"
-      description="Toggle on to sync the mod across all your devices and browser profiles with the PixieBrix extension installed"
-    />
-  );
-};
+const SynchronizeBody: React.FunctionComponent = () => (
+  <ConnectedFieldTemplate
+    name="personalDeployment"
+    title="Sync across personal devices"
+    as={BooleanWidget}
+    label="Sync across personal devices"
+    description="Toggle on to sync the mod across all your devices and browser profiles with the PixieBrix extension installed"
+  />
+);
 
 export default SynchronizeBody;

--- a/src/activation/useActivateModWizard.test.tsx
+++ b/src/activation/useActivateModWizard.test.tsx
@@ -16,22 +16,30 @@
  */
 
 import * as redux from "react-redux";
-import useActivateModWizard from "@/activation/useActivateModWizard";
+import useActivateModWizard, {
+  wizardStateFactory,
+} from "@/activation/useActivateModWizard";
 import { renderHook } from "@testing-library/react-hooks";
 import useDatabaseOptions from "@/hooks/useDatabaseOptions";
 import { valueToAsyncState } from "@/utils/asyncStateUtils";
+import * as Yup from "yup";
 
-import { uuidSequence } from "@/testUtils/factories/stringFactories";
+import {
+  autoUUIDSequence,
+  uuidSequence,
+} from "@/testUtils/factories/stringFactories";
 import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { propertiesToSchema } from "@/utils/schemaUtils";
 import { makeDatabasePreviewName } from "@/activation/modOptionsHelpers";
 import { useGetFeatureFlagsQuery } from "@/data/service/api";
 import {
+  FeatureFlags,
   mapRestrictedFeatureToFeatureFlag,
   RestrictedFeatures,
 } from "@/auth/featureFlags";
 import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
 import { BusinessError } from "@/errors/businessErrors";
+import { type RegistryId } from "@/types/registryTypes";
 
 jest.mock("@/components/integrations/AuthWidget", () => {});
 jest.mock("react-redux");
@@ -99,6 +107,25 @@ describe("useActivateModWizard", () => {
 
     const { data: { wizardSteps } = {} } = result.current;
     expect(wizardSteps).toHaveLength(1);
+  });
+
+  test("show synchronize tab when MOD_PERSONAL_SYNC flag is on", () => {
+    const spy = jest.spyOn(redux, "useSelector");
+    spy.mockReturnValue([]);
+
+    jest
+      .mocked(useGetFeatureFlagsQuery)
+      .mockReturnValue(
+        valueToAsyncState([FeatureFlags.MOD_PERSONAL_SYNC]) as any,
+      );
+
+    const { result } = renderHook(() =>
+      useActivateModWizard(defaultModDefinitionFactory()),
+    );
+
+    const { data: { wizardSteps } = {} } = result.current;
+    expect(wizardSteps).toHaveLength(2);
+    expect(wizardSteps?.[0]?.key).toBe("synchronize");
   });
 
   test("sets database preview initial value", async () => {
@@ -188,6 +215,46 @@ describe("useActivateModWizard", () => {
     expect(error).toBeInstanceOf(BusinessError);
     expect((error as BusinessError).message).toBe(
       "Your team's policy does not permit you to activate this mod. Contact your team admin for assistance",
+    );
+  });
+
+  test("validation schema rejects personal deployment with local integrations", () => {
+    const testAuthConfigId = autoUUIDSequence();
+    const { validationSchema } = wizardStateFactory({
+      flagOn: () => true,
+      modDefinition: defaultModDefinitionFactory(),
+      authOptions: [
+        {
+          value: testAuthConfigId,
+          label: "Local Config",
+          local: true,
+          serviceId: "test-integration" as RegistryId,
+          sharingType: "private",
+        },
+      ],
+      defaultAuthOptions: {},
+      databaseOptions: [],
+      activatedModComponents: [],
+      optionsValidationSchema: Yup.object(),
+      initialModOptions: {},
+    });
+
+    const testValues = {
+      modComponents: {},
+      integrationDependencies: [
+        {
+          integrationId: "test-integration",
+          configId: testAuthConfigId,
+          serviceId: "test-integration" as RegistryId,
+          sharingType: "private",
+        },
+      ],
+      optionsArgs: {},
+      personalDeployment: true,
+    };
+
+    expect(() => validationSchema.validateSync(testValues)).toThrow(
+      'Local integrations are not supported for mods with "Sync across devices" enabled',
     );
   });
 });

--- a/src/activation/useActivateModWizard.test.tsx
+++ b/src/activation/useActivateModWizard.test.tsx
@@ -37,6 +37,7 @@ jest.mock("@/components/integrations/AuthWidget", () => {});
 jest.mock("react-redux");
 jest.mock("@/data/service/api", () => ({
   useGetFeatureFlagsQuery: jest.fn(() => valueToAsyncState([])),
+  useGetIntegrationAuthsQuery: jest.fn(() => valueToAsyncState([])),
 }));
 
 jest.mock("@/hooks/useDatabaseOptions", () => ({

--- a/src/activation/useActivateModWizard.ts
+++ b/src/activation/useActivateModWizard.ts
@@ -18,7 +18,7 @@
 import { type WizardStep, type WizardValues } from "@/activation/wizardTypes";
 import { useSelector } from "react-redux";
 import { selectActivatedModComponents } from "@/store/modComponents/modComponentSelectors";
-import type React from "react";
+import React, { useMemo } from "react";
 import { isEmpty, mapValues } from "lodash";
 import OptionsBody from "@/extensionConsole/pages/activateMod/OptionsBody";
 import IntegrationsBody from "@/extensionConsole/pages/activateMod/IntegrationsBody";
@@ -54,7 +54,9 @@ import SynchronizeBody from "@/activation/SynchronizeBody";
 import useFlags from "@/hooks/useFlags";
 import { type FeatureFlag, FeatureFlags } from "@/auth/featureFlags";
 import type { IntegrationDependency } from "@/integrations/integrationTypes";
-import { useAuthOptionsWithEmptyFallback } from "@/hooks/auth";
+import { useAuthOptions } from "@/hooks/auth";
+import { freeze } from "@/utils/objectUtils";
+import { fallbackValue } from "@/utils/asyncStateUtils";
 
 const STEPS: WizardStep[] = [
   { key: "services", label: "Integrations", Component: IntegrationsBody },
@@ -247,7 +249,11 @@ function useActivateModWizard(
 
   const { flagOn } = useFlags();
 
-  const { data: authOptions } = useAuthOptionsWithEmptyFallback();
+  const emptyAuthOptions = useMemo(() => freeze<AuthOption[]>([]), []);
+  const { data: authOptions } = fallbackValue(
+    useAuthOptions(),
+    emptyAuthOptions,
+  );
 
   const policyState = useOrganizationActivationPolicy(modDefinition);
 

--- a/src/activation/useActivateModWizard.ts
+++ b/src/activation/useActivateModWizard.ts
@@ -18,7 +18,7 @@
 import { type WizardStep, type WizardValues } from "@/activation/wizardTypes";
 import { useSelector } from "react-redux";
 import { selectActivatedModComponents } from "@/store/modComponents/modComponentSelectors";
-import React, { useMemo } from "react";
+import React from "react";
 import { isEmpty, mapValues } from "lodash";
 import OptionsBody from "@/extensionConsole/pages/activateMod/OptionsBody";
 import IntegrationsBody from "@/extensionConsole/pages/activateMod/IntegrationsBody";
@@ -237,6 +237,8 @@ export function wizardStateFactory({
   };
 }
 
+const NO_AUTH_OPTIONS = freeze<AuthOption[]>([]);
+
 function useActivateModWizard(
   modDefinition: ModDefinition,
   defaultAuthOptions: Record<RegistryId, AuthOption | null> = {},
@@ -249,10 +251,9 @@ function useActivateModWizard(
 
   const { flagOn } = useFlags();
 
-  const emptyAuthOptions = useMemo(() => freeze<AuthOption[]>([]), []);
   const { data: authOptions } = fallbackValue(
     useAuthOptions(),
-    emptyAuthOptions,
+    NO_AUTH_OPTIONS,
   );
 
   const policyState = useOrganizationActivationPolicy(modDefinition);

--- a/src/activation/useActivateModWizard.ts
+++ b/src/activation/useActivateModWizard.ts
@@ -54,7 +54,7 @@ import SynchronizeBody from "@/activation/SynchronizeBody";
 import useFlags from "@/hooks/useFlags";
 import { type FeatureFlag, FeatureFlags } from "@/auth/featureFlags";
 import type { IntegrationDependency } from "@/integrations/integrationTypes";
-import { useAuthOptions } from "@/hooks/auth";
+import { useAuthOptionsWithEmptyFallback } from "@/hooks/auth";
 
 const STEPS: WizardStep[] = [
   { key: "services", label: "Integrations", Component: IntegrationsBody },
@@ -247,7 +247,7 @@ function useActivateModWizard(
 
   const { flagOn } = useFlags();
 
-  const { data: authOptions } = useAuthOptions();
+  const { data: authOptions } = useAuthOptionsWithEmptyFallback();
 
   const policyState = useOrganizationActivationPolicy(modDefinition);
 

--- a/src/activation/useActivateModWizard.ts
+++ b/src/activation/useActivateModWizard.ts
@@ -50,7 +50,7 @@ import { BusinessError } from "@/errors/businessErrors";
 import useOrganizationActivationPolicy, {
   type OrganizationActivationPolicyResult,
 } from "@/activation/useOrganizationActivationPolicy";
-import SynchronizeBody from "@/activation/SynchronizeBody";
+import PersonalDeploymentField from "@/activation/PersonalDeploymentField";
 import useFlags from "@/hooks/useFlags";
 import { type FeatureFlag, FeatureFlags } from "@/auth/featureFlags";
 import type { IntegrationDependency } from "@/integrations/integrationTypes";
@@ -72,7 +72,7 @@ const STEPS: WizardStep[] = [
   {
     key: "synchronize",
     label: "Synchronize Settings",
-    Component: SynchronizeBody,
+    Component: PersonalDeploymentField,
   },
   { key: "activate", label: "Permissions & URLs", Component: PermissionsBody },
 ];

--- a/src/activation/useActivateModWizard.ts
+++ b/src/activation/useActivateModWizard.ts
@@ -18,7 +18,7 @@
 import { type WizardStep, type WizardValues } from "@/activation/wizardTypes";
 import { useSelector } from "react-redux";
 import { selectActivatedModComponents } from "@/store/modComponents/modComponentSelectors";
-import React from "react";
+import type React from "react";
 import { isEmpty, mapValues } from "lodash";
 import OptionsBody from "@/extensionConsole/pages/activateMod/OptionsBody";
 import IntegrationsBody from "@/extensionConsole/pages/activateMod/IntegrationsBody";

--- a/src/activation/wizardTypes.ts
+++ b/src/activation/wizardTypes.ts
@@ -41,4 +41,9 @@ export type WizardValues = {
 
   // XXX: optionsArgs can contain periods, which will throw off formik
   optionsArgs: Record<string, Primitive>;
+
+  /**
+   * Whether to set up a personal deployment with the mod
+   */
+  personalDeployment?: boolean;
 };

--- a/src/auth/featureFlags.ts
+++ b/src/auth/featureFlags.ts
@@ -123,6 +123,11 @@ export const FeatureFlags = {
    * Support creating new dynamic quickbar starter bricks in the Page Editor.
    */
   PAGE_EDITOR_DYNAMIC_QUICKBAR: "pageeditor-quickbar-provider",
+
+  /**
+   * Enables the mod personal sync feature.
+   */
+  MOD_PERSONAL_SYNC: "mod-personal-sync",
 } as const;
 
 /**

--- a/src/components/fields/schemaFields/integrations/IntegrationDependencyWidget.tsx
+++ b/src/components/fields/schemaFields/integrations/IntegrationDependencyWidget.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/components/fields/schemaFields/integrations/integrationDependencyFieldUtils";
 import { produce } from "immer";
 import { setIn, useField, useFormikContext } from "formik";
-import { useAuthOptions } from "@/hooks/auth";
+import { useAuthOptionsWithEmptyFallback } from "@/hooks/auth";
 import { isEmpty, isEqual, unset } from "lodash";
 import { type SelectWidgetOnChange } from "@/components/form/widgets/SelectWidget";
 import IntegrationAuthSelectWidget from "@/components/fields/schemaFields/integrations/IntegrationAuthSelectWidget";
@@ -37,13 +37,11 @@ import {
 import { type RegistryId } from "@/types/registryTypes";
 import { type SafeString, type UUID } from "@/types/stringTypes";
 import { type IntegrationDependency } from "@/integrations/integrationTypes";
-import { fallbackValue } from "@/utils/asyncStateUtils";
 import { freshIdentifier, makeVariableExpression } from "@/utils/variableUtils";
 import useAsyncEffect from "use-async-effect";
 import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
 import extractIntegrationIdsFromSchema from "@/integrations/util/extractIntegrationIdsFromSchema";
-import { freeze } from "@/utils/objectUtils";
 import { assertNotNullish } from "@/utils/nullishUtils";
 import { type FieldAnnotation } from "@/components/form/FieldAnnotation";
 
@@ -175,8 +173,6 @@ function clearIntegrationSelection(
   return produceExcludeUnusedDependencies(nextState);
 }
 
-const NO_AUTH_OPTIONS = freeze<AuthOption[]>([]);
-
 type SelectedEventPayload = {
   integration_id?: RegistryId;
   is_user_action?: boolean;
@@ -212,10 +208,8 @@ const IntegrationDependencyWidget: React.FC<
   IntegrationDependencyWidgetProps
 > = ({ detectDefault = true, ...props }) => {
   const { schema, isRequired } = props;
-  const { data: authOptions, refetch: refreshOptions } = fallbackValue(
-    useAuthOptions(),
-    NO_AUTH_OPTIONS,
-  );
+  const { data: authOptions, refetch: refreshOptions } =
+    useAuthOptionsWithEmptyFallback();
   const { values: rootValues, setValues: setRootValues } =
     useFormikContext<IntegrationsFormSlice>();
   const [{ value, ...field }, , helpers] =

--- a/src/components/fields/schemaFields/integrations/IntegrationDependencyWidget.tsx
+++ b/src/components/fields/schemaFields/integrations/IntegrationDependencyWidget.tsx
@@ -175,6 +175,8 @@ function clearIntegrationSelection(
   return produceExcludeUnusedDependencies(nextState);
 }
 
+const NO_AUTH_OPTIONS = freeze<AuthOption[]>([]);
+
 type SelectedEventPayload = {
   integration_id?: RegistryId;
   is_user_action?: boolean;
@@ -210,10 +212,10 @@ const IntegrationDependencyWidget: React.FC<
   IntegrationDependencyWidgetProps
 > = ({ detectDefault = true, ...props }) => {
   const { schema, isRequired } = props;
-  const emptyAuthOptions = useMemo(() => freeze<AuthOption[]>([]), []);
+
   const { data: authOptions, refetch: refreshOptions } = fallbackValue(
     useAuthOptions(),
-    emptyAuthOptions,
+    NO_AUTH_OPTIONS,
   );
   const { values: rootValues, setValues: setRootValues } =
     useFormikContext<IntegrationsFormSlice>();

--- a/src/components/fields/schemaFields/integrations/IntegrationDependencyWidget.tsx
+++ b/src/components/fields/schemaFields/integrations/IntegrationDependencyWidget.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/components/fields/schemaFields/integrations/integrationDependencyFieldUtils";
 import { produce } from "immer";
 import { setIn, useField, useFormikContext } from "formik";
-import { useAuthOptionsWithEmptyFallback } from "@/hooks/auth";
+import { useAuthOptions } from "@/hooks/auth";
 import { isEmpty, isEqual, unset } from "lodash";
 import { type SelectWidgetOnChange } from "@/components/form/widgets/SelectWidget";
 import IntegrationAuthSelectWidget from "@/components/fields/schemaFields/integrations/IntegrationAuthSelectWidget";
@@ -44,6 +44,8 @@ import { Events } from "@/telemetry/events";
 import extractIntegrationIdsFromSchema from "@/integrations/util/extractIntegrationIdsFromSchema";
 import { assertNotNullish } from "@/utils/nullishUtils";
 import { type FieldAnnotation } from "@/components/form/FieldAnnotation";
+import { freeze } from "@/utils/objectUtils";
+import { fallbackValue } from "@/utils/asyncStateUtils";
 
 export type IntegrationDependencyWidgetProps = SchemaFieldProps & {
   /** Set the value of the field on mount to the integration auth already selected, or the only available credential (default=true) */
@@ -208,8 +210,11 @@ const IntegrationDependencyWidget: React.FC<
   IntegrationDependencyWidgetProps
 > = ({ detectDefault = true, ...props }) => {
   const { schema, isRequired } = props;
-  const { data: authOptions, refetch: refreshOptions } =
-    useAuthOptionsWithEmptyFallback();
+  const emptyAuthOptions = useMemo(() => freeze<AuthOption[]>([]), []);
+  const { data: authOptions, refetch: refreshOptions } = fallbackValue(
+    useAuthOptions(),
+    emptyAuthOptions,
+  );
   const { values: rootValues, setValues: setRootValues } =
     useFormikContext<IntegrationsFormSlice>();
   const [{ value, ...field }, , helpers] =

--- a/src/extensionConsole/pages/activateMod/ActivateModPage.test.tsx
+++ b/src/extensionConsole/pages/activateMod/ActivateModPage.test.tsx
@@ -18,7 +18,7 @@
 import React from "react";
 import { render } from "@/extensionConsole/testHelpers";
 import { waitForEffect } from "@/testUtils/testHelpers";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
 import { type RegistryId } from "@/types/registryTypes";
 import userEvent from "@testing-library/user-event";
@@ -159,16 +159,18 @@ describe("ActivateModDefinitionPage", () => {
     await waitForEffect();
     expect(asFragment()).toMatchSnapshot();
     await userEvent.click(screen.getByText("Activate"));
-    await waitForEffect();
-    expect(activateModCallbackMock).toHaveBeenCalledWith(
-      {
-        modComponents: { "0": true },
-        optionsArgs: {},
-        integrationDependencies: [],
-        personalDeployment: false,
-      },
-      modDefinition,
-    );
+
+    await waitFor(() => {
+      expect(activateModCallbackMock).toHaveBeenCalledWith(
+        {
+          modComponents: { "0": true },
+          optionsArgs: {},
+          integrationDependencies: [],
+          personalDeployment: false,
+        },
+        modDefinition,
+      );
+    });
   });
 
   test("activate mod with personal deployment enabled", async () => {
@@ -200,17 +202,18 @@ describe("ActivateModDefinitionPage", () => {
     await userEvent.click(container.querySelector(".switch")!);
 
     await userEvent.click(screen.getByText("Activate"));
-    await waitForEffect();
 
-    expect(activateModCallbackMock).toHaveBeenCalledWith(
-      {
-        modComponents: { "0": true },
-        optionsArgs: {},
-        integrationDependencies: [],
-        personalDeployment: true,
-      },
-      modDefinition,
-    );
+    await waitFor(() => {
+      expect(activateModCallbackMock).toHaveBeenCalledWith(
+        {
+          modComponents: { "0": true },
+          optionsArgs: {},
+          integrationDependencies: [],
+          personalDeployment: true,
+        },
+        modDefinition,
+      );
+    });
   });
 
   test("user reject permissions", async () => {
@@ -235,11 +238,10 @@ describe("ActivateModDefinitionPage", () => {
     render(<ActivateModDefinitionPageWrapper />);
     await waitForEffect();
     await userEvent.click(screen.getByText("Activate"));
-    await waitForEffect();
 
-    expect(
-      screen.getByText("You must accept browser permissions to activate"),
-    ).toBeVisible();
+    await expect(
+      screen.findByText("You must accept browser permissions to activate"),
+    ).resolves.toBeVisible();
   });
 
   test("renders instructions", async () => {
@@ -253,9 +255,10 @@ describe("ActivateModDefinitionPage", () => {
     setupMod(mod);
     const { asFragment } = render(<ActivateModDefinitionPageWrapper />);
 
-    await waitForEffect();
+    await expect(
+      screen.findByText("These are some instructions"),
+    ).resolves.toBeVisible();
 
-    expect(screen.getByText("These are some instructions")).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/src/extensionConsole/pages/activateMod/ActivateModPage.test.tsx
+++ b/src/extensionConsole/pages/activateMod/ActivateModPage.test.tsx
@@ -168,6 +168,7 @@ describe("ActivateModDefinitionPage", () => {
         modComponents: { "0": true },
         optionsArgs: {},
         integrationDependencies: [],
+        personalDeployment: false,
       },
       modDefinition,
     );

--- a/src/extensionConsole/pages/activateMod/ActivateModPage.test.tsx
+++ b/src/extensionConsole/pages/activateMod/ActivateModPage.test.tsx
@@ -18,7 +18,7 @@
 import React from "react";
 import { render } from "@/extensionConsole/testHelpers";
 import { waitForEffect } from "@/testUtils/testHelpers";
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
 import { type RegistryId } from "@/types/registryTypes";
 import userEvent from "@testing-library/user-event";
@@ -192,11 +192,9 @@ describe("ActivateModDefinitionPage", () => {
 
     const { container } = render(<ActivateModDefinitionPageWrapper />);
 
-    await waitForEffect();
-
-    await waitFor(() => {
-      expect(screen.getByText("Synchronize Settings")).toBeInTheDocument();
-    });
+    await expect(
+      screen.findByText("Synchronize Settings"),
+    ).resolves.toBeInTheDocument();
 
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- Boolean Widget needs a better selector
     await userEvent.click(container.querySelector(".switch")!);

--- a/src/extensionConsole/pages/activateMod/ActivateModPage.test.tsx
+++ b/src/extensionConsole/pages/activateMod/ActivateModPage.test.tsx
@@ -24,7 +24,7 @@ import { type RegistryId } from "@/types/registryTypes";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
-import { appApiMock } from "@/testUtils/appApiMock";
+import { appApiMock, mockAllApiEndpoints } from "@/testUtils/appApiMock";
 import { validateRegistryId } from "@/types/helpers";
 import { type RetrieveRecipeResponse } from "@/types/contract";
 import {
@@ -69,12 +69,8 @@ function setupMod(modDefinition: ModDefinition) {
     },
   };
 
-  appApiMock
-    .onGet(API_PATHS.MOD(testModId))
-    .reply(200, modResponse)
-    // Databases, organizations, etc.
-    .onGet()
-    .reply(200, []);
+  appApiMock.onGet(API_PATHS.MOD(testModId)).reply(200, modResponse);
+  mockAllApiEndpoints();
 }
 
 beforeEach(() => {

--- a/src/extensionConsole/pages/activateMod/IntegrationsBody.tsx
+++ b/src/extensionConsole/pages/activateMod/IntegrationsBody.tsx
@@ -23,19 +23,16 @@ import { type ModDefinition } from "@/types/modDefinitionTypes";
 import AuthWidget from "@/components/integrations/AuthWidget";
 import IntegrationDescriptor from "@/extensionConsole/pages/activateMod/IntegrationDescriptor";
 import { useField } from "formik";
-import { useAuthOptions } from "@/hooks/auth";
+import { useAuthOptionsWithEmptyFallback } from "@/hooks/auth";
 import { useGetIntegrationsQuery } from "@/data/service/api";
 import ServiceFieldError from "@/extensionConsole/components/ServiceFieldError";
 import FieldAnnotationAlert from "@/components/annotationAlert/FieldAnnotationAlert";
 import { AnnotationType } from "@/types/annotationTypes";
-import { fallbackValue } from "@/utils/asyncStateUtils";
-import { type AuthOption } from "@/auth/authTypes";
 import { isEmpty } from "lodash";
 import { type RegistryId } from "@/types/registryTypes";
 import { joinName } from "@/utils/formUtils";
 import { type IntegrationDependency } from "@/integrations/integrationTypes";
 import getModDefinitionIntegrationIds from "@/integrations/util/getModDefinitionIntegrationIds";
-import { freeze } from "@/utils/objectUtils";
 import { assertNotNullish } from "@/utils/nullishUtils";
 
 interface OwnProps {
@@ -50,17 +47,13 @@ type ValueField = {
   isOptional?: boolean;
 };
 
-const EMPTY_AUTH_OPTIONS = freeze<AuthOption[]>([]);
-
 const IntegrationsBody: React.FunctionComponent<OwnProps> = ({
   mod,
   hideBuiltInIntegrations,
   showOwnTitle,
 }) => {
-  const { data: authOptions, refetch: refreshAuthOptions } = fallbackValue(
-    useAuthOptions(),
-    EMPTY_AUTH_OPTIONS,
-  );
+  const { data: authOptions, refetch: refreshAuthOptions } =
+    useAuthOptionsWithEmptyFallback();
   assertNotNullish(authOptions, "authOptions must be defined");
   const [
     integrationDependenciesField,

--- a/src/extensionConsole/pages/activateMod/IntegrationsBody.tsx
+++ b/src/extensionConsole/pages/activateMod/IntegrationsBody.tsx
@@ -38,6 +38,8 @@ import { freeze } from "@/utils/objectUtils";
 import type { AuthOption } from "@/auth/authTypes";
 import { fallbackValue } from "@/utils/asyncStateUtils";
 
+const NO_AUTH_OPTIONS = freeze<AuthOption[]>([]);
+
 interface OwnProps {
   mod: ModDefinition;
   hideBuiltInIntegrations?: boolean;
@@ -55,10 +57,9 @@ const IntegrationsBody: React.FunctionComponent<OwnProps> = ({
   hideBuiltInIntegrations,
   showOwnTitle,
 }) => {
-  const emptyAuthOptions = useMemo(() => freeze<AuthOption[]>([]), []);
   const { data: authOptions, refetch: refreshAuthOptions } = fallbackValue(
     useAuthOptions(),
-    emptyAuthOptions,
+    NO_AUTH_OPTIONS,
   );
   assertNotNullish(authOptions, "authOptions must be defined");
   const [

--- a/src/extensionConsole/pages/activateMod/IntegrationsBody.tsx
+++ b/src/extensionConsole/pages/activateMod/IntegrationsBody.tsx
@@ -23,7 +23,7 @@ import { type ModDefinition } from "@/types/modDefinitionTypes";
 import AuthWidget from "@/components/integrations/AuthWidget";
 import IntegrationDescriptor from "@/extensionConsole/pages/activateMod/IntegrationDescriptor";
 import { useField } from "formik";
-import { useAuthOptionsWithEmptyFallback } from "@/hooks/auth";
+import { useAuthOptions } from "@/hooks/auth";
 import { useGetIntegrationsQuery } from "@/data/service/api";
 import ServiceFieldError from "@/extensionConsole/components/ServiceFieldError";
 import FieldAnnotationAlert from "@/components/annotationAlert/FieldAnnotationAlert";
@@ -34,6 +34,9 @@ import { joinName } from "@/utils/formUtils";
 import { type IntegrationDependency } from "@/integrations/integrationTypes";
 import getModDefinitionIntegrationIds from "@/integrations/util/getModDefinitionIntegrationIds";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import { freeze } from "@/utils/objectUtils";
+import type { AuthOption } from "@/auth/authTypes";
+import { fallbackValue } from "@/utils/asyncStateUtils";
 
 interface OwnProps {
   mod: ModDefinition;
@@ -52,8 +55,11 @@ const IntegrationsBody: React.FunctionComponent<OwnProps> = ({
   hideBuiltInIntegrations,
   showOwnTitle,
 }) => {
-  const { data: authOptions, refetch: refreshAuthOptions } =
-    useAuthOptionsWithEmptyFallback();
+  const emptyAuthOptions = useMemo(() => freeze<AuthOption[]>([]), []);
+  const { data: authOptions, refetch: refreshAuthOptions } = fallbackValue(
+    useAuthOptions(),
+    emptyAuthOptions,
+  );
   assertNotNullish(authOptions, "authOptions must be defined");
   const [
     integrationDependenciesField,

--- a/src/extensionConsole/pages/activateMod/__snapshots__/ActivateModPage.test.tsx.snap
+++ b/src/extensionConsole/pages/activateMod/__snapshots__/ActivateModPage.test.tsx.snap
@@ -732,7 +732,7 @@ exports[`ActivateModDefinitionPage renders instructions 1`] = `
               <h3
                 class="page-title"
               >
-                Activate Mod 6
+                Activate Mod 7
               </h3>
               <div
                 class="page-documentation"
@@ -813,12 +813,12 @@ exports[`ActivateModDefinitionPage renders instructions 1`] = `
                   <div
                     class="card-title h5"
                   >
-                    Mod 6
+                    Mod 7
                   </div>
                   <code
                     class="packageId"
                   >
-                    test/mod-6
+                    test/mod-7
                   </code>
                 </span>
               </div>

--- a/src/hooks/auth.test.ts
+++ b/src/hooks/auth.test.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { waitFor } from "@testing-library/react";
+import { useAuthOptions } from "./auth";
+import * as readRawConfigurationsModule from "@/integrations/util/readRawConfigurations";
+import { useGetIntegrationAuthsQuery } from "@/data/service/api";
+import { renderHook } from "@testing-library/react-hooks";
+import { IntegrationConfig } from "@/integrations/integrationTypes";
+
+// Mock the modules
+jest.mock("@/integrations/util/readRawConfigurations");
+jest.mock("@/data/service/api");
+
+describe("useAuthOptions", () => {
+  const mockLocalConfigs: IntegrationConfig[] = [
+    {
+      _rawIntegrationConfigBrand: null,
+      id: "local1",
+      label: "Local Config 1",
+      integrationId: "service1",
+    },
+    {
+      _rawIntegrationConfigBrand: null,
+      id: "local2",
+      label: "Local Config 2",
+      integrationId: "service2",
+    },
+  ];
+
+  const mockRemoteConfigs = [
+    {
+      id: "remote1",
+      label: "Remote Config 1",
+      service: { config: { metadata: { id: "service1" } } },
+      user: "user1",
+    },
+    {
+      id: "remote2",
+      label: "Remote Config 2",
+      service: { config: { metadata: { id: "service2" } } },
+      organization: { name: "Org 1" },
+    },
+    {
+      id: "remote3",
+      label: "",
+      service: { config: { metadata: { id: "service3" } } },
+    },
+  ];
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest
+      .mocked(readRawConfigurationsModule.readRawConfigurations)
+      .mockResolvedValue(mockLocalConfigs);
+    jest.mocked(useGetIntegrationAuthsQuery).mockReturnValue({
+      data: mockRemoteConfigs,
+      currentData: mockRemoteConfigs,
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      isUninitialized: false,
+      isFetching: false,
+    });
+  });
+
+  it("should return the correct auth options", async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useAuthOptions());
+
+    // Wait for the hook to finish its asynchronous operations
+    await waitForNextUpdate();
+
+    // Use waitFor to ensure the data is available before assertions
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined();
+    });
+
+    expect(result.current.data).toEqual([
+      {
+        value: "local1",
+        label: "Local Config 1 — Private Local",
+        local: true,
+        serviceId: "service1",
+        sharingType: "private",
+      },
+      {
+        value: "local2",
+        label: "Local Config 2 — Private Local",
+        local: true,
+        serviceId: "service2",
+        sharingType: "private",
+      },
+      {
+        value: "remote1",
+        label: "Remote Config 1 — Private",
+        local: false,
+        user: "user1",
+        serviceId: "service1",
+        sharingType: "private",
+      },
+      {
+        value: "remote3",
+        label: "Default — ✨ Built-in",
+        local: false,
+        user: undefined,
+        serviceId: "service3",
+        sharingType: "built-in",
+      },
+      {
+        value: "remote2",
+        label: "Remote Config 2 — Org 1",
+        local: false,
+        user: undefined,
+        serviceId: "service2",
+        sharingType: "shared",
+      },
+    ]);
+  });
+
+  it("should handle loading state", () => {
+    jest.mocked(useGetIntegrationAuthsQuery).mockReturnValue({
+      isLoading: true,
+    });
+
+    const { result } = renderHook(() => useAuthOptions());
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("should handle error state", () => {
+    jest.mocked(useGetIntegrationAuthsQuery).mockReturnValue({
+      isError: true,
+      error: new Error("Test error"),
+    });
+
+    const { result } = renderHook(() => useAuthOptions());
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.error).toEqual(new Error("Test error"));
+  });
+});

--- a/src/hooks/auth.test.ts
+++ b/src/hooks/auth.test.ts
@@ -83,12 +83,8 @@ describe("useAuthOptions", () => {
   });
 
   it("should return the correct auth options", async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useAuthOptions());
+    const { result } = renderHook(() => useAuthOptions());
 
-    // Wait for the hook to finish its asynchronous operations
-    await waitForNextUpdate();
-
-    // Use waitFor to ensure the data is available before assertions
     await waitFor(() => {
       expect(result.current.data).toBeDefined();
     });

--- a/src/hooks/auth.test.ts
+++ b/src/hooks/auth.test.ts
@@ -20,9 +20,10 @@ import { useAuthOptions } from "./auth";
 import * as readRawConfigurationsModule from "@/integrations/util/readRawConfigurations";
 import { useGetIntegrationAuthsQuery } from "@/data/service/api";
 import { renderHook } from "@testing-library/react-hooks";
-import { IntegrationConfig } from "@/integrations/integrationTypes";
+import { type IntegrationConfig } from "@/integrations/integrationTypes";
+import { type UUID } from "@/types/stringTypes";
+import { type RegistryId } from "@/types/registryTypes";
 
-// Mock the modules
 jest.mock("@/integrations/util/readRawConfigurations");
 jest.mock("@/data/service/api");
 
@@ -30,15 +31,17 @@ describe("useAuthOptions", () => {
   const mockLocalConfigs: IntegrationConfig[] = [
     {
       _rawIntegrationConfigBrand: null,
-      id: "local1",
+      id: "local1" as UUID,
       label: "Local Config 1",
-      integrationId: "service1",
+      integrationId: "service1" as RegistryId,
+      config: { _integrationConfigBrand: null },
     },
     {
       _rawIntegrationConfigBrand: null,
-      id: "local2",
+      id: "local2" as UUID,
       label: "Local Config 2",
-      integrationId: "service2",
+      integrationId: "service2" as RegistryId,
+      config: { _integrationConfigBrand: null },
     },
   ];
 
@@ -75,6 +78,7 @@ describe("useAuthOptions", () => {
       isSuccess: true,
       isUninitialized: false,
       isFetching: false,
+      refetch: jest.fn(),
     });
   });
 
@@ -134,6 +138,7 @@ describe("useAuthOptions", () => {
   it("should handle loading state", () => {
     jest.mocked(useGetIntegrationAuthsQuery).mockReturnValue({
       isLoading: true,
+      refetch: jest.fn(),
     });
 
     const { result } = renderHook(() => useAuthOptions());
@@ -145,6 +150,7 @@ describe("useAuthOptions", () => {
     jest.mocked(useGetIntegrationAuthsQuery).mockReturnValue({
       isError: true,
       error: new Error("Test error"),
+      refetch: jest.fn(),
     });
 
     const { result } = renderHook(() => useAuthOptions());

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -28,8 +28,6 @@ import { useGetIntegrationAuthsQuery } from "@/data/service/api";
 import getModDefinitionIntegrationIds from "@/integrations/util/getModDefinitionIntegrationIds";
 import { type Nullishable } from "@/utils/nullishUtils";
 import { readRawConfigurations } from "@/integrations/util/readRawConfigurations";
-import { fallbackValue } from "@/utils/asyncStateUtils";
-import { freeze } from "@/utils/objectUtils";
 
 function defaultLabel(label: Nullishable<string>): string {
   const normalized = (label ?? "").trim();

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -74,7 +74,7 @@ function mapConfigurationsToOptions(
   const localOptions = sortBy(
     locationIntegrationConfigs.map((integrationConfig) => ({
       value: integrationConfig.id,
-      label: `${defaultLabel(integrationConfig.label)} — Private`,
+      label: `${defaultLabel(integrationConfig.label)} — Private Local`,
       local: true,
       serviceId: integrationConfig.integrationId,
       sharingType: "private" as AuthSharing,

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -28,6 +28,8 @@ import { useGetIntegrationAuthsQuery } from "@/data/service/api";
 import getModDefinitionIntegrationIds from "@/integrations/util/getModDefinitionIntegrationIds";
 import { type Nullishable } from "@/utils/nullishUtils";
 import { readRawConfigurations } from "@/integrations/util/readRawConfigurations";
+import { fallbackValue } from "@/utils/asyncStateUtils";
+import { freeze } from "@/utils/objectUtils";
 
 function defaultLabel(label: Nullishable<string>): string {
   const normalized = (label ?? "").trim();
@@ -96,6 +98,11 @@ function mapConfigurationsToOptions(
   );
 
   return [...localOptions, ...sharedOptions];
+}
+
+const EMPTY_AUTH_OPTIONS = freeze<AuthOption[]>([]);
+export function useAuthOptionsWithEmptyFallback() {
+  return fallbackValue(useAuthOptions(), EMPTY_AUTH_OPTIONS);
 }
 
 /**

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -100,11 +100,6 @@ function mapConfigurationsToOptions(
   return [...localOptions, ...sharedOptions];
 }
 
-const EMPTY_AUTH_OPTIONS = freeze<AuthOption[]>([]);
-export function useAuthOptionsWithEmptyFallback() {
-  return fallbackValue(useAuthOptions(), EMPTY_AUTH_OPTIONS);
-}
-
 /**
  * Return available integration configuration options suitable for display in a react-select dropdown.
  */

--- a/src/sidebar/activateMod/ActivateMultipleModsPanel.tsx
+++ b/src/sidebar/activateMod/ActivateMultipleModsPanel.tsx
@@ -33,6 +33,7 @@ import useActivateMod, {
 import { SuccessPanel } from "@/sidebar/activateMod/ActivateModPanel";
 import sidebarSlice from "@/store/sidebar/sidebarSlice";
 import type { ModActivationConfig } from "@/types/modTypes";
+import useFlags from "@/hooks/useFlags";
 
 type ModResultPair = {
   mod: RequiredModDefinition;
@@ -77,6 +78,7 @@ const AutoActivatePanel: React.FC<{ mods: RequiredModDefinition[] }> = ({
   const newMods = useMemo(() => mods.filter((x) => !x.isActive), [mods]);
   const activatedModComponents = useSelector(selectActivatedModComponents);
   const databaseOptionsState = useDatabaseOptions({ refetchOnMount: true });
+  const { flagOn } = useFlags();
 
   // A bit hacky -- using useDeriveAsyncState to automatically activate the mods on mount
   const activationResultState = useDeriveAsyncState(
@@ -95,6 +97,7 @@ const AutoActivatePanel: React.FC<{ mods: RequiredModDefinition[] }> = ({
           );
 
           const wizard = wizardStateFactory({
+            flagOn,
             modDefinition: mod.modDefinition,
             defaultAuthOptions: mod.defaultAuthOptions,
             databaseOptions,

--- a/src/testUtils/appApiMock.ts
+++ b/src/testUtils/appApiMock.ts
@@ -29,6 +29,8 @@ export const appApiMock = new MockAdapter(axios);
 
 /**
  * Mock all API endpoints to return empty responses.
+ * Make sure that this is the last rule applied to the appApiMock, as it will match all requests.
+ * Any subsequent mocks will be ignored if they are added after this one.
  */
 export function mockAllApiEndpoints() {
   // Ideally we could do this automatically, but rules provided to appApiMock are evaluated in order. So we can't


### PR DESCRIPTION
## What does this PR do?

- Part of #9091
- This set of changes includes the UI for the new personal synchronize settings section in the mod activation page
- Includes feature flag gating
- Includes validation to display an error if the user attempts to activate with a local integration selected
- No actual functionality to create the personal deployment, just focusing on the UI and that the form state is correct in this change

## Discussion

- wizardStateFactory is getting a bit unwieldy with this change adding two new prop arguments. Is now a good time to consider refactoring? 

## Demo

![Screenshot 2024-09-11 at 10 13 36 AM](https://github.com/user-attachments/assets/10d401da-977d-4b04-9bb5-fb7f5f2413f4)
![Screenshot 2024-09-11 at 10 17 08 AM](https://github.com/user-attachments/assets/5d450f59-f8c0-4986-a10e-7e8aa5767c8f)


## Future Work

- Actually making the API request to the backend to create the personal deployment when this option is true.
- UI for the sidebar mod panel activation (not done in this PR)

## Checklist

_Leave all that are relevant and check off as completed_

- [ ] This PR requires a security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [X] This PR requires a feature flag
- [ ] This PR requires a environment variable change
- [X] Added jest or playwright tests and/or storybook stories

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
