### PR TITLE
Slice 4: Use `ModInstance` type in mods updater

### DIFF
--- a/src/background/modUpdater.test.ts
+++ b/src/background/modUpdater.test.ts
@@ -143,42 +143,6 @@ describe("getActivatedMarketplaceModVersions function", () => {
       },
     ]);
   });
-
-  it("reports error if multiple mod component versions activated for same mod", async () => {
-    const sameMod = modMetadataFactory({
-      sharing: publicSharingDefinitionFactory(),
-    });
-
-    const onePublicActivatedMod = activatedModComponentFactory({
-      _recipe: sameMod,
-    });
-
-    const sameModDifferentVersion = modMetadataFactory({
-      ...sameMod,
-      version: "2.0.0" as SemVerString,
-    });
-
-    const anotherPublicActivatedMod = activatedModComponentFactory({
-      _recipe: sameModDifferentVersion,
-    });
-
-    await saveModComponentState({
-      activatedModComponents: [
-        onePublicActivatedMod,
-        anotherPublicActivatedMod,
-      ],
-    });
-
-    const result = await getActivatedMarketplaceModVersions();
-
-    expect(result).toEqual([
-      {
-        name: onePublicActivatedMod._recipe!.id,
-        version: onePublicActivatedMod._recipe!.version,
-      },
-    ]);
-    expect(reportError).toHaveBeenCalled();
-  });
 });
 
 describe("fetchModUpdates function", () => {

--- a/src/background/utils/deactivateMod.ts
+++ b/src/background/utils/deactivateMod.ts
@@ -16,22 +16,20 @@
  */
 
 import deactivateModComponent from "@/background/utils/deactivateModComponent";
-import getModComponentsForMod from "@/mods/util/getModComponentsForMod";
 import { type EditorState } from "@/pageEditor/store/editor/pageEditorTypes";
 import { type ModComponentState } from "@/store/modComponents/modComponentTypes";
-import { type ActivatedModComponent } from "@/types/modComponentTypes";
-import { type RegistryId } from "@/types/registryTypes";
+import { type ModInstance } from "@/types/modInstanceTypes";
 
 /**
- * Deactivates all mod components with the given mod id. Does not remove the mod UI from existing tabs.
+ * Returns the Redux state that excludes the mod. NOTE: does not remove the mod UI from existing tabs.
  *
- * @param modId the mod registry id
+ * @param modInstance the active mod to deactivate
  * @param reduxState the current state of the modComponent and editor redux stores
  * @returns new redux state with the mod components deactivated
  * and the mod components that were deactivated
  */
 function deactivateMod(
-  modId: RegistryId,
+  modInstance: ModInstance,
   {
     editorState,
     modComponentState,
@@ -42,36 +40,26 @@ function deactivateMod(
 ): {
   modComponentState: ModComponentState;
   editorState: EditorState | undefined;
-  deactivatedModComponents: ActivatedModComponent[];
 } {
-  const activatedModComponents = getModComponentsForMod(
-    modId,
-    modComponentState,
-  );
-  const deactivatedModComponents: ActivatedModComponent[] = [];
-
   let _nextModComponentState = modComponentState;
   let _nextEditorState = editorState;
 
-  for (const activatedModComponent of activatedModComponents) {
+  for (const modComponentId of modInstance.modComponentIds) {
     const {
       modComponentState: nextModComponentState,
       editorState: nextEditorState,
-    } = deactivateModComponent(activatedModComponent.id, {
+    } = deactivateModComponent(modComponentId, {
       modComponentState: _nextModComponentState,
       editorState: _nextEditorState,
     });
 
     _nextModComponentState = nextModComponentState;
     _nextEditorState = nextEditorState;
-
-    deactivatedModComponents.push(activatedModComponent);
   }
 
   return {
     modComponentState: _nextModComponentState,
     editorState: _nextEditorState,
-    deactivatedModComponents,
   };
 }
 


### PR DESCRIPTION
## What does this PR do?

- Context: https://www.notion.so/pixiebrix/Return-mod-instance-from-slice-selectors-instead-of-returning-activated-mod-components-fff43b21a25381269578d4845535e37e?pvs=4
- Stacked on https://github.com/pixiebrix/pixiebrix-extension/pull/9191
- Refactors mod updater code to use `ModInstance` type

## Future Work

Continue gradual work toward eliminating mod components on the slice boundary:
- Replace remaining occurrences of `selectActivatedModComponents`, `selectGetModComponentsForMod`, `selectModHasAnyActivatedModComponents`, etc.
- Replace component slice actions taking mod components with actions taking mod instances

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
