### PR TITLE
Slice 3: Use `ModInstance` type on the mods screen (3/3)

### DIFF
--- a/src/activation/useActivateModWizard.test.tsx
+++ b/src/activation/useActivateModWizard.test.tsx
@@ -34,7 +34,7 @@ import {
   mapRestrictedFeatureToFeatureFlag,
   RestrictedFeatures,
 } from "@/auth/featureFlags";
-import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
+import { publicSharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
 import { BusinessError } from "@/errors/businessErrors";
 import { type RegistryId } from "@/types/registryTypes";
 import { appApiMock } from "@/testUtils/appApiMock";
@@ -195,9 +195,7 @@ describe("useActivateModWizard", () => {
 
   test("reject public marketplace activations", async () => {
     const modDefinition = defaultModDefinitionFactory({
-      sharing: sharingDefinitionFactory({
-        public: true,
-      }),
+      sharing: publicSharingDefinitionFactory(),
     });
 
     appApiMock.onGet(API_PATHS.FEATURE_FLAGS).reply(200, {

--- a/src/background/deploymentUpdater.test.ts
+++ b/src/background/deploymentUpdater.test.ts
@@ -52,7 +52,7 @@ import {
   modComponentFactory,
   modMetadataFactory,
 } from "@/testUtils/factories/modComponentFactories";
-import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
+import { personalSharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
 import {
   modComponentDefinitionFactory,
   starterBrickDefinitionFactory,
@@ -440,7 +440,7 @@ describe("syncDeployments", () => {
         name: deployment.package.name,
         version: normalizeSemVerString("0.0.1"),
         updated_at: deployment.updated_at!,
-        sharing: sharingDefinitionFactory(),
+        sharing: personalSharingDefinitionFactory(),
       },
     }) as ActivatedModComponent;
     delete modComponent._deployment;
@@ -492,7 +492,7 @@ describe("syncDeployments", () => {
         name: deployment.package.name,
         version: normalizeSemVerString("0.0.1"),
         updated_at: deployment.updated_at!,
-        sharing: sharingDefinitionFactory(),
+        sharing: personalSharingDefinitionFactory(),
       },
     }) as ActivatedModComponent;
     delete modComponent._deployment;

--- a/src/background/modUpdater.test.ts
+++ b/src/background/modUpdater.test.ts
@@ -39,7 +39,10 @@ import {
 } from "@/testUtils/factories/modDefinitionFactories";
 import { getEditorState } from "@/store/editorStorage";
 import modComponentSlice from "@/store/modComponents/modComponentSlice";
-import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
+import {
+  personalSharingDefinitionFactory,
+  publicSharingDefinitionFactory,
+} from "@/testUtils/factories/registryFactories";
 import type { ModDefinition } from "@/types/modDefinitionTypes";
 import type { ActivatedModComponent } from "@/types/modComponentTypes";
 import { uninstallContextMenu } from "@/background/contextMenus/uninstallContextMenu";
@@ -67,26 +70,26 @@ describe("getActivatedMarketplaceModVersions function", () => {
 
     publicActivatedMod = activatedModComponentFactory({
       _recipe: modMetadataFactory({
-        sharing: sharingDefinitionFactory({ public: true }),
+        sharing: publicSharingDefinitionFactory(),
       }),
     });
 
     privateActivatedMod = activatedModComponentFactory({
       _recipe: modMetadataFactory({
-        sharing: sharingDefinitionFactory({ public: false }),
+        sharing: personalSharingDefinitionFactory(),
       }),
     });
 
     publicActivatedDeployment = activatedModComponentFactory({
       _recipe: modMetadataFactory({
-        sharing: sharingDefinitionFactory({ public: true }),
+        sharing: publicSharingDefinitionFactory(),
       }),
       _deployment: {} as ActivatedModComponent["_deployment"],
     });
 
     privateActivatedDeployment = activatedModComponentFactory({
       _recipe: modMetadataFactory({
-        sharing: sharingDefinitionFactory({ public: false }),
+        sharing: personalSharingDefinitionFactory(),
       }),
       _deployment: {} as ActivatedModComponent["_deployment"],
     });
@@ -119,7 +122,7 @@ describe("getActivatedMarketplaceModVersions function", () => {
   it("returns expected object with registry id keys and version number values", async () => {
     const anotherPublicActivatedMod = activatedModComponentFactory({
       _recipe: modMetadataFactory({
-        sharing: sharingDefinitionFactory({ public: true }),
+        sharing: publicSharingDefinitionFactory(),
       }),
     });
 
@@ -143,7 +146,7 @@ describe("getActivatedMarketplaceModVersions function", () => {
 
   it("reports error if multiple mod component versions activated for same mod", async () => {
     const sameMod = modMetadataFactory({
-      sharing: sharingDefinitionFactory({ public: true }),
+      sharing: publicSharingDefinitionFactory(),
     });
 
     const onePublicActivatedMod = activatedModComponentFactory({
@@ -185,12 +188,12 @@ describe("fetchModUpdates function", () => {
     activatedMods = [
       activatedModComponentFactory({
         _recipe: modMetadataFactory({
-          sharing: sharingDefinitionFactory({ public: true }),
+          sharing: publicSharingDefinitionFactory(),
         }),
       }),
       activatedModComponentFactory({
         _recipe: modMetadataFactory({
-          sharing: sharingDefinitionFactory({ public: true }),
+          sharing: publicSharingDefinitionFactory(),
         }),
       }),
     ];
@@ -284,7 +287,7 @@ describe("updateModsIfUpdatesAvailable", () => {
     axiosMock.reset();
 
     publicMod = modDefinitionWithVersionedStarterBrickFactory()({
-      sharing: sharingDefinitionFactory({ public: true }),
+      sharing: publicSharingDefinitionFactory(),
     });
 
     publicModUpdate = {

--- a/src/extensionConsole/pages/mods/ModsPage.test.tsx
+++ b/src/extensionConsole/pages/mods/ModsPage.test.tsx
@@ -38,6 +38,7 @@ import { modDefinitionFactory } from "@/testUtils/factories/modDefinitionFactori
 import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 import { actions as modComponentActions } from "@/store/modComponents/modComponentSlice";
 import useOnboarding from "@/extensionConsole/pages/mods/onboardingView/useOnboarding";
+import { waitFor } from "@testing-library/react";
 
 jest.mock("@/modDefinitions/modDefinitionHooks");
 const useAllModDefinitionsMock = jest.mocked(useAllModDefinitions);
@@ -247,14 +248,19 @@ describe("ModsPage", () => {
 
     const searchQuery = "query doesn't match any mods";
     const searchInput = screen.getByTestId("mod-search-input");
+
     await userEvent.type(searchInput, searchQuery);
 
-    expect(screen.getByText("No mods found")).toBeInTheDocument();
+    // Wait for the search query to take effect
+    await waitFor(() => {
+      expect(screen.getByText("No mods found")).toBeInTheDocument();
+    });
+
     expect(screen.queryByText("Test Mod 1")).not.toBeInTheDocument();
     expect(screen.queryByText("Test Mod 2")).not.toBeInTheDocument();
   }, 10_000);
 
-  test("renders OnboardingView when there are no mods anfd no search query", async () => {
+  test("renders OnboardingView when there are no mods and no search query", async () => {
     render(
       <DeploymentsProvider>
         <ModsPage />

--- a/src/extensionConsole/pages/mods/ModsPage.test.tsx
+++ b/src/extensionConsole/pages/mods/ModsPage.test.tsx
@@ -38,7 +38,6 @@ import { modDefinitionFactory } from "@/testUtils/factories/modDefinitionFactori
 import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 import { actions as modComponentActions } from "@/store/modComponents/modComponentSlice";
 import useOnboarding from "@/extensionConsole/pages/mods/onboardingView/useOnboarding";
-import { waitFor } from "@testing-library/react";
 
 jest.mock("@/modDefinitions/modDefinitionHooks");
 const useAllModDefinitionsMock = jest.mocked(useAllModDefinitions);
@@ -252,9 +251,9 @@ describe("ModsPage", () => {
     await userEvent.type(searchInput, searchQuery);
 
     // Wait for the search query to take effect
-    await waitFor(() => {
-      expect(screen.getByText("No mods found")).toBeInTheDocument();
-    });
+    await expect(
+      screen.findByText("No mods found"),
+    ).resolves.toBeInTheDocument();
 
     expect(screen.queryByText("Test Mod 1")).not.toBeInTheDocument();
     expect(screen.queryByText("Test Mod 2")).not.toBeInTheDocument();

--- a/src/extensionConsole/pages/mods/modsPageSelectors.ts
+++ b/src/extensionConsole/pages/mods/modsPageSelectors.ts
@@ -20,7 +20,6 @@ import { createSelector } from "@reduxjs/toolkit";
 import { selectAllModDefinitions } from "@/modDefinitions/modDefinitionsSelectors";
 import { appApi } from "@/data/service/api";
 import { selectOrganizations, selectScope } from "@/auth/authSelectors";
-import { selectActivatedModComponents } from "@/store/modComponents/modComponentSelectors";
 import buildModsList from "@/extensionConsole/pages/mods/utils/buildModsList";
 import buildGetModActivationStatus from "@/extensionConsole/pages/mods/utils/buildGetModActivationStatus";
 import buildGetModVersionStatus from "@/extensionConsole/pages/mods/utils/buildGetModVersionStatus";
@@ -32,7 +31,7 @@ import {
   mapRestrictedFeatureToFeatureFlag,
   RestrictedFeatures,
 } from "@/auth/featureFlags";
-import { assertNotNullish } from "@/utils/nullishUtils";
+import { selectModInstanceMap } from "@/store/modComponents/modInstanceSelectors";
 
 export type ModsPageRootState = {
   modsPage: ModsPageState;
@@ -50,36 +49,20 @@ export const selectSearchQuery = ({ modsPage }: ModsPageRootState) =>
 export const selectIsLoadingData = ({ modsPage }: ModsPageRootState) =>
   modsPage.isLoadingData;
 
-const selectActivatedModIds = createSelector(
-  selectActivatedModComponents,
-  (activatedModComponents) =>
-    new Set(
-      activatedModComponents.map((modComponent) => {
-        assertNotNullish(
-          modComponent._recipe,
-          "Found activated mod component without a _recipe! " +
-            modComponent.label,
-        );
-        return modComponent._recipe.id;
-      }),
-    ),
-);
-
 const selectModsList = createSelector(
   selectScope,
-  selectActivatedModComponents,
+  selectModInstanceMap,
   selectAllModDefinitions,
-  selectActivatedModIds,
   buildModsList,
 );
 
 const selectGetModActivationStatus = createSelector(
-  selectActivatedModComponents,
+  selectModInstanceMap,
   buildGetModActivationStatus,
 );
 
 const selectGetModVersionStatus = createSelector(
-  selectActivatedModComponents,
+  selectModInstanceMap,
   buildGetModVersionStatus,
 );
 
@@ -112,7 +95,7 @@ const selectModsPageUserPermissions = createSelector(
 const selectGetModSharingSource = createSelector(
   selectScope,
   selectOrganizations,
-  selectActivatedModComponents,
+  selectModInstanceMap,
   buildGetModSharingSource,
 );
 

--- a/src/extensionConsole/pages/mods/utils/buildGetModActivationStatus.test.ts
+++ b/src/extensionConsole/pages/mods/utils/buildGetModActivationStatus.test.ts
@@ -18,74 +18,46 @@
 import buildGetModActivationStatus from "@/extensionConsole/pages/mods/utils/buildGetModActivationStatus";
 import { modDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import {
-  activatedModComponentFactory,
-  modMetadataFactory,
-} from "@/testUtils/factories/modComponentFactories";
-import { autoUUIDSequence } from "@/testUtils/factories/stringFactories";
-import { nowTimestamp } from "@/utils/timeUtils";
+  modInstanceFactory,
+  teamDeploymentMetadataFactory,
+} from "@/testUtils/factories/modInstanceFactories";
 
 describe("buildGetModActivationStatus", () => {
   it("returns inactive for a mod with no activated components", () => {
-    const getActivationStatus = buildGetModActivationStatus([]);
+    const getActivationStatus = buildGetModActivationStatus(new Map());
     expect(getActivationStatus(modDefinitionFactory())).toBe("Inactive");
   });
 
   it("returns active for a mod with an activated component and no deployment", () => {
-    const modMetadata = modMetadataFactory();
-    const mod = modDefinitionFactory({
-      metadata: modMetadata,
-    });
-    const activatedModComponents = [
-      activatedModComponentFactory({ _recipe: modMetadata }),
-    ];
+    const modInstance = modInstanceFactory();
 
     const getActivationStatus = buildGetModActivationStatus(
-      activatedModComponents,
+      new Map([[modInstance.definition.metadata.id, modInstance]]),
     );
-    expect(getActivationStatus(mod)).toBe("Active");
+    expect(getActivationStatus(modInstance.definition)).toBe("Active");
   });
 
   it("returns active for a mod with an activated component and an active deployment", () => {
-    const modMetadata = modMetadataFactory();
-    const mod = modDefinitionFactory({
-      metadata: modMetadata,
+    const modInstance = modInstanceFactory({
+      deploymentMetadata: teamDeploymentMetadataFactory(),
     });
-    const activatedModComponents = [
-      activatedModComponentFactory({
-        _recipe: modMetadata,
-        _deployment: {
-          id: autoUUIDSequence(),
-          timestamp: nowTimestamp(),
-          active: true,
-        },
-      }),
-    ];
 
     const getActivationStatus = buildGetModActivationStatus(
-      activatedModComponents,
+      new Map([[modInstance.definition.metadata.id, modInstance]]),
     );
-    expect(getActivationStatus(mod)).toBe("Active");
+    expect(getActivationStatus(modInstance.definition)).toBe("Active");
   });
 
   it("returns paused for a mod with an activated component and a paused deployment", () => {
-    const modMetadata = modMetadataFactory();
-    const mod = modDefinitionFactory({
-      metadata: modMetadata,
-    });
-    const activatedModComponents = [
-      activatedModComponentFactory({
-        _recipe: modMetadata,
-        _deployment: {
-          id: autoUUIDSequence(),
-          timestamp: nowTimestamp(),
-          active: false,
-        },
+    const modInstance = modInstanceFactory({
+      deploymentMetadata: teamDeploymentMetadataFactory({
+        active: false,
       }),
-    ];
+    });
 
     const getActivationStatus = buildGetModActivationStatus(
-      activatedModComponents,
+      new Map([[modInstance.definition.metadata.id, modInstance]]),
     );
-    expect(getActivationStatus(mod)).toBe("Paused");
+    expect(getActivationStatus(modInstance.definition)).toBe("Paused");
   });
 });

--- a/src/extensionConsole/pages/mods/utils/buildGetModActivationStatus.ts
+++ b/src/extensionConsole/pages/mods/utils/buildGetModActivationStatus.ts
@@ -15,38 +15,30 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type ActivatedModComponent } from "@/types/modComponentTypes";
 import { type Mod, type ModActivationStatus } from "@/types/modTypes";
+import { type RegistryId } from "@/types/registryTypes";
+import { type ModInstance } from "@/types/modInstanceTypes";
 
 export default function buildGetModActivationStatus(
-  activatedModComponents: ActivatedModComponent[],
+  modInstanceMap: Map<RegistryId, ModInstance>,
 ): (mod: Mod) => ModActivationStatus {
   return (mod: Mod) => {
-    const activatedComponentsForMod = activatedModComponents.filter(
-      ({ _recipe }) => _recipe?.id === mod.metadata.id,
-    );
+    const modInstance = modInstanceMap.get(mod.metadata.id);
 
-    // If there are no activated components, then the mod is inactive, regardless of deployment status
-    if (activatedComponentsForMod.length === 0) {
+    // If there is no mod instance, then the mod is inactive, regardless of deployment status
+    if (modInstance == null) {
       return "Inactive";
     }
 
-    const deploymentFromComponent = activatedComponentsForMod.find(
-      ({ _deployment }) => _deployment != null,
-    )?._deployment;
+    const { deploymentMetadata } = modInstance;
 
     // If not part of a deployment, then the mod is active
-    if (!deploymentFromComponent) {
+    if (!deploymentMetadata) {
       return "Active";
     }
 
     // If part of a deployment, check deployment status
-    if (
-      // Check for null/undefined to preserve backward compatability
-      // Prior to extension version 1.4.0, there was no `active` field, because there was no ability to pause deployments
-      deploymentFromComponent.active == null ||
-      deploymentFromComponent.active
-    ) {
+    if (deploymentMetadata.active) {
       return "Active";
     }
 

--- a/src/extensionConsole/pages/settings/useDiagnostics.ts
+++ b/src/extensionConsole/pages/settings/useDiagnostics.ts
@@ -64,7 +64,7 @@ async function collectDiagnostics({
 }
 
 function useDiagnostics() {
-  const extensions = useSelector(selectActivatedModComponents);
+  const activatedModComponents = useSelector(selectActivatedModComponents);
   const permissionsState = useExtensionPermissions();
 
   const exportDiagnostics = useUserAction(
@@ -75,7 +75,7 @@ function useDiagnostics() {
 
       const data = await collectDiagnostics({
         permissions: permissionsState.data,
-        modComponents: extensions,
+        modComponents: activatedModComponents,
       });
 
       download(
@@ -88,7 +88,7 @@ function useDiagnostics() {
       successMessage: "Exported diagnostics",
       errorMessage: "Error exporting diagnostics",
     },
-    [permissionsState, extensions],
+    [permissionsState, activatedModComponents],
   );
 
   return {

--- a/src/modDefinitions/modDefinitionsSelectors.ts
+++ b/src/modDefinitions/modDefinitionsSelectors.ts
@@ -16,6 +16,7 @@
  */
 
 import { type ModDefinitionsRootState } from "./modDefinitionsTypes";
+import { createSelector } from "@reduxjs/toolkit";
 
 export function selectModDefinitionsAsyncState({
   modDefinitions,
@@ -23,8 +24,8 @@ export function selectModDefinitionsAsyncState({
   return modDefinitions;
 }
 
-export function selectAllModDefinitions({
-  modDefinitions,
-}: ModDefinitionsRootState): ModDefinitionsRootState["modDefinitions"]["data"] {
-  return modDefinitions.data ?? [];
-}
+// Memoize via createSelector because it produces a new object if data is undefined
+export const selectAllModDefinitions = createSelector(
+  (state: ModDefinitionsRootState) => state.modDefinitions.data,
+  (modDefinitions) => modDefinitions ?? [],
+);

--- a/src/mods/hooks/useModPermissions.ts
+++ b/src/mods/hooks/useModPermissions.ts
@@ -26,8 +26,8 @@ import { assertNotNullish } from "@/utils/nullishUtils";
 import type { ModInstance } from "@/types/modInstanceTypes";
 import { mapModInstanceToActivatedModComponents } from "@/store/modComponents/modInstanceUtils";
 
-// By default, assume the extensions have permissions.
-const fallback: PermissionsStatus = {
+// By default, assume the extension has required permissions.
+const noRequiredPermissionsStatus: PermissionsStatus = {
   hasPermissions: true,
   permissions: emptyPermissionsFactory(),
 };
@@ -45,16 +45,16 @@ function useModPermissions(modInstances: ModInstance[]): {
 
   const { data } = fallbackValue(
     useAsyncState(async () => {
-      if (isSuccess) {
+      if (isSuccess && modInstances.length > 0) {
         const modComponents = modInstances.flatMap((x) =>
           mapModInstanceToActivatedModComponents(x),
         );
         return checkExtensionPermissions(modComponents);
       }
 
-      return fallback;
+      return noRequiredPermissionsStatus;
     }, [modInstances, browserPermissions, isSuccess]),
-    fallback,
+    noRequiredPermissionsStatus,
   );
 
   assertNotNullish(data, "Permissions data is null");

--- a/src/sidebar/activateMod/RequireMods.tsx
+++ b/src/sidebar/activateMod/RequireMods.tsx
@@ -29,7 +29,6 @@ import { type AuthOption } from "@/auth/authTypes";
 import useDeriveAsyncState from "@/hooks/useDeriveAsyncState";
 import { isDatabaseField } from "@/components/fields/schemaFields/fieldTypeCheckers";
 import { useSelector } from "react-redux";
-import { selectActivatedModComponents } from "@/store/modComponents/modComponentSelectors";
 import { includesQuickBarStarterBrick } from "@/starterBricks/starterBrickModUtils";
 import { PIXIEBRIX_INTEGRATION_ID } from "@/integrations/constants";
 import getUnconfiguredComponentIntegrations from "@/integrations/util/getUnconfiguredComponentIntegrations";
@@ -37,6 +36,7 @@ import type { ModActivationConfig } from "@/types/modTypes";
 import { valueToAsyncState } from "@/utils/asyncStateUtils";
 import { assertNotNullish } from "@/utils/nullishUtils";
 import castError from "@/utils/castError";
+import { selectModInstanceMap } from "@/store/modComponents/modInstanceSelectors";
 
 export type RequiredModDefinition = {
   /**
@@ -151,8 +151,7 @@ const RequireMods: React.FC<Props> = ({ mods, children }) => {
   );
   const originalState = valueToAsyncState(mods);
   const authOptionsState = useAuthOptions();
-
-  const activatedModComponents = useSelector(selectActivatedModComponents);
+  const modInstanceMap = useSelector(selectModInstanceMap);
 
   const state = useDeriveAsyncState(
     originalState,
@@ -186,9 +185,7 @@ const RequireMods: React.FC<Props> = ({ mods, children }) => {
               ),
               includesQuickBar:
                 await includesQuickBarStarterBrick(modDefinition),
-              isActive: activatedModComponents.some(
-                (x) => x._recipe?.id === modDefinition.metadata.id,
-              ),
+              isActive: modInstanceMap.has(modDefinition.metadata.id),
             };
           },
         ),

--- a/src/store/modComponents/modComponentSelectors.ts
+++ b/src/store/modComponents/modComponentSelectors.ts
@@ -49,6 +49,8 @@ export const selectIsModComponentSavedOnCloud =
 export const selectGetModComponentsForMod = createSelector(
   selectActivatedModComponents,
   (activatedModComponents) =>
+    // When activatedModComponents changes, the createSelector call will return a new function with the memoized
+    // method referencing the new activatedModComponents
     memoize((modId: RegistryId) =>
       activatedModComponents.filter(
         (activatedModComponent) => activatedModComponent._recipe?.id === modId,

--- a/src/store/modComponents/modInstanceUtils.ts
+++ b/src/store/modComponents/modInstanceUtils.ts
@@ -36,6 +36,7 @@ import type { SetRequired } from "type-fest";
 import { pickModDefinitionMetadata } from "@/modDefinitions/util/pickModDefinitionMetadata";
 import getModDefinitionIntegrationIds from "@/integrations/util/getModDefinitionIntegrationIds";
 import { emptyPermissionsFactory } from "@/permissions/permissionsUtils";
+import { type DeploymentMetadata } from "@/types/deploymentTypes";
 
 /**
  * A version of ActivatedModComponent with stronger nullness guarantees to support type evolution in the future.
@@ -137,6 +138,15 @@ export function mapModInstanceToActivatedModComponents(
   );
 }
 
+function migrateDeploymentMetadata(
+  deploymentMetadata: DeploymentMetadata,
+): SetRequired<DeploymentMetadata, "active"> {
+  return {
+    ...deploymentMetadata,
+    active: deploymentMetadata.active ?? true,
+  };
+}
+
 /**
  * Maps activated mod components to a mod instance.
  * @param modComponents mod components from the mod
@@ -154,7 +164,9 @@ export function mapActivatedModComponentsToModInstance(
   return {
     id: generateModInstanceId(),
     modComponentIds: modComponents.map(({ id }) => id),
-    deploymentMetadata: firstComponent._deployment,
+    deploymentMetadata: firstComponent._deployment
+      ? migrateDeploymentMetadata(firstComponent._deployment)
+      : undefined,
     optionsArgs: collectModOptions(modComponents),
     integrationsArgs: collectIntegrationDependencies(modComponents),
     updatedAt: firstComponent.updateTimestamp,

--- a/src/testUtils/factories/modComponentFactories.ts
+++ b/src/testUtils/factories/modComponentFactories.ts
@@ -31,7 +31,7 @@ import {
 import { type ApiVersion } from "@/types/runtimeTypes";
 import { validateRegistryId } from "@/types/helpers";
 import { type IntegrationDependency } from "@/integrations/integrationTypes";
-import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
+import { personalSharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
 import { metadataFactory } from "@/testUtils/factories/metadataFactory";
 import {
   DefinitionKinds,
@@ -71,7 +71,7 @@ export const modMetadataFactory = extend<Metadata, ModMetadata>(
   metadataFactory,
   {
     updated_at: validateTimestamp("2021-10-07T12:52:16.189Z"),
-    sharing: sharingDefinitionFactory,
+    sharing: personalSharingDefinitionFactory,
   },
 );
 

--- a/src/testUtils/factories/modDefinitionFactories.ts
+++ b/src/testUtils/factories/modDefinitionFactories.ts
@@ -30,7 +30,7 @@ import { type OutputKey } from "@/types/runtimeTypes";
 import { type Permissions } from "webextension-polyfill";
 import { emptyPermissionsFactory } from "@/permissions/permissionsUtils";
 import { type BrickPipeline } from "@/bricks/types";
-import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
+import { personalSharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
 import { validateRegistryId } from "@/types/helpers";
 import {
   type StarterBrickDefinitionLike,
@@ -67,7 +67,7 @@ export const modDefinitionFactory = define<ModDefinition>({
   kind: DefinitionKinds.MOD,
   apiVersion: "v3",
   metadata: metadataFactory,
-  sharing: sharingDefinitionFactory,
+  sharing: personalSharingDefinitionFactory,
   updated_at: validateTimestamp("2021-10-07T12:52:16.189Z"),
   extensionPoints: array(modComponentDefinitionFactory, 1),
 });

--- a/src/testUtils/factories/modInstanceFactories.ts
+++ b/src/testUtils/factories/modInstanceFactories.ts
@@ -22,14 +22,35 @@ import {
   timestampFactory,
 } from "@/testUtils/factories/stringFactories";
 import { modDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { nowTimestamp } from "@/utils/timeUtils";
+import { organizationStateFactory } from "@/testUtils/factories/authFactories";
 import { generateModInstanceId } from "@/store/modComponents/modInstanceUtils";
+
+export const personalDeploymentMetadataFactory = define<
+  ModInstance["deploymentMetadata"]
+>({
+  id: autoUUIDSequence(),
+  timestamp: nowTimestamp(),
+  active: true,
+  isPersonalDeployment: true,
+  organization: undefined,
+});
+
+export const teamDeploymentMetadataFactory = define<
+  ModInstance["deploymentMetadata"]
+>({
+  id: autoUUIDSequence(),
+  timestamp: nowTimestamp(),
+  active: true,
+  organization: organizationStateFactory(),
+});
 
 export const modInstanceFactory = define<ModInstance>({
   id: generateModInstanceId,
   modComponentIds: () => [autoUUIDSequence()],
-  definition: modDefinitionFactory(),
+  definition: modDefinitionFactory,
   deploymentMetadata: undefined,
-  integrationsArgs: [],
-  optionsArgs: {},
+  integrationsArgs: () => [],
+  optionsArgs: () => ({}),
   updatedAt: timestampFactory(),
 });

--- a/src/testUtils/factories/registryFactories.ts
+++ b/src/testUtils/factories/registryFactories.ts
@@ -25,9 +25,19 @@ import {
   timestampFactory,
 } from "@/testUtils/factories/stringFactories";
 
-export const sharingDefinitionFactory = define<Sharing>({
+export const personalSharingDefinitionFactory = define<Sharing>({
   public: false,
   organizations: () => [] as UUID[],
+});
+
+export const publicSharingDefinitionFactory = define<Sharing>({
+  public: true,
+  organizations: () => [] as UUID[],
+});
+
+export const teamSharingDefinitionFactory = define<Sharing>({
+  public: false,
+  organizations: () => [autoUUIDSequence()],
 });
 
 export const editablePackageMetadataFactory = define<EditablePackageMetadata>({
@@ -37,6 +47,6 @@ export const editablePackageMetadataFactory = define<EditablePackageMetadata>({
   version: "1.0.0",
   kind: "Blueprint",
   updated_at: timestampFactory(),
-  sharing: sharingDefinitionFactory,
+  sharing: personalSharingDefinitionFactory,
   _editableBrickBrand: undefined as never,
 });

--- a/src/types/deploymentTypes.ts
+++ b/src/types/deploymentTypes.ts
@@ -45,7 +45,7 @@ type BaseDeploymentMetadata = {
   timestamp: string;
 
   /**
-   * True iff the deployment is temporarily disabled.
+   * False iff the deployment is temporarily disabled.
    *
    * If undefined, is considered active for backward compatability
    *

--- a/src/types/modInstanceTypes.ts
+++ b/src/types/modInstanceTypes.ts
@@ -20,7 +20,7 @@ import type { OptionsArgs } from "@/types/runtimeTypes";
 import type { IntegrationDependency } from "@/integrations/integrationTypes";
 import type { Timestamp, UUID } from "@/types/stringTypes";
 import type { DeploymentMetadata } from "@/types/deploymentTypes";
-import type { Tagged } from "type-fest";
+import type { SetRequired, Tagged } from "type-fest";
 
 /**
  * A unique identifier for a mod instance activation. Tagged to prevent mixing with mod component id.
@@ -56,7 +56,7 @@ export type ModInstance = {
    * The deployment metadata for the mod instance, or undefined if the mod instance is not managed via a
    * team or personal deployment
    */
-  deploymentMetadata: DeploymentMetadata | undefined;
+  deploymentMetadata: SetRequired<DeploymentMetadata, "active"> | undefined;
 
   /**
    * The mod definition.

--- a/src/utils/modUtils.ts
+++ b/src/utils/modUtils.ts
@@ -58,6 +58,8 @@ import {
   validateRegistryId,
 } from "@/types/helpers";
 import { nowTimestamp } from "@/utils/timeUtils";
+import { type ModInstance } from "@/types/modInstanceTypes";
+import { createPrivateSharing } from "@/utils/registryUtils";
 
 /**
  * Returns a synthetic mod id for a standalone mod component for use in the runtime
@@ -287,22 +289,15 @@ export function normalizeModDefinition<
   });
 }
 
-export function mapModComponentToUnavailableMod(
-  modComponent: ModComponentBase,
+export function mapModInstanceToUnavailableMod(
+  modInstance: ModInstance,
 ): UnavailableMod {
-  assertNotNullish(
-    modComponent._recipe,
-    "modComponent._recipe is nullish, can't map to unavailable mod, something went wrong, this shouldn't happen",
-  );
   return {
-    metadata: modComponent._recipe,
+    metadata: modInstance.definition.metadata,
     kind: DefinitionKinds.MOD,
     isStub: true,
-    updated_at: modComponent._recipe.updated_at ?? nowTimestamp(),
-    sharing: modComponent._recipe.sharing ?? {
-      public: false,
-      organizations: [],
-    },
+    updated_at: modInstance.definition.updated_at ?? nowTimestamp(),
+    sharing: modInstance.definition.sharing ?? createPrivateSharing(),
   };
 }
 

--- a/src/utils/modUtils.ts
+++ b/src/utils/modUtils.ts
@@ -296,8 +296,8 @@ export function mapModInstanceToUnavailableMod(
     metadata: modInstance.definition.metadata,
     kind: DefinitionKinds.MOD,
     isStub: true,
-    updated_at: modInstance.definition.updated_at ?? nowTimestamp(),
-    sharing: modInstance.definition.sharing ?? createPrivateSharing(),
+    updated_at: modInstance.definition.updated_at,
+    sharing: modInstance.definition.sharing,
   };
 }
 
@@ -316,10 +316,7 @@ export function createNewUnsavedModMetadata({
     name: modName,
     description: "Created with the PixieBrix Page Editor",
     version: normalizeSemVerString("1.0.0"),
-    sharing: {
-      public: false,
-      organizations: [] as UUID[],
-    },
+    sharing: createPrivateSharing(),
     updated_at: nowTimestamp(),
   };
 }

--- a/src/validators/schemaValidator.test.ts
+++ b/src/validators/schemaValidator.test.ts
@@ -30,7 +30,7 @@ import reactReader from "@contrib/readers/redfin-reader.yaml";
 import { type Schema, SCHEMA_EMPTY_OBJECT } from "@/types/schemaTypes";
 import { uuidv4, validateRegistryId } from "@/types/helpers";
 import { timestampFactory } from "@/testUtils/factories/stringFactories";
-import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
+import { personalSharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
 import { keyAuthIntegrationDefinitionFactory } from "@/testUtils/factories/integrationFactories";
 import integrationRegistry from "@/integrations/registry";
 import { fromJS } from "@/integrations/UserDefinedIntegration";
@@ -64,7 +64,7 @@ describe("validateKind", () => {
     const json = loadBrickYaml(serviceText) as UnknownObject;
 
     json.updated_at = timestampFactory();
-    json.sharing = sharingDefinitionFactory();
+    json.sharing = personalSharingDefinitionFactory();
 
     const result = validatePackageDefinition("service", json);
 


### PR DESCRIPTION
## What does this PR do?

- Context: https://www.notion.so/pixiebrix/Return-mod-instance-from-slice-selectors-instead-of-returning-activated-mod-components-fff43b21a25381269578d4845535e37e?pvs=4
- Stacked on https://github.com/pixiebrix/pixiebrix-extension/pull/9190
- Use `ModInstance` type on the mods screen
- Other refactoring:
  - Split the sharing metadata factory to make usage clearer

## Future Work

Future work before hitting the Page Editor / migrating the state:
1. Update modUpdater code: https://github.com/pixiebrix/pixiebrix-extension/pull/9192

Other future work:
- Review selectors to ensure using reselect or returning null/undefined instead of a fresh object: https://github.com/pixiebrix/pixiebrix-extension/issues/9251#issue-2571936038

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
