### PR TITLE
#9150 Introduce SandboxInjectionError and increase sandbox timeouts to 5s

### DIFF
--- a/src/sandbox/messenger/api.ts
+++ b/src/sandbox/messenger/api.ts
@@ -17,7 +17,10 @@
 
 /** @file It doesn't actually use the Messenger but this file tries to replicate the pattern */
 
-import injectIframe, { hiddenIframeStyle } from "@/utils/injectIframe";
+import injectIframe, {
+  hiddenIframeStyle,
+  SandboxInjectionError,
+} from "@/utils/injectIframe";
 import postMessage, { type Payload } from "@/utils/postMessage";
 import pMemoize, { pMemoizeClear } from "p-memoize";
 import { memoizeUntilSettled } from "@/utils/promiseUtils";
@@ -74,7 +77,9 @@ async function postSandboxMessage<TReturn extends Payload = Payload>({
         }),
       {
         retries: 3,
-        shouldRetry: (error) => isSpecificError(error, TimeoutError),
+        shouldRetry: (error) =>
+          isSpecificError(error, TimeoutError) ||
+          isSpecificError(error, SandboxInjectionError),
         onFailedAttempt(error) {
           console.warn(
             `Failed to send message ${type} to sandbox. Retrying... Attempt ${error.attemptNumber}`,

--- a/src/sandbox/messenger/api.ts
+++ b/src/sandbox/messenger/api.ts
@@ -30,6 +30,7 @@ import { TimeoutError } from "p-timeout";
 import { isSpecificError } from "@/errors/errorHelpers";
 
 const SANDBOX_SHADOW_ROOT_ID = "pixiebrix-sandbox";
+const MAX_RETRIES = 3;
 
 const loadSandbox = pMemoize(async () =>
   injectIframe(
@@ -75,7 +76,7 @@ async function postSandboxMessage<TReturn extends Payload = Payload>({
           type,
         }),
       {
-        retries: 3,
+        retries: MAX_RETRIES,
         shouldRetry: (error) =>
           isSpecificError(error, TimeoutError) ||
           isSpecificError(error, SandboxInjectionError),
@@ -87,7 +88,10 @@ async function postSandboxMessage<TReturn extends Payload = Payload>({
       },
     );
   } catch (error) {
-    if (isSpecificError(error, TimeoutError)) {
+    if (
+      isSpecificError(error, TimeoutError) ||
+      isSpecificError(error, SandboxInjectionError)
+    ) {
       throw new Error(
         `Failed to send message ${type} to sandbox. The host page may be preventing the sandbox from loading.`,
         {

--- a/src/sandbox/messenger/api.ts
+++ b/src/sandbox/messenger/api.ts
@@ -40,7 +40,7 @@ const loadSandbox = pMemoize(async () =>
 );
 
 const getSandbox = memoizeUntilSettled(async () => {
-  let sandbox = await loadSandbox();
+  const sandbox = await loadSandbox();
   const isSandboxWrapperInDom = document.querySelector(
     `#${SANDBOX_SHADOW_ROOT_ID}`,
   );
@@ -52,9 +52,8 @@ const getSandbox = memoizeUntilSettled(async () => {
       type: "SANDBOX_PING",
     });
   } else {
-    console.warn("Sandbox iframe was removed from the DOM. Reinjecting...");
     pMemoizeClear(loadSandbox);
-    sandbox = await loadSandbox();
+    throw new SandboxInjectionError("Sandbox iframe was removed from the DOM.");
   }
 
   return sandbox.contentWindow;

--- a/src/sandbox/messenger/api.ts
+++ b/src/sandbox/messenger/api.ts
@@ -19,7 +19,7 @@
 
 import injectIframe, {
   hiddenIframeStyle,
-  SandboxInjectionError,
+  IframeInjectionError,
 } from "@/utils/injectIframe";
 import postMessage, { type Payload } from "@/utils/postMessage";
 import pMemoize, { pMemoizeClear } from "p-memoize";
@@ -54,7 +54,7 @@ const getSandbox = memoizeUntilSettled(async () => {
     });
   } else {
     pMemoizeClear(loadSandbox);
-    throw new SandboxInjectionError("Sandbox iframe was removed from the DOM.");
+    throw new IframeInjectionError("Sandbox iframe was removed from the DOM.");
   }
 
   return sandbox.contentWindow;
@@ -79,7 +79,7 @@ async function postSandboxMessage<TReturn extends Payload = Payload>({
         retries: MAX_RETRIES,
         shouldRetry: (error) =>
           isSpecificError(error, TimeoutError) ||
-          isSpecificError(error, SandboxInjectionError),
+          isSpecificError(error, IframeInjectionError),
         onFailedAttempt(error) {
           console.warn(
             `Failed to send message ${type} to sandbox. Retrying... Attempt ${error.attemptNumber}`,
@@ -90,7 +90,7 @@ async function postSandboxMessage<TReturn extends Payload = Payload>({
   } catch (error) {
     if (
       isSpecificError(error, TimeoutError) ||
-      isSpecificError(error, SandboxInjectionError)
+      isSpecificError(error, IframeInjectionError)
     ) {
       throw new Error(
         `Failed to send message ${type} to sandbox. The host page may be preventing the sandbox from loading.`,

--- a/src/utils/injectIframe.tsx
+++ b/src/utils/injectIframe.tsx
@@ -22,6 +22,13 @@ import { waitForDocumentRoot } from "@/utils/domUtils";
 
 const TIMEOUT_MS = 5000;
 
+export class SandboxInjectionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SandboxInjectionError";
+  }
+}
+
 export const hiddenIframeStyle: Partial<CSSStyleDeclaration> = {
   position: "absolute",
   bottom: "105%",
@@ -78,10 +85,9 @@ async function _injectIframe(
   ]);
 
   if (result === "removed") {
-    console.warn(
-      `The host page removed the iframe for ${url} before it could be loaded. Retrying...`,
+    throw new SandboxInjectionError(
+      `The host page removed the iframe for ${url} before it could be loaded.`,
     );
-    return _injectIframe(url, style, shadowRootId);
   }
 
   return iframe as LoadedFrame;

--- a/src/utils/injectIframe.tsx
+++ b/src/utils/injectIframe.tsx
@@ -23,10 +23,7 @@ import { waitForDocumentRoot } from "@/utils/domUtils";
 const TIMEOUT_MS = 5000;
 
 export class SandboxInjectionError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "SandboxInjectionError";
-  }
+  override name = "SandboxInjectionError";
 }
 
 export const hiddenIframeStyle: Partial<CSSStyleDeclaration> = {

--- a/src/utils/injectIframe.tsx
+++ b/src/utils/injectIframe.tsx
@@ -20,7 +20,7 @@ import pTimeout from "p-timeout";
 import shadowWrap from "@/utils/shadowWrap";
 import { waitForDocumentRoot } from "@/utils/domUtils";
 
-const TIMEOUT_MS = 3000;
+const TIMEOUT_MS = 5000;
 
 export const hiddenIframeStyle: Partial<CSSStyleDeclaration> = {
   position: "absolute",

--- a/src/utils/injectIframe.tsx
+++ b/src/utils/injectIframe.tsx
@@ -22,8 +22,8 @@ import { waitForDocumentRoot } from "@/utils/domUtils";
 
 const TIMEOUT_MS = 5000;
 
-export class SandboxInjectionError extends Error {
-  override name = "SandboxInjectionError";
+export class IframeInjectionError extends Error {
+  override name = "IframeInjectionError";
 }
 
 export const hiddenIframeStyle: Partial<CSSStyleDeclaration> = {
@@ -82,7 +82,7 @@ async function _injectIframe(
   ]);
 
   if (result === "removed") {
-    throw new SandboxInjectionError(
+    throw new IframeInjectionError(
       `The host page removed the iframe for ${url} before it could be loaded.`,
     );
   }

--- a/src/utils/postMessage.ts
+++ b/src/utils/postMessage.ts
@@ -37,7 +37,7 @@ import { assertNotNullish } from "./nullishUtils";
 import { type JsonValue } from "type-fest";
 import { type AbortSignalAsOptions } from "./promiseUtils";
 
-const TIMEOUT_MS = 3000;
+const TIMEOUT_MS = 5000;
 
 export type Payload = JsonValue | void;
 


### PR DESCRIPTION
## What does this PR do?

- Part of #9150 
- While we haven't identified root cause of #9150, this PR
    1. Increases the timeout associated with injecting & sending messages to the sandbox from 3s to 5s (to address the hypothesis that this error is happening on slow machines) and
    2. Introduces a more specific `SandboxInjectionError` to be explicit about the cause of the sandbox errors we are seeing (to rule out the less-strong hypothesis that the sandbox is getting removed from the page more often than before)

## Discussion

- See notion document for context and bug triage notes https://www.notion.so/pixiebrix/Nunjucks-Error-Spike-0283abe59c6a48ad96f5f84715516ec3?showMoveTo=true&saveParent=true