### PR TITLE
#9202: add with cache brick with memoization/expiry

### DIFF
--- a/src/bricks/transformers/controlFlow/WithAsyncModVariable.test.ts
+++ b/src/bricks/transformers/controlFlow/WithAsyncModVariable.test.ts
@@ -31,8 +31,9 @@ import { type Expression } from "@/types/runtimeTypes";
 import { toExpression } from "@/utils/expressionUtils";
 import { modComponentRefFactory } from "@/testUtils/factories/modComponentFactories";
 import { reduceOptionsFactory } from "@/testUtils/factories/runtimeFactories";
-import { MergeStrategies, StateNamespaces } from "@/platform/state/stateTypes";
+import { StateNamespaces } from "@/platform/state/stateTypes";
 import { getPlatform } from "@/platform/platformContext";
+import { TEST_resetStateController } from "@/contentScript/stateController/stateController";
 
 const withAsyncModVariableBrick = new WithAsyncModVariable();
 
@@ -71,13 +72,7 @@ describe("WithAsyncModVariable", () => {
   let asyncEchoBrick: DeferredEchoBrick;
 
   beforeEach(async () => {
-    // Reset the page state to avoid interference between tests
-    await getPlatform().state.setState({
-      namespace: StateNamespaces.MOD,
-      data: {},
-      modComponentRef,
-      mergeStrategy: MergeStrategies.REPLACE,
-    });
+    await TEST_resetStateController();
 
     // Most tests just require a single brick instance for testing
     deferred = pDefer();

--- a/src/bricks/transformers/controlFlow/WithCache.test.ts
+++ b/src/bricks/transformers/controlFlow/WithCache.test.ts
@@ -85,7 +85,7 @@ async function expectPageState(expectedState: UnknownObject): Promise<void> {
   expect(pageState).toStrictEqual(expectedState);
 }
 
-describe("WithAsyncModVariable", () => {
+describe("WithCache", () => {
   let deferred: DeferredPromise<void>;
   let asyncEchoBrick: DeferredEchoBrick;
 

--- a/src/bricks/transformers/controlFlow/WithCache.test.ts
+++ b/src/bricks/transformers/controlFlow/WithCache.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { Brick } from "@/types/brickTypes";
+import type { Expression } from "@/types/runtimeTypes";
+import { toExpression } from "@/utils/expressionUtils";
+import { modComponentRefFactory } from "@/testUtils/factories/modComponentFactories";
+import { getPlatform } from "@/platform/platformContext";
+import { StateNamespaces } from "@/platform/state/stateTypes";
+import { WithCache } from "@/bricks/transformers/controlFlow/WithCache";
+import pDefer, { type DeferredPromise } from "p-defer";
+import {
+  DeferredEchoBrick,
+  simpleInput,
+  throwBrick,
+  echoBrick,
+} from "@/runtime/pipelineTests/pipelineTestHelpers";
+import brickRegistry from "@/bricks/registry";
+import { TEST_resetStateController } from "@/contentScript/stateController/stateController";
+import { reducePipeline } from "@/runtime/reducePipeline";
+import { reduceOptionsFactory } from "@/testUtils/factories/runtimeFactories";
+
+const withCacheBrick = new WithCache();
+
+function makeCachePipeline(
+  brick: Brick,
+  {
+    message,
+    stateKey,
+  }: {
+    message: string;
+    stateKey: string | Expression;
+  },
+) {
+  return {
+    id: withCacheBrick.id,
+    config: {
+      body: toExpression("pipeline", [
+        {
+          id: brick.id,
+          config: {
+            message,
+          },
+        },
+      ]),
+      stateKey,
+    },
+  };
+}
+
+const modComponentRef = modComponentRefFactory();
+
+async function expectPageState(expectedState: UnknownObject): Promise<void> {
+  const pageState = await getPlatform().state.getState({
+    namespace: StateNamespaces.MOD,
+    modComponentRef,
+  });
+
+  expect(pageState).toStrictEqual(expectedState);
+}
+
+describe("WithAsyncModVariable", () => {
+  let deferred: DeferredPromise<void>;
+  let asyncEchoBrick: DeferredEchoBrick;
+
+  beforeEach(async () => {
+    await TEST_resetStateController();
+
+    // Most tests just require a single brick instance for testing
+    deferred = pDefer();
+    asyncEchoBrick = new DeferredEchoBrick(deferred.promise);
+
+    brickRegistry.clear();
+    brickRegistry.register([
+      asyncEchoBrick,
+      throwBrick,
+      echoBrick,
+      withCacheBrick,
+    ]);
+  });
+
+  it("returns value if pipeline succeeds", async () => {
+    const pipeline = makeCachePipeline(echoBrick, {
+      stateKey: "foo",
+      message: "bar",
+    });
+
+    const brickOutput = await reducePipeline(
+      pipeline,
+      simpleInput({}),
+      reduceOptionsFactory("v3", { modComponentRef }),
+    );
+
+    const expectedData = { message: "bar" };
+
+    expect(brickOutput).toStrictEqual(expectedData);
+
+    await expectPageState({
+      foo: {
+        isLoading: false,
+        isFetching: false,
+        isSuccess: true,
+        isError: false,
+        data: expectedData,
+        currentData: expectedData,
+        requestId: expect.toBeString(),
+        error: null,
+        expiresAt: null,
+      },
+    });
+  });
+
+  it("throws exception if pipeline throws", async () => {
+    const pipeline = makeCachePipeline(throwBrick, {
+      stateKey: "foo",
+      message: "bar",
+    });
+
+    const brickPromise = reducePipeline(
+      pipeline,
+      simpleInput({}),
+      reduceOptionsFactory("v3", { modComponentRef }),
+    );
+
+    await expect(brickPromise).rejects.toThrow("bar");
+  });
+});

--- a/src/bricks/transformers/controlFlow/WithCache.ts
+++ b/src/bricks/transformers/controlFlow/WithCache.ts
@@ -420,24 +420,24 @@ export class WithCache extends TransformerABC {
       );
     }
 
-    if (isCacheVariableState(currentVariable) && currentVariable.isFetching) {
-      return this.waitForSettledRequest({
-        requestId: currentVariable.requestId,
-        args,
-        options,
-      });
-    }
+    if (!forceFetch && isCacheVariableState(currentVariable)) {
+      if (currentVariable.isFetching) {
+        return this.waitForSettledRequest({
+          requestId: currentVariable.requestId,
+          args,
+          options,
+        });
+      }
 
-    if (
-      !forceFetch &&
-      isCacheVariableState(currentVariable) &&
-      // Don't throw settled exceptions/rejections
-      currentVariable.isSuccess &&
-      // Only refetch if the cached value is still valid w.r.t. the TTL
-      (currentVariable.expiresAt == null ||
-        Date.now() < currentVariable.expiresAt)
-    ) {
-      return currentVariable.data;
+      if (
+        // Don't throw settled exceptions/rejections
+        currentVariable.isSuccess &&
+        // Only refetch if the cached value is still valid w.r.t. the TTL
+        (currentVariable.expiresAt == null ||
+          Date.now() < currentVariable.expiresAt)
+      ) {
+        return currentVariable.data;
+      }
     }
 
     return this.generateValue({

--- a/src/bricks/transformers/controlFlow/WithCache.ts
+++ b/src/bricks/transformers/controlFlow/WithCache.ts
@@ -125,13 +125,13 @@ export class WithCache extends TransformerABC {
         title: "Time-to-Live (s)",
         type: "integer",
         description:
-          "The time-to-live for the cached value in seconds. Expiry is calculated from the start of the run.",
+          "The time-to-live for the cached value in seconds. If not provided, the value will not expire. Expiry is calculated from the start of the run.",
       },
       forceFetch: {
         title: "Force Fetch",
         type: "boolean",
         description:
-          "If true, the cache will be ignored and the body always be run.",
+          "If toggled on, the cache will be ignored and the body always be run.",
       },
     },
     ["body", "stateKey"],
@@ -245,7 +245,6 @@ export class WithCache extends TransformerABC {
         }
 
         if (variableUpdate.requestId !== requestId) {
-          // XXX: should this be a CancelError?
           deferredValuePromise.reject(
             new CancelError("Value generation was superseded"),
           );

--- a/src/bricks/transformers/controlFlow/WithCache.ts
+++ b/src/bricks/transformers/controlFlow/WithCache.ts
@@ -1,0 +1,398 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { TransformerABC } from "@/types/bricks/transformerTypes";
+import { uuidv4, validateRegistryId } from "@/types/helpers";
+import { type Schema } from "@/types/schemaTypes";
+import {
+  type BrickArgs,
+  type BrickOptions,
+  type PipelineExpression,
+} from "@/types/runtimeTypes";
+import { deserializeError, serializeError } from "serialize-error";
+import { type JsonObject } from "type-fest";
+import { isNullOrBlank } from "@/utils/stringUtils";
+import { isEmpty } from "lodash";
+import { BusinessError, PropError } from "@/errors/businessErrors";
+import { type BrickConfig } from "@/bricks/types";
+import { castTextLiteralOrThrow } from "@/utils/expressionUtils";
+import { propertiesToSchema } from "@/utils/schemaUtils";
+import {
+  MergeStrategies,
+  STATE_CHANGE_JS_EVENT_TYPE,
+  StateNamespaces,
+} from "@/platform/state/stateTypes";
+import { ContextError } from "@/errors/genericErrors";
+import pDefer from "p-defer";
+
+type CacheVariableState = {
+  isFetching: boolean;
+  isError: boolean;
+  isSuccess: boolean;
+  error: unknown;
+  data: unknown;
+  expiresAt: number | null;
+};
+
+function isCacheVariableState(value: unknown): value is CacheVariableState {
+  if (typeof value !== "object" || value == null) {
+    return false;
+  }
+
+  const { isFetching, isError } = value as UnknownObject;
+
+  if (typeof isFetching !== "boolean") {
+    return false;
+  }
+
+  if (typeof isError !== "boolean") {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * A brick that runs synchronously and caches the result in a Mod Variable. Repeat calls are memoized until settled.
+ *
+ * The state shape is defined to be similar to RTK Query and our async hooks:
+ * https://redux-toolkit.js.org/rtk-query/api/created-api/hooks#usequery
+ */
+export class WithCache extends TransformerABC {
+  static readonly BRICK_ID = validateRegistryId("@pixiebrix/cache");
+
+  constructor() {
+    super(
+      WithCache.BRICK_ID,
+      "Run with Cache",
+      "Run bricks synchronously and cache the status and result in a Mod Variable",
+    );
+  }
+
+  override async isPure(): Promise<boolean> {
+    // Modifies the Page State
+    return false;
+  }
+
+  override async isPageStateAware(): Promise<boolean> {
+    return true;
+  }
+
+  inputSchema: Schema = propertiesToSchema(
+    {
+      body: {
+        $ref: "https://app.pixiebrix.com/schemas/pipeline#",
+        title: "Body",
+        description: "The bricks to run asynchronously",
+      },
+      stateKey: {
+        title: "Mod Variable Name",
+        type: "string",
+        description: "The Mod Variable to store the status and data in",
+      },
+      ttl: {
+        title: "Time-to-Live (s)",
+        type: "integer",
+        description:
+          "The time-to-live for the cached value in seconds. Expiry is calculated from the start of the run.",
+      },
+      forceFetch: {
+        title: "Force Fetch",
+        type: "boolean",
+        description:
+          "If true, the cache will be ignored and the body always be run.",
+      },
+    },
+    ["body", "stateKey"],
+  );
+
+  override defaultOutputKey = "cachedValue";
+
+  override async getModVariableSchema(
+    _config: BrickConfig,
+  ): Promise<Schema | undefined> {
+    const { stateKey } = _config.config;
+
+    let name: string | null = null;
+    try {
+      name = castTextLiteralOrThrow(stateKey);
+    } catch {
+      return;
+    }
+
+    if (name) {
+      return {
+        type: "object",
+        properties: {
+          [name]: {
+            type: "object",
+            properties: {
+              isLoading: {
+                type: "boolean",
+              },
+              isFetching: {
+                type: "boolean",
+              },
+              isSuccess: {
+                type: "boolean",
+              },
+              isError: {
+                type: "boolean",
+              },
+              currentData: {},
+              data: {},
+              expiresAt: {
+                type: "integer",
+              },
+              requestId: {
+                type: "string",
+                format: "uuid",
+              },
+              error: {
+                type: "object",
+              },
+            },
+            additionalProperties: false,
+            required: [
+              "isLoading",
+              "isFetching",
+              "isSuccess",
+              "isError",
+              "currentData",
+              "data",
+              "requestId",
+              "error",
+            ],
+          },
+        },
+        additionalProperties: false,
+        required: [name],
+      };
+    }
+
+    return {
+      type: "object",
+      additionalProperties: true,
+    };
+  }
+
+  async transform(
+    {
+      body,
+      stateKey,
+      ttl,
+      forceFetch,
+    }: BrickArgs<{
+      body: PipelineExpression;
+      stateKey: string;
+      ttl?: number;
+      forceFetch?: boolean;
+    }>,
+    {
+      meta: { modComponentRef },
+      runPipeline,
+      platform,
+      abortSignal,
+    }: BrickOptions,
+  ) {
+    if (isNullOrBlank(stateKey)) {
+      throw new PropError(
+        "Mod Variable Name is required",
+        this.id,
+        "stateKey",
+        stateKey,
+      );
+    }
+
+    const isCurrentNonce = async (query: string) => {
+      const currentState = await platform.state.getState({
+        namespace: StateNamespaces.MOD,
+        modComponentRef,
+      });
+
+      // eslint-disable-next-line security/detect-object-injection -- user provided value that's readonly
+      const currentVariable = (currentState[stateKey] ?? {}) as JsonObject;
+
+      const { requestId: currentRequestId } = currentVariable;
+
+      return currentRequestId == null || currentRequestId === query;
+    };
+
+    const setModVariable = async (data: JsonObject) => {
+      await platform.state.setState({
+        // Store as Mod Variable
+        namespace: StateNamespaces.MOD,
+        modComponentRef,
+        // Using shallow will replace the state key, but keep other keys. Always pass the full state object in order
+        // to ensure the shape is valid.
+        mergeStrategy: MergeStrategies.SHALLOW,
+        data: {
+          [stateKey]: data,
+        },
+      });
+    };
+
+    // `getState/setState` are async. So calls need to account for interlacing state modifications (including deletes).
+    // The main concern is ensuring the shape of the async state is always valid.
+    // We don't need to have strong consistency guarantees on which calls "win" if the state is updated concurrently.
+    const currentState = await platform.state.getState({
+      namespace: StateNamespaces.MOD,
+      modComponentRef,
+    });
+
+    // eslint-disable-next-line security/detect-object-injection -- user provided value that's readonly
+    const currentVariable = (currentState[stateKey] ?? {}) as JsonObject;
+
+    if (isCacheVariableState(currentVariable) && currentVariable.isFetching) {
+      // Coalesce multiple requests into a single request
+      const fetchingRequestId = currentVariable.requestId;
+
+      const deferredValuePromise = pDefer<unknown>();
+
+      document.addEventListener(
+        STATE_CHANGE_JS_EVENT_TYPE,
+        async () => {
+          const stateUpdate = await platform.state.getState({
+            namespace: StateNamespaces.MOD,
+            modComponentRef,
+          });
+
+          // eslint-disable-next-line security/detect-object-injection -- user provided value that's readonly
+          const variableUpdate = (stateUpdate[stateKey] ?? {}) as JsonObject;
+
+          if (!isCacheVariableState(variableUpdate)) {
+            deferredValuePromise.reject(
+              new BusinessError(
+                "Invalid cache shape. Cache value was overwritten.",
+              ),
+            );
+          }
+
+          if (variableUpdate.requestId !== fetchingRequestId) {
+            // XXX: should this be a CancelError?
+            deferredValuePromise.reject(
+              new BusinessError("Value generation was superseded"),
+            );
+          }
+
+          if (!variableUpdate.isFetching) {
+            if (variableUpdate.isError) {
+              deferredValuePromise.reject(
+                deserializeError(variableUpdate.error),
+              );
+            }
+
+            deferredValuePromise.resolve(variableUpdate.data);
+          }
+
+          // Ignore if still fetching
+        },
+        { signal: abortSignal },
+      );
+
+      return deferredValuePromise.promise;
+    }
+
+    if (
+      !forceFetch &&
+      isCacheVariableState(currentVariable) &&
+      currentVariable.isSuccess &&
+      (currentVariable.expiresAt == null ||
+        Date.now() < currentVariable.expiresAt)
+    ) {
+      // Cache hit. Don't return settled exceptions
+      return currentVariable.data;
+    }
+
+    // Perform a new request
+    const requestId = uuidv4();
+    const expiresAt = ttl == null ? null : Date.now() + ttl * 1000;
+
+    if (isEmpty(currentVariable)) {
+      // Initialize the mod variable.
+      await setModVariable({
+        requestId,
+        expiresAt,
+        isLoading: true,
+        isFetching: true,
+        isSuccess: false,
+        isError: false,
+        currentData: null,
+        data: null,
+        error: null,
+      });
+    } else {
+      await setModVariable({
+        // Preserve the previous data/error, if any. Due to get/setState being async, it's possible that
+        // the state could have been deleted since the getState call. Therefore, pass a full state object
+        ...currentVariable,
+        requestId,
+        expiresAt,
+        isFetching: true,
+        currentData: null,
+      });
+    }
+
+    let data: JsonObject;
+
+    try {
+      data = (await runPipeline(body, {
+        key: "body",
+        counter: 0,
+      })) as JsonObject;
+    } catch (_error) {
+      if (!(await isCurrentNonce(requestId))) {
+        // XXX: should this be a CancelError?
+        throw new BusinessError("Value generation was superseded");
+      }
+
+      await setModVariable({
+        isLoading: false,
+        isFetching: false,
+        isSuccess: false,
+        isError: true,
+        currentData: null,
+        data: null,
+        requestId,
+        error: serializeError(_error) as JsonObject,
+      });
+
+      throw new ContextError("An error occurred generating the cached value", {
+        cause: _error,
+      });
+    }
+
+    if (!(await isCurrentNonce(requestId))) {
+      // XXX: should this be a CancelError?
+      throw new BusinessError("Value generation was superseded");
+    }
+
+    await setModVariable({
+      isLoading: false,
+      isFetching: false,
+      isSuccess: true,
+      isError: false,
+      currentData: data,
+      data,
+      requestId,
+      error: null,
+      expiresAt,
+    });
+
+    return data;
+  }
+}

--- a/src/bricks/transformers/controlFlow/WithCache.ts
+++ b/src/bricks/transformers/controlFlow/WithCache.ts
@@ -317,7 +317,8 @@ export class WithCache extends TransformerABC {
       // Initialize the mod variable.
       await setModVariable({
         requestId,
-        expiresAt,
+        // Don't set expiresAt until the value is set
+        expiresAt: null,
         isLoading: true,
         isFetching: true,
         isSuccess: false,
@@ -332,7 +333,6 @@ export class WithCache extends TransformerABC {
         // the state could have been deleted since the getState call. Therefore, pass a full state object
         ...currentVariable,
         requestId,
-        expiresAt,
         isFetching: true,
         currentData: null,
       });
@@ -379,6 +379,7 @@ export class WithCache extends TransformerABC {
       data,
       requestId,
       error: null,
+      // Record expiresAt (if provided) when the value is set
       expiresAt,
     });
 

--- a/src/bricks/transformers/getAllTransformers.ts
+++ b/src/bricks/transformers/getAllTransformers.ts
@@ -61,6 +61,7 @@ import type { RegistryId, RegistryProtocol } from "@/types/registryTypes";
 import RunBrickByIdTransformer from "@/bricks/transformers/RunBrickByIdTransformer";
 import GetBrickInterfaceTransformer from "@/bricks/transformers/GetBrickInterfaceTransformer";
 import RunMetadataTransformer from "@/bricks/transformers/RunMetadataTransformer";
+import { WithCache } from "@/bricks/transformers/controlFlow/WithCache";
 
 function getAllTransformers(
   registry: RegistryProtocol<RegistryId, Brick>,
@@ -115,6 +116,7 @@ function getAllTransformers(
     new Run(),
     new MapValues(),
     new WithAsyncModVariable(),
+    new WithCache(),
 
     // Render Pipelines
     new DisplayTemporaryInfo(),

--- a/src/development/headers.test.ts
+++ b/src/development/headers.test.ts
@@ -25,7 +25,7 @@ import registerBuiltinBricks from "@/bricks/registerBuiltinBricks";
 import registerContribBricks from "@/contrib/registerContribBricks";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 137;
+const EXPECTED_HEADER_COUNT = 138;
 
 registerBuiltinBricks();
 registerContribBricks();

--- a/src/runtime/pipelineTests/pipelineTestHelpers.ts
+++ b/src/runtime/pipelineTests/pipelineTestHelpers.ts
@@ -109,7 +109,9 @@ class FeatureFlagBrick extends BrickABC {
 
 export class DeferredEchoBrick extends BrickABC {
   static BRICK_ID = validateRegistryId("test/deferred");
+
   readonly promiseOrFactory: Promise<unknown> | (() => Promise<unknown>);
+
   constructor(promiseOrFactory: Promise<unknown> | (() => Promise<unknown>)) {
     super(DeferredEchoBrick.BRICK_ID, "Deferred Brick");
     this.promiseOrFactory = promiseOrFactory;
@@ -131,7 +133,6 @@ export class DeferredEchoBrick extends BrickABC {
       await this.promiseOrFactory();
     }
 
-    await this.promiseOrFactory;
     return { message };
   }
 }


### PR DESCRIPTION
## What does this PR do?

- Closes #9202 
- PR for demos/deciding if we like the technical approach and brick ergonomics: https://www.notion.so/pixiebrix/Mod-variable-syncing-across-Page-Load-and-all-Frames-in-runtime-and-workshop-c533b56bc9ed4f6ea7aa8502439c632a?pvs=4#10143b21a25380b2aae2ef4d29b6eb82
- For reference/prior art, the Django cache framework API for `get_or_set`: https://docs.djangoproject.com/en/5.1/topics/cache/#django.core.cache.cache.get_or_set

## Discussion

- Open question on expiresAt behavior (should it be set on the leading edge of the request, or after the value comes back): https://www.notion.so/pixiebrix/Mod-variable-syncing-across-Page-Load-and-all-Frames-in-runtime-and-workshop-c533b56bc9ed4f6ea7aa8502439c632a?pvs=4#10c43b21a2538056adc1c23ee89238e4

## Demo

- _Paste a screenshot or demo video here_

## Checklist

- [ ] Update headers file on app and upload to server
- [ ] After 2.1.3 is published, deprecate `@pixies/util/with-cache`. We can't replace the brick because the state shape is different and some mods rely on the other brick only storing the value instead of the async shape
- [ ] Update the Marketplace Listing tags for the old cache brick and the new brick

## Future Work

Potential brick improvements
- Consider adding a flag to force ejection from the cache at expiry (vs. re-calculating on the next call). This is useful is other bricks are watching the async state of the cache
- Consider supporting passing a cache key/dependency array. Currently, the caller could use `forceFetch` and calculate input changes on their own. If we do implement, should consider if we want to cache old values

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
