### PR TITLE
#9221: Attach db name and operation name to idb errors

### DIFF
--- a/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
+++ b/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
@@ -64,7 +64,7 @@ export class ModsPage extends BasePageObject {
       .waitForEvent("requestfinished", {
         predicate: (request) =>
           request.url().includes(API_PATHS.REGISTRY_BRICKS),
-        timeout: 15_000,
+        timeout: 20_000,
       });
     await this.page.goto(this.extensionConsoleUrl);
     await expect(this.getByText("Extension Console")).toBeVisible();

--- a/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
+++ b/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
@@ -64,7 +64,7 @@ export class ModsPage extends BasePageObject {
       .waitForEvent("requestfinished", {
         predicate: (request) =>
           request.url().includes(API_PATHS.REGISTRY_BRICKS),
-        timeout: 20_000,
+        timeout: 30_000,
       });
     await this.page.goto(this.extensionConsoleUrl);
     await expect(this.getByText("Extension Console")).toBeVisible();

--- a/src/registry/packageRegistry.ts
+++ b/src/registry/packageRegistry.ts
@@ -176,7 +176,7 @@ const ensurePopulated = memoizeUntilSettled(async () => {
 export async function clear(): Promise<void> {
   await withRegistryDB(async (db) => {
     await db.clear(BRICK_STORE);
-  }, IDB_OPERATION.PACKAGE_REGISTRY.CLEAR);
+  }, IDB_OPERATION[DATABASE_NAME.PACKAGE_REGISTRY].CLEAR);
 }
 
 /**
@@ -188,7 +188,7 @@ export async function recreateDB(): Promise<void> {
   // Open the database to recreate it
   await withRegistryDB(
     async () => {},
-    IDB_OPERATION.PACKAGE_REGISTRY.RECREATE_DB,
+    IDB_OPERATION[DATABASE_NAME.PACKAGE_REGISTRY].RECREATE_DB,
   );
 
   // Re-populate the packages from the remote registry
@@ -218,7 +218,7 @@ export async function getByKinds(
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- there's at least one element per group
         latestVersion(versions)!,
     );
-  }, IDB_OPERATION.PACKAGE_REGISTRY.GET_BY_KINDS);
+  }, IDB_OPERATION[DATABASE_NAME.PACKAGE_REGISTRY].GET_BY_KINDS);
 }
 
 /**
@@ -228,7 +228,7 @@ export async function count(): Promise<number> {
   // Don't need to ensure populated, because we're just counting current records
   return withRegistryDB(
     async (db) => db.count(BRICK_STORE),
-    IDB_OPERATION.PACKAGE_REGISTRY.COUNT,
+    IDB_OPERATION[DATABASE_NAME.PACKAGE_REGISTRY].COUNT,
   );
 }
 
@@ -244,7 +244,7 @@ async function replaceAll(packages: PackageVersion[]): Promise<void> {
     await Promise.all(packages.map(async (obj) => tx.store.add(obj)));
 
     await tx.done;
-  }, IDB_OPERATION.PACKAGE_REGISTRY.REPLACE_ALL);
+  }, IDB_OPERATION[DATABASE_NAME.PACKAGE_REGISTRY].REPLACE_ALL);
 }
 
 export function parsePackage(
@@ -294,5 +294,5 @@ export async function find(id: string): Promise<Nullishable<PackageVersion>> {
     const versions = await db.getAllFromIndex(BRICK_STORE, "id", id);
 
     return latestVersion(versions);
-  }, IDB_OPERATION.PACKAGE_REGISTRY.FIND);
+  }, IDB_OPERATION[DATABASE_NAME.PACKAGE_REGISTRY].FIND);
 }

--- a/src/registry/packageRegistry.ts
+++ b/src/registry/packageRegistry.ts
@@ -19,7 +19,7 @@ import { type DBSchema, type IDBPDatabase, openDB } from "idb";
 import { flatten, groupBy, sortBy } from "lodash";
 import { type RegistryPackage } from "@/types/contract";
 import { type Except } from "type-fest";
-import { deleteDatabase } from "@/utils/idbUtils";
+import { deleteDatabase, DATABASE_NAME } from "@/utils/idbUtils";
 import { PACKAGE_REGEX } from "@/types/helpers";
 import { memoizeUntilSettled } from "@/utils/promiseUtils";
 import { getApiClient } from "@/data/service/apiClient";
@@ -27,7 +27,6 @@ import { type Nullishable, assertNotNullish } from "@/utils/nullishUtils";
 import { type DefinitionKind } from "@/types/registryTypes";
 import { API_PATHS } from "@/data/service/urlPaths";
 
-const DATABASE_NAME = "BRICK_REGISTRY";
 const BRICK_STORE = "bricks";
 const VERSION = 1;
 
@@ -67,7 +66,7 @@ async function openRegistryDB() {
   // https://stackoverflow.com/questions/21418954/is-it-bad-to-open-several-database-connections-in-indexeddb
   let database: IDBPDatabase<RegistryDB> | null = null;
 
-  database = await openDB<RegistryDB>(DATABASE_NAME, VERSION, {
+  database = await openDB<RegistryDB>(DATABASE_NAME.PACKAGE_REGISTRY, VERSION, {
     upgrade(db) {
       // Create a store of objects
       const store = db.createObjectStore(BRICK_STORE, {
@@ -176,7 +175,7 @@ export async function clear(): Promise<void> {
  * Deletes and recreates the brick definition database.
  */
 export async function recreateDB(): Promise<void> {
-  await deleteDatabase(DATABASE_NAME);
+  await deleteDatabase(DATABASE_NAME.PACKAGE_REGISTRY);
 
   // Open the database to recreate it
   await openRegistryDB();

--- a/src/telemetry/logging.test.ts
+++ b/src/telemetry/logging.test.ts
@@ -21,8 +21,8 @@ import {
   count,
   getLogEntries,
   sweepLogs,
-  reportToApplicationErrorTelemetry,
 } from "@/telemetry/logging";
+import { reportToApplicationErrorTelemetry } from "./reportToApplicationErrorTelemetry";
 import {
   logEntryFactory,
   messageContextFactory,

--- a/src/telemetry/logging.test.ts
+++ b/src/telemetry/logging.test.ts
@@ -22,7 +22,6 @@ import {
   getLogEntries,
   sweepLogs,
 } from "@/telemetry/logging";
-import { reportToApplicationErrorTelemetry } from "./reportToApplicationErrorTelemetry";
 import {
   logEntryFactory,
   messageContextFactory,
@@ -76,13 +75,13 @@ const mockFlag = (flag: FeatureFlag) => {
 
 const sendMessageSpy = jest.spyOn(global.chrome.runtime, "sendMessage");
 
-afterEach(async () => {
-  await clearLog();
-  flagOnMock.mockReset();
-  sendMessageSpy.mockReset();
-});
-
 describe("logging", () => {
+  beforeEach(async () => {
+    await clearLog();
+    flagOnMock.mockReset();
+    sendMessageSpy.mockReset();
+  });
+
   test("appendEntry", async () => {
     flagOnMock.mockResolvedValue(false);
     await appendEntry(logEntryFactory());
@@ -200,42 +199,5 @@ describe("logging", () => {
         context: expect.objectContaining({ modId }),
       }),
     ]);
-  });
-
-  test("allow Application error telemetry reporting", async () => {
-    flagOnMock.mockResolvedValue(false);
-
-    const nestedError = new Error("nested cause");
-    const reportedError = new Error("test", { cause: nestedError });
-    await reportToApplicationErrorTelemetry(reportedError, {}, "error message");
-
-    expect(flagOnMock).toHaveBeenCalledExactlyOnceWith(
-      "application-error-telemetry-disable-report",
-    );
-    expect(sendMessageSpy).toHaveBeenCalledOnce();
-    expect(sendMessageSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        target: "offscreen-doc",
-        data: expect.objectContaining({
-          error: serializeError(reportedError),
-          errorMessage: "error message",
-          messageContext: expect.objectContaining({
-            cause: nestedError,
-            code: undefined,
-            extensionVersion: "1.5.2",
-            name: "Error",
-            stack: expect.any(String),
-          }),
-        }),
-      }),
-    );
-  });
-
-  test("disable Application error telemetry reporting", async () => {
-    mockFlag(FeatureFlags.APPLICATION_ERROR_TELEMETRY_DISABLE_REPORT);
-
-    await reportToApplicationErrorTelemetry(new Error("test"), {}, "");
-
-    expect(sendMessageSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/telemetry/reportToApplicationErrorTelemetry.test.ts
+++ b/src/telemetry/reportToApplicationErrorTelemetry.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { flagOn } from "@/auth/featureFlagStorage";
+import { reportToApplicationErrorTelemetry } from "@/telemetry/reportToApplicationErrorTelemetry";
+import { serializeError } from "serialize-error";
+import Reason = chrome.offscreen.Reason;
+import { FeatureFlags, type FeatureFlag } from "@/auth/featureFlags";
+
+jest.mock("@/auth/featureFlagStorage", () => ({
+  flagOn: jest.fn().mockRejectedValue(new Error("Not mocked")),
+}));
+
+global.chrome = {
+  ...global.chrome,
+  offscreen: {
+    ...global.chrome.offscreen,
+    Reason: {
+      BLOBS: "blobs" as typeof global.chrome.offscreen.Reason.BLOBS,
+    } as typeof Reason,
+    createDocument: jest.fn(),
+  },
+};
+
+jest.mock("@/telemetry/telemetryHelpers", () => ({
+  ...jest.requireActual("@/telemetry/telemetryHelpers"),
+  mapAppUserToTelemetryUser: jest.fn().mockResolvedValue({}),
+}));
+
+const flagOnMock = jest.mocked(flagOn);
+const mockFlag = (flag: FeatureFlag) => {
+  flagOnMock.mockImplementation(async (testFlag) => flag === testFlag);
+};
+
+const sendMessageSpy = jest.spyOn(global.chrome.runtime, "sendMessage");
+
+describe("reportToApplicationErrorTelemetry", () => {
+  beforeEach(async () => {
+    flagOnMock.mockReset();
+    sendMessageSpy.mockReset();
+  });
+
+  test("allow Application error telemetry reporting", async () => {
+    flagOnMock.mockResolvedValue(false);
+
+    const nestedError = new Error("nested cause");
+    const reportedError = new Error("test", { cause: nestedError });
+    await reportToApplicationErrorTelemetry(reportedError, {}, "error message");
+
+    expect(flagOnMock).toHaveBeenCalledExactlyOnceWith(
+      "application-error-telemetry-disable-report",
+    );
+    expect(sendMessageSpy).toHaveBeenCalledOnce();
+    expect(sendMessageSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: "offscreen-doc",
+        data: expect.objectContaining({
+          error: serializeError(reportedError),
+          errorMessage: "error message",
+          messageContext: expect.objectContaining({
+            cause: nestedError,
+            code: undefined,
+            extensionVersion: "1.5.2",
+            name: "Error",
+            stack: expect.any(String),
+          }),
+        }),
+      }),
+    );
+  });
+
+  test("disable Application error telemetry reporting", async () => {
+    mockFlag(FeatureFlags.APPLICATION_ERROR_TELEMETRY_DISABLE_REPORT);
+
+    await reportToApplicationErrorTelemetry(new Error("test"), {}, "");
+
+    expect(sendMessageSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/telemetry/reportToApplicationErrorTelemetry.ts
+++ b/src/telemetry/reportToApplicationErrorTelemetry.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { readAuthData } from "@/auth/authStorage";
+import { FeatureFlags } from "@/auth/featureFlags";
+import { flagOn } from "@/auth/featureFlagStorage";
+import { selectExtraContext } from "@/data/service/errorService";
+import { BusinessError } from "@/errors/businessErrors";
+import { hasSpecificErrorCause } from "@/errors/errorHelpers";
+import { isAxiosError } from "@/errors/networkErrorHelpers";
+import { allowsTrack } from "@/telemetry/dnt";
+
+import { mapAppUserToTelemetryUser } from "@/telemetry/telemetryHelpers";
+import { ensureOffscreenDocument } from "@/tinyPages/offscreenDocumentController";
+import type { RecordErrorMessage } from "@/tinyPages/offscreenProtocol";
+import type { MessageContext } from "@/types/loggerTypes";
+import { once } from "lodash";
+import { serializeError } from "serialize-error";
+
+const warnAboutDisabledDNT = once(() => {
+  console.warn("Error telemetry is disabled because DNT is turned on");
+});
+
+const THROTTLE_AXIOS_SERVER_ERROR_STATUS_CODES = new Set([502, 503, 504]);
+const THROTTLE_RATE_MS = 60_000; // 1 minute
+let lastAxiosServerErrorTimestamp: number | null = null;
+
+/**
+ * Do not use this function directly. Use `reportError` instead: `import reportError from "@/telemetry/reportError"`
+ * It's only exported for testing.
+ */
+
+export async function reportToApplicationErrorTelemetry(
+  // Ensure it's an Error instance before passing it to Application error telemetry so Application error telemetry
+  // treats it as the error.
+  error: Error,
+  flatContext: MessageContext,
+  errorMessage: string,
+): Promise<void> {
+  // Business errors are now sent to the PixieBrix error service instead of the Application error service - see reportToErrorService
+  if (
+    hasSpecificErrorCause(error, BusinessError) ||
+    (await flagOn(FeatureFlags.APPLICATION_ERROR_TELEMETRY_DISABLE_REPORT))
+  ) {
+    return;
+  }
+
+  // Throttle certain Axios status codes because they are redundant with our platform alerts
+  if (
+    isAxiosError(error) &&
+    error.response?.status &&
+    THROTTLE_AXIOS_SERVER_ERROR_STATUS_CODES.has(error.response.status)
+  ) {
+    // JS allows subtracting dates directly but TS complains, so get the date as a number in milliseconds:
+    // https://github.com/microsoft/TypeScript/issues/8260
+    const now = Date.now();
+
+    if (
+      lastAxiosServerErrorTimestamp &&
+      now - lastAxiosServerErrorTimestamp < THROTTLE_RATE_MS
+    ) {
+      console.debug("Skipping remote error telemetry report due to throttling");
+      return;
+    }
+
+    lastAxiosServerErrorTimestamp = now;
+  }
+
+  if (!(await allowsTrack())) {
+    warnAboutDisabledDNT();
+    return;
+  }
+
+  const { version_name: versionName } = chrome.runtime.getManifest();
+  const [telemetryUser, extraContext] = await Promise.all([
+    mapAppUserToTelemetryUser(await readAuthData()),
+    selectExtraContext(error),
+  ]);
+  const errorData: RecordErrorMessage["data"] = {
+    error: serializeError(error),
+    errorMessage,
+    errorReporterInitInfo: {
+      // It should never happen that versionName is undefined, but handle undefined just in case
+      versionName: versionName ?? "",
+      telemetryUser,
+    },
+    messageContext: {
+      ...flatContext,
+      ...extraContext,
+    },
+  };
+
+  // Due to service worker limitations with the Datadog SDK, which we currently use for Application error telemetry,
+  // we need to send the error from an offscreen document.
+  // See https://github.com/pixiebrix/pixiebrix-extension/issues/8268
+  // and offscreen.ts
+  await ensureOffscreenDocument();
+
+  await chrome.runtime.sendMessage({
+    type: "record-error",
+    target: "offscreen-doc",
+    data: errorData,
+  } satisfies RecordErrorMessage);
+}

--- a/src/telemetry/trace.ts
+++ b/src/telemetry/trace.ts
@@ -28,10 +28,9 @@ import {
   type OutputKey,
   type RenderedArgs,
 } from "@/types/runtimeTypes";
-import { deleteDatabase } from "@/utils/idbUtils";
+import { DATABASE_NAME, deleteDatabase } from "@/utils/idbUtils";
 import { type Nullishable } from "@/utils/nullishUtils";
 
-const DATABASE_NAME = "TRACE";
 const ENTRY_OBJECT_STORE = "traces";
 const DB_VERSION_NUMBER = 4;
 
@@ -181,7 +180,7 @@ async function openTraceDB() {
   // https://stackoverflow.com/questions/21418954/is-it-bad-to-open-several-database-connections-in-indexeddb
   let database: IDBPDatabase<TraceDB> | null = null;
 
-  database = await openDB<TraceDB>(DATABASE_NAME, DB_VERSION_NUMBER, {
+  database = await openDB<TraceDB>(DATABASE_NAME.TRACE, DB_VERSION_NUMBER, {
     upgrade(db) {
       try {
         // For now, just clear local logs whenever we need to upgrade the log database structure. There's no real use
@@ -315,7 +314,7 @@ export async function count(): Promise<number> {
  */
 export async function recreateDB(): Promise<void> {
   // Delete the database and open the database to recreate it
-  await deleteDatabase(DATABASE_NAME);
+  await deleteDatabase(DATABASE_NAME.TRACE);
   const db = await openTraceDB();
   db.close();
 }

--- a/src/utils/idbUtils.ts
+++ b/src/utils/idbUtils.ts
@@ -100,7 +100,7 @@ export function isIDBQuotaError(error: unknown): boolean {
 
 // Rather than use reportError from @/telemetry/reportError, IDB errors are directly reported
 // to application error telemetry to avoid attempting to record the error in the idb log database.
-export function handleIdbError(
+function handleIdbError(
   error: unknown,
   {
     operationName,

--- a/src/utils/idbUtils.ts
+++ b/src/utils/idbUtils.ts
@@ -16,7 +16,7 @@ export const DATABASE_NAME = {
 } as const;
 
 export const IDB_OPERATION = {
-  LOG: {
+  [DATABASE_NAME.LOG]: {
     APPEND_ENTRY: "appendEntry",
     COUNT: "count",
     RECREATE_DB: "recreateDB",
@@ -26,7 +26,7 @@ export const IDB_OPERATION = {
     SWEEP_LOGS: "sweepLogs",
     CLEAR_MOD_COMPONENT_DEBUG_LOGS: "clearModComponentDebugLogs",
   },
-  TRACE: {
+  [DATABASE_NAME.TRACE]: {
     ADD_TRACE_ENTRY: "addTraceEntry",
     ADD_TRACE_EXIT: "addTraceExit",
     CLEAR_TRACES: "clearTraces",
@@ -35,7 +35,7 @@ export const IDB_OPERATION = {
     CLEAR_MOD_COMPONENT_TRACES: "clearModComponentTraces",
     GET_LATEST_RUN_BY_MOD_COMPONENT_ID: "getLatestRunByModComponentId",
   },
-  PACKAGE_REGISTRY: {
+  [DATABASE_NAME.PACKAGE_REGISTRY]: {
     CLEAR: "clear",
     RECREATE_DB: "recreateDB",
     GET_BY_KINDS: "getByKinds",
@@ -44,6 +44,11 @@ export const IDB_OPERATION = {
     FIND: "find",
   },
 } as const;
+
+type OperationNames =
+  | ValueOf<(typeof IDB_OPERATION)[typeof DATABASE_NAME.LOG]>
+  | ValueOf<(typeof IDB_OPERATION)[typeof DATABASE_NAME.TRACE]>
+  | ValueOf<(typeof IDB_OPERATION)[typeof DATABASE_NAME.PACKAGE_REGISTRY]>;
 
 // IDB Quota Error message strings
 const QUOTA_ERRORS = [
@@ -98,10 +103,8 @@ export function handleIdbError(
     operationName,
     databaseName,
   }: {
-    operationName:
-      | ValueOf<typeof IDB_OPERATION.LOG>
-      | ValueOf<typeof IDB_OPERATION.TRACE>
-      | ValueOf<typeof IDB_OPERATION.PACKAGE_REGISTRY>;
+    operationName: OperationNames;
+
     databaseName: ValueOf<typeof DATABASE_NAME>;
   },
 ): void {
@@ -131,10 +134,7 @@ export const withIdbErrorHandling =
   ) =>
   async <DBOperationResult>(
     dbOperation: (db: IDBPDatabase<DBType>) => Promise<DBOperationResult>,
-    operationName:
-      | ValueOf<typeof IDB_OPERATION.LOG>
-      | ValueOf<typeof IDB_OPERATION.TRACE>
-      | ValueOf<typeof IDB_OPERATION.PACKAGE_REGISTRY>,
+    operationName: OperationNames,
   ) => {
     let db: IDBPDatabase<DBType> | null = null;
     try {

--- a/src/utils/idbUtils.ts
+++ b/src/utils/idbUtils.ts
@@ -35,7 +35,14 @@ export const IDB_OPERATION = {
     CLEAR_MOD_COMPONENT_TRACES: "clearModComponentTraces",
     GET_LATEST_RUN_BY_MOD_COMPONENT_ID: "getLatestRunByModComponentId",
   },
-  PACKAGE_REGISTRY: {},
+  PACKAGE_REGISTRY: {
+    CLEAR: "clear",
+    RECREATE_DB: "recreateDB",
+    GET_BY_KINDS: "getByKinds",
+    COUNT: "count",
+    REPLACE_ALL: "replaceAll",
+    FIND: "find",
+  },
 } as const;
 
 // IDB Quota Error message strings
@@ -93,7 +100,8 @@ export function handleIdbError(
   }: {
     operationName:
       | ValueOf<typeof IDB_OPERATION.LOG>
-      | ValueOf<typeof IDB_OPERATION.TRACE>;
+      | ValueOf<typeof IDB_OPERATION.TRACE>
+      | ValueOf<typeof IDB_OPERATION.PACKAGE_REGISTRY>;
     databaseName: ValueOf<typeof DATABASE_NAME>;
   },
 ): void {

--- a/src/utils/idbUtils.ts
+++ b/src/utils/idbUtils.ts
@@ -43,7 +43,10 @@ export const IDB_OPERATION = {
     REPLACE_ALL: "replaceAll",
     FIND: "find",
   },
-} as const;
+} as const satisfies Record<
+  ValueOf<typeof DATABASE_NAME>,
+  Record<string, string>
+>;
 
 type OperationNames =
   | ValueOf<(typeof IDB_OPERATION)[typeof DATABASE_NAME.LOG]>

--- a/src/utils/idbUtils.ts
+++ b/src/utils/idbUtils.ts
@@ -26,7 +26,15 @@ export const IDB_OPERATION = {
     SWEEP_LOGS: "sweepLogs",
     CLEAR_MOD_COMPONENT_DEBUG_LOGS: "clearModComponentDebugLogs",
   },
-  TRACE: {},
+  TRACE: {
+    ADD_TRACE_ENTRY: "addTraceEntry",
+    ADD_TRACE_EXIT: "addTraceExit",
+    CLEAR_TRACES: "clearTraces",
+    COUNT: "count",
+    RECREATE_DB: "recreateDB",
+    CLEAR_MOD_COMPONENT_TRACES: "clearModComponentTraces",
+    GET_LATEST_RUN_BY_MOD_COMPONENT_ID: "getLatestRunByModComponentId",
+  },
   PACKAGE_REGISTRY: {},
 } as const;
 
@@ -115,7 +123,10 @@ export const withIdbErrorHandling =
   ) =>
   async <DBOperationResult>(
     dbOperation: (db: IDBPDatabase<DBType>) => Promise<DBOperationResult>,
-    operationName: ValueOf<typeof IDB_OPERATION.LOG>,
+    operationName:
+      | ValueOf<typeof IDB_OPERATION.LOG>
+      | ValueOf<typeof IDB_OPERATION.TRACE>
+      | ValueOf<typeof IDB_OPERATION.PACKAGE_REGISTRY>,
   ) => {
     let db: IDBPDatabase<DBType> | null = null;
     try {


### PR DESCRIPTION
## What does this PR do?

- Closes #9221 

## Discussion

- Still rethrows the errors, which means some errors will likely be double-reported
- In `logging.ts`, we swallow some of the errors but not others
   - @fungairino, what criteria did you use to determine which errors should be swallowed?

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
