### PR TITLE
precommit eslint hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: prettier # only run the prettier hook since eslint is already run in the lint job
 
   end-to-end-tests:
     name: end-to-end-tests
@@ -196,7 +198,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: end-to-end-tests
-    # Allow depndabot to append the comment to the PR
+    # Allow dependabot to append the comment to the PR
     permissions:
       pull-requests: write
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,10 @@ repos:
     rev: v3.1.0
     hooks:
       - id: prettier
+  - repo: local
+    hooks:
+      - id: eslint
+        name: eslint
+        entry: npm run lint:staged --
+        language: node
+        files: \.js$|\.jsx$|\.ts$|\.tsx$

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 191
+        "line_number": 193
       }
     ],
     ".github/workflows/e2e-test-pre-release-browsers.yml": [
@@ -273,5 +273,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-29T16:58:02Z"
+  "generated_at": "2024-09-12T00:15:02Z"
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "npm run lint:full -- --rule '{\"import/no-cycle\": \"off\"}'",
     "lint:fast": "ESLINT_NO_IMPORTS=1 eslint src --ext js,jsx,ts,tsx --quiet",
     "lint:full": "eslint src end-to-end-tests --ext js,jsx,ts,tsx --quiet --report-unused-disable-directives",
+    "lint:staged": "eslint --ext js,jsx,ts,tsx --fix --quiet --report-unused-disable-directives",
     "fix": "npm run lint -- --fix",
     "watch": "concurrently npm:watch:webpack 'npm:watch:*(!webpack) -- --preserveWatchOutput' -r",
     "watch:webpack": "ENV_FILE='.env.development' webpack ${HMR:-watch} --mode development",


### PR DESCRIPTION
## What does this PR do?

I keep forgetting to run eslint before pushing up my commits and then fix them after realizing they failed the PR CI. Let's catch eslint errors at precommit by checking the staged files.

Linting a few staged files takes about 8 seconds, which I think is worth the cost.