### PR TITLE
Only clear mod component debug logs if logValues is enabled

### DIFF
--- a/src/contentScript/contentScriptPlatform.ts
+++ b/src/contentScript/contentScriptPlatform.ts
@@ -270,11 +270,17 @@ class ContentScriptPlatform extends PlatformBase {
 
   override get debugger(): PlatformProtocol["debugger"] {
     return {
-      async clear(componentId: UUID): Promise<void> {
-        await Promise.all([
-          traces.clear(componentId),
-          clearModComponentDebugLogs(componentId),
-        ]);
+      async clear(
+        componentId: UUID,
+        { logValues }: { logValues: boolean },
+      ): Promise<void> {
+        const clearPromises = [traces.clear(componentId)];
+
+        if (logValues) {
+          clearPromises.push(clearModComponentDebugLogs(componentId));
+        }
+
+        await Promise.all(clearPromises);
       },
       traces: {
         enter: traces.addEntry,

--- a/src/extensionPages/extensionPagePlatform.test.ts
+++ b/src/extensionPages/extensionPagePlatform.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import extensionPagePlatform from "@/extensionPages/extensionPagePlatform";
+import { setPlatform } from "@/platform/platformContext";
+import { modComponentFactory } from "@/testUtils/factories/modComponentFactories";
+import { clearModComponentDebugLogs, traces } from "@/background/messenger/api";
+
+jest.mock("@/background/messenger/api", () => ({
+  clearModComponentDebugLogs: jest.fn(),
+  traces: {
+    clear: jest.fn(),
+  },
+}));
+
+const tracesClearMock = jest.mocked(traces.clear);
+const clearModComponentDebugLogsMock = jest.mocked(clearModComponentDebugLogs);
+
+describe("extensionPagePlatform", () => {
+  beforeEach(() => {
+    setPlatform(extensionPagePlatform);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("debugger", () => {
+    it("clears traces and clears logs when logValues is true", async () => {
+      const componentId = modComponentFactory().id;
+      await extensionPagePlatform.debugger.clear(componentId, {
+        logValues: true,
+      });
+
+      expect(tracesClearMock).toHaveBeenCalledExactlyOnceWith(componentId);
+      expect(clearModComponentDebugLogsMock).toHaveBeenCalledExactlyOnceWith(
+        componentId,
+      );
+    });
+
+    it("clears traces and skips clearing logs when logValues is false", async () => {
+      const componentId = modComponentFactory().id;
+      await extensionPagePlatform.debugger.clear(componentId, {
+        logValues: false,
+      });
+
+      expect(tracesClearMock).toHaveBeenCalledExactlyOnceWith(componentId);
+      expect(clearModComponentDebugLogsMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/extensionPages/extensionPagePlatform.ts
+++ b/src/extensionPages/extensionPagePlatform.ts
@@ -69,11 +69,17 @@ class ExtensionPagePlatform extends PlatformBase {
   // Support tracing for bricks run in the sidebar and clearing logs in Page Editor/Extension Console. See PanelBody.tsx
   override get debugger(): PlatformProtocol["debugger"] {
     return {
-      async clear(componentId: UUID): Promise<void> {
-        await Promise.all([
-          traces.clear(componentId),
-          clearModComponentDebugLogs(componentId),
-        ]);
+      async clear(
+        componentId: UUID,
+        { logValues }: { logValues: boolean },
+      ): Promise<void> {
+        const clearPromises = [traces.clear(componentId)];
+
+        if (logValues) {
+          clearPromises.push(clearModComponentDebugLogs(componentId));
+        }
+
+        await Promise.all(clearPromises);
       },
       traces: {
         enter: traces.addEntry,

--- a/src/platform/platformTypes/debuggerProtocol.ts
+++ b/src/platform/platformTypes/debuggerProtocol.ts
@@ -39,7 +39,10 @@ export interface DebuggerProtocol {
    *
    * @param componentId the mod component id
    */
-  clear: (componentId: UUID) => Promise<void>;
+  clear: (
+    componentId: UUID,
+    { logValues }: { logValues: boolean },
+  ) => Promise<void>;
 
   traces: TraceProtocol;
 }


### PR DESCRIPTION
## What does this PR do?

- Part of #9211 

## Discussion

- `logValues` only impacts whether we append debug logs to the LOG idb database, so we still need to clear traces
- Do we really need to clear traces in the content script platform? 
    - I left it in because I wasn't certain if it's necessary

## Remaining work

- [x] Add tests

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
