### PR TITLE
Allow AsyncButton to accept a ref

### DIFF
--- a/src/components/AsyncButton.tsx
+++ b/src/components/AsyncButton.tsx
@@ -28,51 +28,59 @@ export type AsyncButtonProps = ButtonProps & {
   ariaLabel?: string;
 };
 
-const AsyncButton: React.FunctionComponent<AsyncButtonProps> = ({
-  ariaLabel,
-  onClick,
-  children,
-  disabled: manualDisabled = false,
-  ...buttonProps
-}) => {
-  const mounted = useRef(false);
-  const [pending, setPending] = useState(false);
-
-  useEffect(() => {
-    // https://stackoverflow.com/a/66555159/402560
-    mounted.current = true;
-    return () => {
-      mounted.current = false;
-    };
-  }, []);
-
-  const handleClick = useCallback(
-    async (event: React.MouseEvent) => {
-      setPending(true);
-      try {
-        await onClick(event);
-      } finally {
-        if (mounted.current) {
-          setPending(false);
-        }
-      }
+const AsyncButton = React.forwardRef<HTMLButtonElement, AsyncButtonProps>(
+  (
+    {
+      ariaLabel,
+      onClick,
+      children,
+      disabled: manualDisabled = false,
+      ...buttonProps
     },
-    [onClick],
-  );
+    ref,
+  ) => {
+    const mounted = useRef(false);
+    const [pending, setPending] = useState(false);
 
-  return (
-    <Button
-      aria-label={ariaLabel}
-      disabled={manualDisabled || pending}
-      {...buttonProps}
-      onClick={(event) => {
-        event.stopPropagation();
-        void handleClick(event);
-      }}
-    >
-      {children}
-    </Button>
-  );
-};
+    useEffect(() => {
+      // https://stackoverflow.com/a/66555159/402560
+      mounted.current = true;
+      return () => {
+        mounted.current = false;
+      };
+    }, []);
+
+    const handleClick = useCallback(
+      async (event: React.MouseEvent) => {
+        setPending(true);
+        try {
+          await onClick(event);
+        } finally {
+          if (mounted.current) {
+            setPending(false);
+          }
+        }
+      },
+      [onClick],
+    );
+
+    return (
+      <Button
+        ref={ref}
+        aria-label={ariaLabel}
+        disabled={manualDisabled || pending}
+        {...buttonProps}
+        onClick={(event) => {
+          event.stopPropagation();
+          void handleClick(event);
+        }}
+      >
+        {children}
+      </Button>
+    );
+  },
+);
+
+AsyncButton.displayName = "AsyncButton";
 
 export default AsyncButton;


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-app/issues/5766

## Discussion

- Need to be able to use AsyncButton in the TrialAwareComponent button in App to support prevent admins of expired teams deleting the expired team
- The TrialAwareComponent needs to be able to pass a ref to the AsyncButton


For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
