### PR TITLE
9169 indexeddb logging disable flag + more debug logging

### DIFF
--- a/src/auth/featureFlags.ts
+++ b/src/auth/featureFlags.ts
@@ -115,6 +115,15 @@ export const FeatureFlags = {
     "application-error-telemetry-disable-report",
 
   /**
+   * IndexDB logging kill switch. This disables writing to the LOG database, along with
+   * the clear debug logging and sweep logs functionality.
+   *
+   * Introduced to mitigate issues around idb logging causing runtime performance issues. See:
+   * https://github.com/pixiebrix/pixiebrix-extension/issues/9169
+   */
+  DISABLE_IDB_LOGGING: "disable-idb-logging",
+
+  /**
    * Experimental support for audio capture bricks.
    */
   FEATURE_FLAG_AUDIO_CAPTURE: "capture-audio",

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -68,7 +68,7 @@ export const queryTabs = getMethod("QUERY_TABS", bg);
 export const recordLog = getNotifier("RECORD_LOG", bg);
 export const clearLogs = getMethod("CLEAR_LOGS", bg);
 export const clearLog = getMethod("CLEAR_LOG", bg);
-export const clearExtensionDebugLogs = getMethod(
+export const clearModComponentDebugLogs = getMethod(
   "CLEAR_MOD_COMPONENT_DEBUG_LOGS",
   bg,
 );

--- a/src/contentScript/contentScriptPlatform.ts
+++ b/src/contentScript/contentScriptPlatform.ts
@@ -18,7 +18,7 @@
 import { type PlatformProtocol } from "@/platform/platformProtocol";
 import { hideNotification, showNotification } from "@/utils/notify";
 import {
-  clearExtensionDebugLogs,
+  clearModComponentDebugLogs,
   ensureContextMenu,
   openTab,
   performConfiguredRequestInBackground,
@@ -268,7 +268,7 @@ class ContentScriptPlatform extends PlatformBase {
       async clear(componentId: UUID): Promise<void> {
         await Promise.all([
           traces.clear(componentId),
-          clearExtensionDebugLogs(componentId),
+          clearModComponentDebugLogs(componentId),
         ]);
       },
       traces: {

--- a/src/extensionPages/extensionPagePlatform.ts
+++ b/src/extensionPages/extensionPagePlatform.ts
@@ -22,7 +22,7 @@ import BackgroundLogger from "@/telemetry/BackgroundLogger";
 import type { UUID } from "@/types/stringTypes";
 import {
   traces,
-  clearExtensionDebugLogs,
+  clearModComponentDebugLogs,
   performConfiguredRequestInBackground,
 } from "@/background/messenger/api";
 import { PlatformBase } from "@/platform/platformBase";
@@ -72,7 +72,7 @@ class ExtensionPagePlatform extends PlatformBase {
       async clear(componentId: UUID): Promise<void> {
         await Promise.all([
           traces.clear(componentId),
-          clearExtensionDebugLogs(componentId),
+          clearModComponentDebugLogs(componentId),
         ]);
       },
       traces: {

--- a/src/starterBricks/trigger/triggerStarterBrick.ts
+++ b/src/starterBricks/trigger/triggerStarterBrick.ts
@@ -553,7 +553,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
             trigger: this.trigger,
           });
 
-          componentLogger.info("Successfully ran trigger");
+          componentLogger.debug("Successfully ran trigger");
         }
       }),
     );

--- a/src/telemetry/logging.test.ts
+++ b/src/telemetry/logging.test.ts
@@ -125,26 +125,16 @@ describe("logging", () => {
       }),
     );
 
-    await sweepLogs();
-
-    await expect(count()).resolves.toBe(937);
-    // Increase timeout so test isn't flakey on CI due to slow append operation
-  }, 20_000);
-
-  test("sweep with DISABLE_IDB_LOGGING flag on", async () => {
-    flagOnMock.mockResolvedValue(false);
-    await Promise.all(
-      array(logEntryFactory, 1500)().map(async (x) => {
-        await appendEntry(x);
-      }),
-    );
-
+    // Verify that when the DISABLE_IDB_LOGGING flag is on, the logs are not swept
     mockFlag(FeatureFlags.DISABLE_IDB_LOGGING);
     await sweepLogs();
-
     await expect(count()).resolves.toBe(1500);
+
+    flagOnMock.mockResolvedValue(false);
+    await sweepLogs();
+    await expect(count()).resolves.toBe(937);
     // Increase timeout so test isn't flakey on CI due to slow append operation
-  }, 20_000);
+  }, 25_000);
 
   test("getLogEntries by modId", async () => {
     const modId = registryIdFactory();

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -182,6 +182,10 @@ async function openLoggingDB() {
  * @param entry the log entry to add
  */
 export async function appendEntry(entry: LogEntry): Promise<void> {
+  if (await flagOn(FeatureFlags.DISABLE_IDB_LOGGING)) {
+    return;
+  }
+
   const db = await openLoggingDB();
   try {
     await db.add(ENTRY_OBJECT_STORE, entry);
@@ -504,6 +508,10 @@ export async function setLoggingConfig(config: LoggingConfig): Promise<void> {
 export async function clearModComponentDebugLogs(
   modComponentId: UUID,
 ): Promise<void> {
+  if (await flagOn(FeatureFlags.DISABLE_IDB_LOGGING)) {
+    return;
+  }
+
   const db = await openLoggingDB();
 
   try {
@@ -523,6 +531,10 @@ export async function clearModComponentDebugLogs(
  * Free up space in the log database.
  */
 async function _sweepLogs(): Promise<void> {
+  if (await flagOn(FeatureFlags.DISABLE_IDB_LOGGING)) {
+    return;
+  }
+
   const numRecords = await count();
 
   if (numRecords > MAX_LOG_RECORDS) {

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -335,7 +335,7 @@ let lastAxiosServerErrorTimestamp: number | null = null;
  */
 export async function reportToApplicationErrorTelemetry(
   // Ensure it's an Error instance before passing it to Application error telemetry so Application error telemetry
-  // treats it as the error. Note, Rollbar, treats POJO as the custom data.
+  // treats it as the error.
   error: Error,
   flatContext: MessageContext,
   errorMessage: string,


### PR DESCRIPTION
## What does this PR do?

- Part of #9169
- Adds some additional logging to idb logging database operations
- Adds a feature flag for disabling idb logging
- Method renaming for clarity

## Future Work

https://github.com/pixiebrix/pixiebrix-extension/issues/9169

## Checklist

- [ ] This PR requires a security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change
- [ ] Added jest or playwright tests and/or storybook stories

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
