### PR TITLE
Fix managed schema JSON Schema documentation for `disableBrowserWarning`

### DIFF
--- a/src/store/enterprise/managedStorageTypes.ts
+++ b/src/store/enterprise/managedStorageTypes.ts
@@ -69,7 +69,7 @@ export type ManagedStorageState = {
    */
   deploymentKey?: DeploymentKey;
   /**
-   * Disable the browser warning for non-Chrome browsers, e.g., Microsoft Edge
+   * Disable the browser warning for non-Chrome browsers, e.g., Opera, Brave, etc.
    * @since 1.7.36
    */
   disableBrowserWarning?: boolean;


### PR DESCRIPTION
## What does this PR do?

- Fix JSON Schema documentation for `disableBrowserWarning` because MS Edge is now officially supported

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
