### PR TITLE
fix sweepLogs abort functionality

### DIFF
--- a/src/telemetry/logging.test.ts
+++ b/src/telemetry/logging.test.ts
@@ -180,8 +180,8 @@ describe("logging", () => {
 
     // Verify sweepLogs functionality
     await sweepLogs();
-    await expect(count()).resolves.toBe(937);
-    // Increase timeout so test isn't flaky on CI due to slow append operation
+    await expect(count()).resolves.toBe(930);
+    // Increase timeout so test isn't flakey on CI due to slow append operation
   }, 25_000);
 
   test("getLogEntries by modId", async () => {

--- a/src/telemetry/logging.test.ts
+++ b/src/telemetry/logging.test.ts
@@ -147,10 +147,12 @@ describe("logging", () => {
     await expect(count()).resolves.toBe(1);
   });
 
-  test("sweep", async () => {
+  test("sweepLogs", async () => {
+    // Set up test log database that will trigger sweepLogs due to count > MAX_LOG_RECORDS
+    // sweepLog assertions are all written in one test due to this expensive setup
     flagOnMock.mockResolvedValue(false);
     await Promise.all(
-      array(logEntryFactory, 1500)().map(async (x) => {
+      array(logEntryFactory, 1300)().map(async (x) => {
         await appendEntry(x);
       }),
     );
@@ -158,12 +160,28 @@ describe("logging", () => {
     // Verify that when the DISABLE_IDB_LOGGING flag is on, the logs are not swept
     mockFlag(FeatureFlags.DISABLE_IDB_LOGGING);
     await sweepLogs();
-    await expect(count()).resolves.toBe(1500);
+    await expect(count()).resolves.toBe(1300);
 
     flagOnMock.mockResolvedValue(false);
+
+    // Verify that sweeper will abort if timeout is hit
+    const consoleWarnSpy = jest.spyOn(console, "warn");
+    const originalTimeout = global.setTimeout;
+    // Simulate timeout by mocking setTimeout to immediately call the abort signal
+    const setTimeoutSpy = jest
+      .spyOn(global, "setTimeout")
+      .mockImplementation((fn) => originalTimeout(fn, 0));
+    await sweepLogs();
+    await expect(count()).resolves.toBeGreaterThan(1250);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "Log sweep aborted due to timeout",
+    );
+    setTimeoutSpy.mockRestore();
+
+    // Verify sweepLogs functionality
     await sweepLogs();
     await expect(count()).resolves.toBe(937);
-    // Increase timeout so test isn't flakey on CI due to slow append operation
+    // Increase timeout so test isn't flaky on CI due to slow append operation
   }, 25_000);
 
   test("getLogEntries by modId", async () => {

--- a/src/telemetry/logging.test.ts
+++ b/src/telemetry/logging.test.ts
@@ -180,8 +180,8 @@ describe("logging", () => {
 
     // Verify sweepLogs functionality
     await sweepLogs();
-    await expect(count()).resolves.toBe(930);
-    // Increase timeout so test isn't flakey on CI due to slow append operation
+    await expect(count()).resolves.toBeLessThanOrEqual(930);
+    // Increase timeout so test isn't flaky on CI due to slow append operation
   }, 25_000);
 
   test("getLogEntries by modId", async () => {

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -584,11 +584,6 @@ async function _sweepLogs(): Promise<void> {
     return;
   }
 
-  const abortController = new AbortController();
-  // Ensure in cases where the sweep is taking too long, we abort the operation to reduce the likelihood
-  // of blocking other db transactions.
-  setTimeout(abortController.abort, 30_000);
-
   await withLoggingDB(async (db) => {
     const numRecords = await db.count(ENTRY_OBJECT_STORE);
 
@@ -599,6 +594,13 @@ async function _sweepLogs(): Promise<void> {
         numRecords,
         numToDelete,
       });
+
+      // Ensure in cases where the sweep is taking too long, we abort the operation to reduce the likelihood
+      // of blocking other db transactions.
+      const abortController = new AbortController();
+      setTimeout(() => {
+        abortController.abort();
+      }, 10_000);
 
       const tx = db.transaction(ENTRY_OBJECT_STORE, "readwrite", {
         durability: "relaxed",

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -618,7 +618,7 @@ async function _sweepLogs(): Promise<void> {
         for await (const cursor of tx.store) {
           if (abortController.signal.aborted) {
             console.warn("Log sweep aborted due to timeout");
-            break;
+            return;
           }
 
           await cursor.delete();


### PR DESCRIPTION
## What does this PR do?

- Fixes a bug with the abort timeout in the sweepLogs function where it was not being executed due to improper `this` scope.
- See [this datadog trace](https://app.datadoghq.com/logs?query=service%3Apixiebrix-browser-extension%20%40session_id%3Adaa570c4-9748-43b6-a6ad-740cedf97e05%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&context_event=AZIgFWNRAACDYisbDwODfQAA&event=AgAAAZIgEFbPdc-MfAAAAAAAAAAYAAAAAEFaSWdFTTlKQUFETDB0QTBzNS0zZGdBQQAAACQAAAAAMDE5MjIwMTMtZmMxOC00OWM0LTkxNTMtODQ2OTc2OWE0OWZl&fromUser=true&issueId=b79d14fc-776d-11ef-8147-da7ad0900002&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=&from_ts=1727100836571&to_ts=1727115236571&live=true)
- Tested by manually introducing an infinite loop in the sweeplogs and verifying it is aborted


## Checklist

- [x] Added jest or playwright tests and/or storybook stories

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
