### PR TITLE
9169 idb log durability and timeout changes

### DIFF
--- a/src/auth/featureFlags.ts
+++ b/src/auth/featureFlags.ts
@@ -101,12 +101,12 @@ export const FeatureFlags = {
   SETTINGS_EXPERIMENTAL: "settings-experimental",
 
   /**
-   * PixieBrix error service kill switch/
+   * PixieBrix error service off switch/
    */
   ERROR_SERVICE_DISABLE_REPORT: "error-service-disable-report",
 
   /**
-   * Datadog error telemetry kill switch.
+   * Datadog error telemetry off switch.
    *
    * Originally introduced when moving Datadog to the offscreen document in order to turn off error telemetry if
    * the offscreen document implementation was buggy.
@@ -115,7 +115,7 @@ export const FeatureFlags = {
     "application-error-telemetry-disable-report",
 
   /**
-   * IndexDB logging kill switch. This disables writing to the LOG database, along with
+   * IndexDB logging off switch. This disables writing to the LOG database, along with
    * the clear debug logging and sweep logs functionality.
    *
    * Introduced to mitigate issues around idb logging causing runtime performance issues. See:


### PR DESCRIPTION
## What does this PR do?

- Part of #9169
- adds abort timeout to sweep idb function
- adds blocked handling to openDB method

## Discussion

- Tested by intentionally removing db.close() methods everywhere, and by adding an infinite loop in sweep


## Future Work

The rest of the checklist in https://github.com/pixiebrix/pixiebrix-extension/issues/9169

## Checklist

- [ ] This PR requires a security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change
- [ ] Added jest or playwright tests and/or storybook stories

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
