### PR TITLE
#9239: rename "reset" to "clear changes" in the Page Editor

### DIFF
--- a/src/pageEditor/hooks/useClearModChanges.ts
+++ b/src/pageEditor/hooks/useClearModChanges.ts
@@ -20,22 +20,25 @@ import { type RegistryId } from "@/types/registryTypes";
 import { actions } from "@/pageEditor/store/editor/editorSlice";
 import { useModals } from "@/components/ConfirmationModal";
 import { useDispatch, useSelector } from "react-redux";
-import useResetModComponent from "@/pageEditor/hooks/useResetModComponent";
+import useClearModComponentChanges from "@/pageEditor/hooks/useClearModComponentChanges";
 import { selectModComponentFormStates } from "@/pageEditor/store/editor/editorSelectors";
 
-function useResetMod(): (modId: RegistryId) => Promise<void> {
+/**
+ * @see useClearModComponentChanges
+ */
+function useClearModChanges(): (modId: RegistryId) => Promise<void> {
   const { showConfirmation } = useModals();
   const dispatch = useDispatch();
-  const resetModComponent = useResetModComponent();
+  const clearModComponentChanges = useClearModComponentChanges();
   const modComponentFormStates = useSelector(selectModComponentFormStates);
 
   return useCallback(
     async (modId: RegistryId) => {
       const confirmed = await showConfirmation({
-        title: "Reset Mod?",
+        title: "Clear Mod Changes?",
         message:
           "Unsaved changes to this mod, or to mod options and metadata, will be lost.",
-        submitCaption: "Reset",
+        submitCaption: "Clear Changes",
       });
       if (!confirmed) {
         return;
@@ -43,24 +46,26 @@ function useResetMod(): (modId: RegistryId) => Promise<void> {
 
       await Promise.all(
         modComponentFormStates
-          .filter(
-            (modComponentFormState) =>
-              modComponentFormState.modMetadata?.id === modId,
-          )
+          .filter((x) => x.modMetadata?.id === modId)
           .map(async (modComponentFormState) =>
-            resetModComponent({
+            clearModComponentChanges({
               modComponentId: modComponentFormState.uuid,
               shouldShowConfirmation: false,
             }),
           ),
       );
 
-      dispatch(actions.resetMetadataAndOptionsForMod(modId));
+      dispatch(actions.clearMetadataAndOptionsChangesForMod(modId));
       dispatch(actions.restoreDeletedModComponentFormStatesForMod(modId));
       dispatch(actions.setActiveModId(modId));
     },
-    [dispatch, modComponentFormStates, resetModComponent, showConfirmation],
+    [
+      dispatch,
+      modComponentFormStates,
+      clearModComponentChanges,
+      showConfirmation,
+    ],
   );
 }
 
-export default useResetMod;
+export default useClearModChanges;

--- a/src/pageEditor/hooks/useClearModChanges.ts
+++ b/src/pageEditor/hooks/useClearModChanges.ts
@@ -24,6 +24,7 @@ import useClearModComponentChanges from "@/pageEditor/hooks/useClearModComponent
 import { selectModComponentFormStates } from "@/pageEditor/store/editor/editorSelectors";
 
 /**
+ * Hook that returns a callback to clear unsaved mod changes for a given mod id.
  * @see useClearModComponentChanges
  */
 function useClearModChanges(): (modId: RegistryId) => Promise<void> {

--- a/src/pageEditor/hooks/useClearModComponentChanges.ts
+++ b/src/pageEditor/hooks/useClearModComponentChanges.ts
@@ -36,6 +36,7 @@ type Config = {
 };
 
 /**
+ * Hook that returns a callback to clear unsaved changes for a given mod component id.
  * @see useClearModChanges
  */
 function useClearModComponentChanges(): (

--- a/src/pageEditor/hooks/useClearModComponentChanges.ts
+++ b/src/pageEditor/hooks/useClearModComponentChanges.ts
@@ -35,7 +35,12 @@ type Config = {
   shouldShowConfirmation?: boolean;
 };
 
-function useResetModComponent(): (useResetConfig: Config) => Promise<void> {
+/**
+ * @see useClearModChanges
+ */
+function useClearModComponentChanges(): (
+  useClearModComponentChangesConfig: Config,
+) => Promise<void> {
   const dispatch = useDispatch();
   const sessionId = useSelector(selectSessionId);
   const activatedModComponents = useSelector(selectActivatedModComponents);
@@ -46,9 +51,10 @@ function useResetModComponent(): (useResetConfig: Config) => Promise<void> {
     async ({ modComponentId, shouldShowConfirmation = true }) => {
       if (shouldShowConfirmation) {
         const confirm = await showConfirmation({
-          title: "Reset Brick?",
-          message: "Any changes you made since the last save will be lost",
-          submitCaption: "Reset",
+          title: "Clear Mod Component Changes?",
+          message:
+            "Any changes you made to this mod component since the last save will be lost",
+          submitCaption: "Clear Changes",
         });
 
         if (!confirm) {
@@ -56,7 +62,7 @@ function useResetModComponent(): (useResetConfig: Config) => Promise<void> {
         }
       }
 
-      reportEvent(Events.PAGE_EDITOR_RESET, {
+      reportEvent(Events.PAGE_EDITOR_CLEAR_CHANGES, {
         sessionId,
         modComponentId,
       });
@@ -81,4 +87,4 @@ function useResetModComponent(): (useResetConfig: Config) => Promise<void> {
   );
 }
 
-export default useResetModComponent;
+export default useClearModComponentChanges;

--- a/src/pageEditor/hooks/useCreateModFromUnsavedMod.ts
+++ b/src/pageEditor/hooks/useCreateModFromUnsavedMod.ts
@@ -172,7 +172,9 @@ function useCreateModFromUnsavedMod(): UseCreateModFromUnsavedModReturn {
           }
 
           const newModId = newModDefinition.metadata.id;
-          dispatch(editorActions.resetMetadataAndOptionsForMod(newModId));
+          dispatch(
+            editorActions.clearMetadataAndOptionsChangesForMod(newModId),
+          );
           dispatch(
             editorActions.clearDeletedModComponentFormStatesForMod(newModId),
           );

--- a/src/pageEditor/hooks/useSaveMod.test.ts
+++ b/src/pageEditor/hooks/useSaveMod.test.ts
@@ -274,6 +274,7 @@ describe("useSaveMod", () => {
         setupRedux(dispatch, { store }) {
           jest.spyOn(store, "dispatch");
           dispatch(
+            // FIXME: temporary mod ids should never be activated in the mod component slice
             modComponentSlice.actions.activateMod({
               modDefinition: defaultModDefinitionFactory({
                 metadata: modMetadataFactory({

--- a/src/pageEditor/hooks/useSaveMod.test.ts
+++ b/src/pageEditor/hooks/useSaveMod.test.ts
@@ -35,7 +35,7 @@ import modComponentSlice from "@/store/modComponents/modComponentSlice";
 import { type UUID } from "@/types/stringTypes";
 import { API_PATHS } from "@/data/service/urlPaths";
 import { createNewUnsavedModMetadata } from "@/utils/modUtils";
-import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
+import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
 
 const modId = validateRegistryId("@test/mod");
 
@@ -264,27 +264,23 @@ describe("useSaveMod", () => {
   it("opens the create mod modal if save is called with a temporary, internal mod", async () => {
     appApiMock.reset();
 
-    const temporaryModId = createNewUnsavedModMetadata({
+    const temporaryModMetadata = createNewUnsavedModMetadata({
       modName: "Test Mod",
-    }).id;
+    });
 
     const { result, waitForEffect, getReduxStore } = renderHook(
       () => useSaveMod(),
       {
         setupRedux(dispatch, { store }) {
           jest.spyOn(store, "dispatch");
-          dispatch(
-            // FIXME: temporary mod ids should never be activated in the mod component slice
-            modComponentSlice.actions.activateMod({
-              modDefinition: defaultModDefinitionFactory({
-                metadata: modMetadataFactory({
-                  id: temporaryModId,
-                }),
-              }),
-              screen: "pageEditor",
-              isReactivate: false,
-            }),
-          );
+
+          const formState = formStateFactory({
+            formStateConfig: {
+              modMetadata: temporaryModMetadata,
+            },
+          });
+
+          dispatch(editorActions.addModComponentFormState(formState));
         },
       },
     );
@@ -294,7 +290,7 @@ describe("useSaveMod", () => {
     const { dispatch } = getReduxStore();
 
     await hookAct(async () => {
-      await result.current(temporaryModId);
+      await result.current(temporaryModMetadata.id);
     });
 
     expect(dispatch).toHaveBeenCalledWith(

--- a/src/pageEditor/hooks/useSaveMod.ts
+++ b/src/pageEditor/hooks/useSaveMod.ts
@@ -201,7 +201,9 @@ function useSaveMod(): (modId: RegistryId) => Promise<void> {
       }
 
       // Clear the dirty states
-      dispatch(editorActions.resetMetadataAndOptionsForMod(newModMetadata.id));
+      dispatch(
+        editorActions.clearMetadataAndOptionsChangesForMod(newModMetadata.id),
+      );
       dispatch(
         editorActions.clearDeletedModComponentFormStatesForMod(
           newModMetadata.id,

--- a/src/pageEditor/modListingPanel/ActionMenu.stories.tsx
+++ b/src/pageEditor/modListingPanel/ActionMenu.stories.tsx
@@ -42,7 +42,7 @@ const Template: ComponentStory<typeof ActionMenu> = (args) => (
 
 export const NewModComponent = Template.bind({});
 NewModComponent.args = {
-  onReset: undefined,
+  onClearChanges: undefined,
   onRemoveFromMod: undefined,
   isDirty: true,
 };
@@ -60,7 +60,7 @@ Mod.args = {
 
 export const NewModComponentInMod = Template.bind({});
 NewModComponentInMod.args = {
-  onReset: undefined,
+  onClearChanges: undefined,
   onAddToMod: undefined,
 };
 

--- a/src/pageEditor/modListingPanel/ActionMenu.tsx
+++ b/src/pageEditor/modListingPanel/ActionMenu.tsx
@@ -41,7 +41,7 @@ type ActionMenuProps = {
   onDelete?: () => Promise<void>;
   onDeactivate?: () => Promise<void>;
   onClone: () => Promise<void>;
-  onReset?: () => Promise<void>;
+  onClearChanges?: () => Promise<void>;
   isDirty?: boolean;
   onAddToMod?: () => Promise<void>;
   onRemoveFromMod?: () => Promise<void>;
@@ -56,7 +56,7 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
   onDelete = null,
   onDeactivate = null,
   onClone,
-  onReset = null,
+  onClearChanges = null,
   isDirty,
   onAddToMod = null,
   onRemoveFromMod = null,
@@ -67,11 +67,11 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
 
   const menuItems: EllipsisMenuItem[] = [
     {
-      title: "Reset",
+      title: "Clear Changes",
       icon: <FontAwesomeIcon icon={faHistory} fixedWidth />,
-      action: onReset,
-      disabled: !isDirty || disabled,
-      hide: !onReset,
+      action: onClearChanges,
+      // Always show Clear Changes button, even if there are no changes
+      disabled: !isDirty || disabled || !onClearChanges,
     },
     {
       title: "Add Starter Brick",

--- a/src/pageEditor/modListingPanel/ActionMenu.tsx
+++ b/src/pageEditor/modListingPanel/ActionMenu.tsx
@@ -70,7 +70,8 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
       title: "Clear Changes",
       icon: <FontAwesomeIcon icon={faHistory} fixedWidth />,
       action: onClearChanges,
-      // Always show Clear Changes button, even if there are no changes
+      // Always show Clear Changes button, even if there are no changes so the UI is more consistent / the user doesn't
+      // wonder why the menu item is missing
       disabled: !isDirty || disabled || !onClearChanges,
     },
     {

--- a/src/pageEditor/modListingPanel/DraftModComponentListItem.tsx
+++ b/src/pageEditor/modListingPanel/DraftModComponentListItem.tsx
@@ -44,7 +44,7 @@ import {
   selectModComponentIsDirty,
 } from "@/pageEditor/store/editor/editorSelectors";
 import ActionMenu from "@/pageEditor/modListingPanel/ActionMenu";
-import useResetModComponent from "@/pageEditor/hooks/useResetModComponent";
+import useClearModComponentChanges from "@/pageEditor/hooks/useClearModComponentChanges";
 import {
   useRemoveModComponentFromStorage,
   DEACTIVATE_MOD_MODAL_PROPS,
@@ -104,7 +104,7 @@ const DraftModComponentListItem: React.FunctionComponent<
     await disableOverlay(inspectedTab);
   }, []);
 
-  const resetModComponent = useResetModComponent();
+  const clearModComponentChanges = useClearModComponentChanges();
 
   const deleteModComponent = async () =>
     removeModComponentFromStorage({
@@ -131,8 +131,8 @@ const DraftModComponentListItem: React.FunctionComponent<
     return undefined;
   }, [dispatch, modComponentFormState.modMetadata, modComponentFormState.uuid]);
 
-  const onReset = async () =>
-    resetModComponent({ modComponentId: modComponentFormState.uuid });
+  const onClearChanges = async () =>
+    clearModComponentChanges({ modComponentId: modComponentFormState.uuid });
 
   const onDelete = modId || !isSavedOnCloud ? deleteModComponent : undefined;
 
@@ -208,7 +208,9 @@ const DraftModComponentListItem: React.FunctionComponent<
         onDelete={onDelete}
         onDeactivate={onDeactivate}
         onClone={onClone}
-        onReset={modComponentFormState.installed ? onReset : undefined}
+        onClearChanges={
+          modComponentFormState.installed ? onClearChanges : undefined
+        }
         isDirty={isDirty}
         onAddToMod={
           modComponentFormState.modMetadata

--- a/src/pageEditor/modListingPanel/ModComponents.tsx
+++ b/src/pageEditor/modListingPanel/ModComponents.tsx
@@ -35,7 +35,7 @@ import {
 } from "@/pageEditor/store/editor/editorSelectors";
 import { useDispatch, useSelector } from "react-redux";
 import useSaveMod from "@/pageEditor/hooks/useSaveMod";
-import useResetMod from "@/pageEditor/hooks/useResetMod";
+import useClearModChanges from "@/pageEditor/hooks/useClearModChanges";
 import useDeactivateMod from "@/pageEditor/hooks/useDeactivateMod";
 import ModComponentListItem from "./ModComponentListItem";
 import { actions } from "@/pageEditor/store/editor/editorSlice";
@@ -88,12 +88,13 @@ const ModComponents: React.FunctionComponent = () => {
   );
 
   const saveMod = useSaveMod();
-  const resetMod = useResetMod();
+  const clearModChanges = useClearModChanges();
   const deactivateMod = useDeactivateMod();
 
   const listItems = filteredSidebarItems.map((sidebarItem) => {
     if (isModSidebarItem(sidebarItem)) {
       const { modMetadata, modComponents } = sidebarItem;
+
       return (
         <ModListItem
           key={modMetadata.id}
@@ -101,8 +102,8 @@ const ModComponents: React.FunctionComponent = () => {
           onSave={async () => {
             await saveMod(modMetadata.id);
           }}
-          onReset={async () => {
-            await resetMod(modMetadata.id);
+          onClearChanges={async () => {
+            await clearModChanges(modMetadata.id);
           }}
           onDeactivate={async () => {
             await deactivateMod({ modId: modMetadata.id });

--- a/src/pageEditor/modListingPanel/ModListItem.test.tsx
+++ b/src/pageEditor/modListingPanel/ModListItem.test.tsx
@@ -41,7 +41,7 @@ describe("ModListItem", () => {
           <ModListItem
             modMetadata={modMetadata}
             onSave={jest.fn()}
-            onReset={jest.fn()}
+            onClearChanges={jest.fn()}
             onDeactivate={jest.fn()}
             onClone={jest.fn()}
           >
@@ -72,7 +72,7 @@ describe("ModListItem", () => {
           <ModListItem
             modMetadata={modMetadata}
             onSave={jest.fn()}
-            onReset={jest.fn()}
+            onClearChanges={jest.fn()}
             onDeactivate={jest.fn()}
             onClone={jest.fn()}
           >
@@ -112,7 +112,7 @@ describe("ModListItem", () => {
           <ModListItem
             modMetadata={modMetadata}
             onSave={jest.fn()}
-            onReset={jest.fn()}
+            onClearChanges={jest.fn()}
             onDeactivate={jest.fn()}
             onClone={jest.fn()}
           >

--- a/src/pageEditor/modListingPanel/ModListItem.tsx
+++ b/src/pageEditor/modListingPanel/ModListItem.tsx
@@ -40,11 +40,12 @@ import ActionMenu from "@/pageEditor/modListingPanel/ActionMenu";
 import { useGetModDefinitionQuery } from "@/data/service/api";
 import useAddNewModComponent from "@/pageEditor/hooks/useAddNewModComponent";
 import { type ModMetadata } from "@/types/modComponentTypes";
+import { isInnerDefinitionRegistryId } from "@/types/helpers";
 
 export type ModListItemProps = PropsWithChildren<{
   modMetadata: ModMetadata;
   onSave: () => Promise<void>;
-  onReset: () => Promise<void>;
+  onClearChanges: () => Promise<void>;
   onDeactivate: () => Promise<void>;
   onClone: () => Promise<void>;
 }>;
@@ -53,7 +54,7 @@ const ModListItem: React.FC<ModListItemProps> = ({
   modMetadata,
   children,
   onSave,
-  onReset,
+  onClearChanges,
   onDeactivate,
   onClone,
 }) => {
@@ -80,6 +81,8 @@ const ModListItem: React.FC<ModListItemProps> = ({
   const dirtyName = useSelector(selectDirtyMetadataForModId(modId))?.name;
   const name = dirtyName ?? savedName ?? "Loading...";
   const isDirty = useSelector(selectModIsDirty(modId));
+
+  const isUnsavedMod = isInnerDefinitionRegistryId(modMetadata.id);
 
   const hasUpdate =
     latestModVersion != null &&
@@ -116,7 +119,7 @@ const ModListItem: React.FC<ModListItemProps> = ({
           isActive={isActive}
           labelRoot={name}
           onSave={onSave}
-          onReset={onReset}
+          onClearChanges={isUnsavedMod ? undefined : onClearChanges}
           onDeactivate={onDeactivate}
           onAddStarterBrick={addNewModComponent}
           onClone={onClone}

--- a/src/pageEditor/modListingPanel/ModListingPanel.test.tsx
+++ b/src/pageEditor/modListingPanel/ModListingPanel.test.tsx
@@ -82,7 +82,6 @@ describe("ModListingPanel", () => {
 
     render(<ModListingPanel />, {
       setupRedux(dispatch) {
-        // The addElement also sets the active element
         dispatch(editorActions.addModComponentFormState(formState));
       },
     });

--- a/src/pageEditor/modListingPanel/ModListingPanel.test.tsx
+++ b/src/pageEditor/modListingPanel/ModListingPanel.test.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render } from "@/pageEditor/testHelpers";
+import React from "react";
+import ModListingPanel from "@/pageEditor/modListingPanel/ModListingPanel";
+import { modDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
+import modComponentSlice from "@/store/modComponents/modComponentSlice";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe("ModListingPanel", () => {
+  it("renders listing for activated mod with no changes", async () => {
+    const modDefinition = modDefinitionFactory();
+
+    render(<ModListingPanel />, {
+      setupRedux(dispatch) {
+        dispatch(
+          modComponentSlice.actions.activateMod({
+            modDefinition,
+            configuredDependencies: [],
+            optionsArgs: {},
+            screen: "pageEditor",
+            isReactivate: false,
+            deployment: undefined,
+          }),
+        );
+      },
+    });
+
+    expect(screen.getByText(modDefinition.metadata.name)).toBeInTheDocument();
+
+    // Select the mod
+    await userEvent.click(screen.getByText(modDefinition.metadata.name));
+
+    // Check that clicking expands the mod listing
+    expect(
+      screen.getByText(modDefinition.extensionPoints[0]!.label),
+    ).toBeVisible();
+
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: `${modDefinition.metadata.name} - Ellipsis`,
+      }),
+    );
+
+    // "Clear Changes" is disabled because there's no dirty state
+    expect(screen.getByText("Clear Changes")).toBeInTheDocument();
+    expect(screen.getByText("Clear Changes")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+});

--- a/src/pageEditor/store/editor/editorSlice.ts
+++ b/src/pageEditor/store/editor/editorSlice.ts
@@ -582,7 +582,10 @@ export const editorSlice = createSlice({
       const { payload: metadata } = action;
       editModMetadata(state, metadata);
     },
-    resetMetadataAndOptionsForMod(state, action: PayloadAction<RegistryId>) {
+    clearMetadataAndOptionsChangesForMod(
+      state,
+      action: PayloadAction<RegistryId>,
+    ) {
       const { payload: modId } = action;
       delete state.dirtyModMetadataById[modId];
       delete state.dirtyModOptionsById[modId];

--- a/src/store/modComponents/modComponentSlice.ts
+++ b/src/store/modComponents/modComponentSlice.ts
@@ -37,6 +37,7 @@ import { type OptionsArgs } from "@/types/runtimeTypes";
 import { type IntegrationDependency } from "@/integrations/integrationTypes";
 import { initialState } from "@/store/modComponents/modComponentSliceInitialState";
 import { mapModComponentDefinitionToActivatedModComponent } from "@/activation/mapModComponentDefinitionToActivatedModComponent";
+import { isInnerDefinitionRegistryId } from "@/types/helpers";
 
 type ActivateModPayload = {
   /**
@@ -120,6 +121,12 @@ const modComponentSlice = createSlice({
         },
       }: PayloadAction<ActivateModPayload>,
     ) {
+      if (isInnerDefinitionRegistryId(modDefinition.metadata.id)) {
+        throw new Error(
+          "Unsaved Page Editor mod definitions should not be included in the modComponentSlice",
+        );
+      }
+
       for (const modComponentDefinition of modDefinition.extensionPoints) {
         // May be null from bad Workshop edit?
         if (modComponentDefinition.id == null) {

--- a/src/store/sessionChanges/sessionChangesListenerMiddleware.ts
+++ b/src/store/sessionChanges/sessionChangesListenerMiddleware.ts
@@ -33,7 +33,7 @@ sessionChangesListenerMiddleware.startListening({
     actions.editModMetadata,
     actions.editModOptionsDefinitions,
     actions.editModOptionsValues,
-    actions.resetMetadataAndOptionsForMod,
+    actions.clearMetadataAndOptionsChangesForMod,
     actions.addModComponentFormStateToMod,
     actions.addModComponentFormState,
     actions.removeModComponentFormStateFromMod,

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -97,7 +97,7 @@ export const Events = {
   PAGE_EDITOR_MANUAL_RUN: "PageEditorManualRun",
   PAGE_EDITOR_MOD_COMPONENT_ERROR: "PageEditorExtensionError",
   PAGE_EDITOR_REMOVE: "PageEditorRemove",
-  PAGE_EDITOR_RESET: "PageEditorReset",
+  PAGE_EDITOR_CLEAR_CHANGES: "PageEditorReset",
   PAGE_EDITOR_STANDALONE_MOD_COMPONENT_UPDATE: "PageEditorSave",
   PAGE_EDITOR_VIEW_TEMPLATES: "PageEditorViewTemplates",
   PAGE_EDITOR_MOD_CREATE: "PageEditorModCreate",

--- a/src/telemetry/lexicon.ts
+++ b/src/telemetry/lexicon.ts
@@ -105,6 +105,11 @@ export const lexicon: LexiconMap = {
       "property and add additional properties to this event at will.",
     tags: [LexiconTags.MOD_RUNTIME],
   },
+  PAGE_EDITOR_CLEAR_CHANGES: {
+    description:
+      "Reported when Clear Changes is clicked in 3-dot action action menu for a mod/mod component in the Page Editor",
+    tags: [LexiconTags.PAGE_EDITOR],
+  },
 };
 
 /**


### PR DESCRIPTION
## What does this PR do?

- Closes #9239
- Rename "Reset" to "Clear Changes" (include internal uses of reset)
- Always show, but show as disabled for mods/mod components that have never been saved before

## Discussion

- The "Clear Changes" terminology is better than "Reset". In the future, we might consider "Rollback" or different single word action in the future. (e.g., the Git plugin for IntelliJ uses Rollback)

## Checklist

- [x] This PR requires a documentation change (link to old docs): @Pashaminkovsky @brittanyjoiner15 

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
