### PR TITLE
#9241: add "Duplicate" action to mod components

### DIFF
--- a/src/pageEditor/modListingPanel/DraftModComponentListItem.tsx
+++ b/src/pageEditor/modListingPanel/DraftModComponentListItem.tsx
@@ -43,7 +43,7 @@ import {
   selectActiveModId,
   selectModComponentIsDirty,
 } from "@/pageEditor/store/editor/editorSelectors";
-import ActionMenu from "@/pageEditor/modListingPanel/ActionMenu";
+import ModComponentActionMenu from "@/pageEditor/modListingPanel/ModComponentActionMenu";
 import useClearModComponentChanges from "@/pageEditor/hooks/useClearModComponentChanges";
 import {
   useRemoveModComponentFromStorage,
@@ -113,6 +113,7 @@ const DraftModComponentListItem: React.FunctionComponent<
         ? DELETE_STARTER_BRICK_MODAL_PROPS
         : DELETE_STANDALONE_MOD_COMPONENT_MODAL_PROPS,
     });
+
   const deactivateModComponent = async () =>
     removeModComponentFromStorage({
       modComponentId: modComponentFormState.uuid,
@@ -137,10 +138,6 @@ const DraftModComponentListItem: React.FunctionComponent<
   const onDelete = modId || !isSavedOnCloud ? deleteModComponent : undefined;
 
   const onDeactivate = onDelete ? undefined : deactivateModComponent;
-
-  const onClone = async () => {
-    dispatch(actions.cloneActiveModComponent());
-  };
 
   return (
     <ListGroup.Item
@@ -201,17 +198,19 @@ const DraftModComponentListItem: React.FunctionComponent<
             <UnsavedChangesIcon />
           </span>
         )}
-      <ActionMenu
+      <ModComponentActionMenu
         isActive={isActive}
+        isDirty={isDirty}
         labelRoot={`${getLabel(modComponentFormState)}`}
         onSave={onSave}
         onDelete={onDelete}
         onDeactivate={onDeactivate}
-        onClone={onClone}
+        onDuplicate={async () => {
+          dispatch(actions.duplicateActiveModComponent());
+        }}
         onClearChanges={
           modComponentFormState.installed ? onClearChanges : undefined
         }
-        isDirty={isDirty}
         onAddToMod={
           modComponentFormState.modMetadata
             ? undefined

--- a/src/pageEditor/modListingPanel/ModActionMenu.tsx
+++ b/src/pageEditor/modListingPanel/ModActionMenu.tsx
@@ -19,12 +19,9 @@ import React from "react";
 import SaveButton from "@/pageEditor/modListingPanel/SaveButton";
 import {
   faClone,
-  faFileExport,
-  faFileImport,
   faHistory,
   faPlus,
   faTimes,
-  faTrash,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import styles from "./ActionMenu.module.scss";
@@ -34,34 +31,30 @@ import EllipsisMenu, {
 import { type AddNewModComponent } from "@/pageEditor/hooks/useAddNewModComponent";
 import { useAvailableFormStateAdapters } from "@/pageEditor/starterBricks/adapter";
 
+type OptionalAction = (() => Promise<void>) | undefined;
+
 type ActionMenuProps = {
+  isDirty: boolean;
   isActive: boolean;
-  labelRoot?: string;
-  onSave: (() => Promise<void>) | undefined;
-  onDelete?: () => Promise<void>;
-  onDeactivate?: () => Promise<void>;
-  onClone: () => Promise<void>;
-  onClearChanges?: () => Promise<void>;
-  isDirty?: boolean;
-  onAddToMod?: () => Promise<void>;
-  onRemoveFromMod?: () => Promise<void>;
-  disabled?: boolean;
-  onAddStarterBrick?: AddNewModComponent;
+  labelRoot: string;
+  onDeactivate: () => Promise<void>;
+  onMakeCopy: () => Promise<void>;
+  onAddStarterBrick: AddNewModComponent;
+  // Actions only defined if there are changes
+  onSave: OptionalAction;
+  onClearChanges: OptionalAction;
 };
 
-const ActionMenu: React.FC<ActionMenuProps> = ({
+const ModActionMenu: React.FC<ActionMenuProps> = ({
   isActive,
   labelRoot,
-  onSave,
-  onDelete = null,
-  onDeactivate = null,
-  onClone,
-  onClearChanges = null,
   isDirty,
-  onAddToMod = null,
-  onRemoveFromMod = null,
-  disabled,
-  onAddStarterBrick = null,
+  onAddStarterBrick,
+  onDeactivate,
+  onMakeCopy,
+  // Convert to null because EllipsisMenuItem expects null vs. undefined
+  onSave = null,
+  onClearChanges = null,
 }) => {
   const modComponentFormStateAdapters = useAvailableFormStateAdapters();
 
@@ -72,66 +65,29 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
       action: onClearChanges,
       // Always show Clear Changes button, even if there are no changes so the UI is more consistent / the user doesn't
       // wonder why the menu item is missing
-      disabled: !isDirty || disabled || !onClearChanges,
+      disabled: !isDirty || !onClearChanges,
     },
     {
       title: "Add Starter Brick",
       icon: <FontAwesomeIcon icon={faPlus} fixedWidth />,
       submenu: modComponentFormStateAdapters.map((adapter) => ({
         title: adapter.label,
-        action: onAddStarterBrick
-          ? () => {
-              onAddStarterBrick(adapter);
-            }
-          : null,
+        action() {
+          onAddStarterBrick(adapter);
+        },
         icon: <FontAwesomeIcon icon={adapter.icon} fixedWidth />,
       })),
       hide: !onAddStarterBrick,
     },
     {
-      title: "Add to mod",
-      icon: (
-        <FontAwesomeIcon
-          icon={faFileImport}
-          fixedWidth
-          className={styles.addIcon}
-        />
-      ),
-      action: onAddToMod,
-      disabled,
-      hide: !onAddToMod,
-    },
-    {
-      title: "Move from mod",
-      icon: (
-        <FontAwesomeIcon
-          icon={faFileExport}
-          fixedWidth
-          className={styles.removeIcon}
-        />
-      ),
-      action: onRemoveFromMod,
-      disabled,
-      hide: !onRemoveFromMod,
-    },
-    {
       title: "Make a copy",
       icon: <FontAwesomeIcon icon={faClone} fixedWidth />,
-      action: onClone,
-      disabled,
-    },
-    {
-      title: "Delete",
-      icon: <FontAwesomeIcon icon={faTrash} fixedWidth />,
-      action: onDelete,
-      disabled,
-      hide: !onDelete,
+      action: onMakeCopy,
     },
     {
       title: "Deactivate",
       icon: <FontAwesomeIcon icon={faTimes} fixedWidth />,
       action: onDeactivate,
-      disabled,
       hide: !onDeactivate,
     },
   ];
@@ -142,19 +98,19 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
         <SaveButton
           ariaLabel={labelRoot ? `${labelRoot} - Save` : undefined}
           onClick={onSave}
-          disabled={!isDirty || disabled}
+          disabled={!isDirty}
         />
       )}
       {isActive && (
         <EllipsisMenu
+          portal
           ariaLabel={labelRoot ? `${labelRoot} - Ellipsis` : undefined}
           items={menuItems}
           classNames={{ menu: styles.menu, menuButton: styles.ellipsisMenu }}
-          portal={true}
         />
       )}
     </div>
   );
 };
 
-export default ActionMenu;
+export default ModActionMenu;

--- a/src/pageEditor/modListingPanel/ModComponentActionMenu.stories.tsx
+++ b/src/pageEditor/modListingPanel/ModComponentActionMenu.stories.tsx
@@ -16,12 +16,12 @@
  */
 
 import React from "react";
-import ActionMenu from "@/pageEditor/modListingPanel/ActionMenu";
+import ModComponentActionMenu from "@/pageEditor/modListingPanel/ModComponentActionMenu";
 import { type ComponentMeta, type ComponentStory } from "@storybook/react";
 
 export default {
   title: "Sidebar/ActionMenu",
-  component: ActionMenu,
+  component: ModComponentActionMenu,
   argTypes: {
     isDirty: {
       control: "boolean",
@@ -32,11 +32,11 @@ export default {
       defaultValue: false,
     },
   },
-} as ComponentMeta<typeof ActionMenu>;
+} as ComponentMeta<typeof ModComponentActionMenu>;
 
-const Template: ComponentStory<typeof ActionMenu> = (args) => (
+const Template: ComponentStory<typeof ModComponentActionMenu> = (args) => (
   <div className="d-flex">
-    <ActionMenu {...args} />
+    <ModComponentActionMenu {...args} />
   </div>
 );
 

--- a/src/pageEditor/modListingPanel/ModComponentActionMenu.tsx
+++ b/src/pageEditor/modListingPanel/ModComponentActionMenu.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import {
+  faClone,
+  faFileExport,
+  faFileImport,
+  faHistory,
+  faTimes,
+  faTrash,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import styles from "./ActionMenu.module.scss";
+import EllipsisMenu, {
+  type EllipsisMenuItem,
+} from "@/components/ellipsisMenu/EllipsisMenu";
+import SaveButton from "@/pageEditor/modListingPanel/SaveButton";
+
+type OptionalAction = (() => Promise<void>) | undefined;
+
+type ActionMenuProps = {
+  labelRoot: string;
+  isDirty: boolean;
+  isActive: boolean;
+  onDelete: OptionalAction;
+  onDuplicate: OptionalAction;
+  onClearChanges: OptionalAction;
+  onAddToMod: OptionalAction;
+  onRemoveFromMod: OptionalAction;
+  // TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/9242, remove standalone mod component actions
+  onSave: OptionalAction;
+  onDeactivate: OptionalAction;
+};
+
+const ModComponentActionMenu: React.FC<ActionMenuProps> = ({
+  isActive,
+  labelRoot,
+  isDirty,
+  onDelete = null,
+  onDuplicate = null,
+  onClearChanges = null,
+  onAddToMod = null,
+  onRemoveFromMod = null,
+  // Standalone Mod Component Actions
+  onSave = null,
+  onDeactivate = null,
+}) => {
+  const menuItems: EllipsisMenuItem[] = [
+    {
+      title: "Clear Changes",
+      icon: <FontAwesomeIcon icon={faHistory} fixedWidth />,
+      action: onClearChanges,
+      // Always show Clear Changes button, even if there are no changes so the UI is more consistent / the user doesn't
+      // wonder why the menu item is missing
+      disabled: !isDirty || !onClearChanges,
+    },
+    {
+      title: "Duplicate",
+      icon: <FontAwesomeIcon icon={faClone} fixedWidth />,
+      action: onDuplicate,
+      hide: !onDuplicate,
+    },
+    {
+      title: "Add to mod",
+      icon: (
+        <FontAwesomeIcon
+          icon={faFileImport}
+          fixedWidth
+          className={styles.addIcon}
+        />
+      ),
+      action: onAddToMod,
+      hide: !onAddToMod,
+    },
+    {
+      title: "Move from mod",
+      icon: (
+        <FontAwesomeIcon
+          icon={faFileExport}
+          fixedWidth
+          className={styles.removeIcon}
+        />
+      ),
+      action: onRemoveFromMod,
+      hide: !onRemoveFromMod,
+    },
+    {
+      title: "Delete",
+      icon: <FontAwesomeIcon icon={faTrash} fixedWidth />,
+      action: onDelete,
+      hide: !onDelete,
+    },
+    {
+      title: "Deactivate",
+      icon: <FontAwesomeIcon icon={faTimes} fixedWidth />,
+      action: onDeactivate,
+      hide: !onDeactivate,
+    },
+  ];
+
+  return (
+    <div className={styles.root}>
+      {onSave != null && (
+        <SaveButton
+          ariaLabel={labelRoot ? `${labelRoot} - Save` : undefined}
+          onClick={onSave}
+          disabled={!isDirty}
+        />
+      )}
+      {isActive && (
+        <EllipsisMenu
+          portal
+          ariaLabel={labelRoot ? `${labelRoot} - Ellipsis` : undefined}
+          items={menuItems}
+          classNames={{ menu: styles.menu, menuButton: styles.ellipsisMenu }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default ModComponentActionMenu;

--- a/src/pageEditor/modListingPanel/ModComponents.tsx
+++ b/src/pageEditor/modListingPanel/ModComponents.tsx
@@ -108,7 +108,7 @@ const ModComponents: React.FunctionComponent = () => {
           onDeactivate={async () => {
             await deactivateMod({ modId: modMetadata.id });
           }}
-          onClone={async () => {
+          onMakeCopy={async () => {
             dispatch(actions.showCreateModModal({ keepLocalCopy: true }));
           }}
         >

--- a/src/pageEditor/modListingPanel/ModListItem.test.tsx
+++ b/src/pageEditor/modListingPanel/ModListItem.test.tsx
@@ -43,7 +43,7 @@ describe("ModListItem", () => {
             onSave={jest.fn()}
             onClearChanges={jest.fn()}
             onDeactivate={jest.fn()}
-            onClone={jest.fn()}
+            onMakeCopy={jest.fn()}
           >
             <div>test children</div>
           </ModListItem>
@@ -74,7 +74,7 @@ describe("ModListItem", () => {
             onSave={jest.fn()}
             onClearChanges={jest.fn()}
             onDeactivate={jest.fn()}
-            onClone={jest.fn()}
+            onMakeCopy={jest.fn()}
           >
             <div>test children</div>
           </ModListItem>
@@ -114,7 +114,7 @@ describe("ModListItem", () => {
             onSave={jest.fn()}
             onClearChanges={jest.fn()}
             onDeactivate={jest.fn()}
-            onClone={jest.fn()}
+            onMakeCopy={jest.fn()}
           >
             <div>test children</div>
           </ModListItem>

--- a/src/pageEditor/modListingPanel/ModListItem.tsx
+++ b/src/pageEditor/modListingPanel/ModListItem.tsx
@@ -36,18 +36,18 @@ import {
   selectModIsDirty,
 } from "@/pageEditor/store/editor/editorSelectors";
 import * as semver from "semver";
-import ActionMenu from "@/pageEditor/modListingPanel/ActionMenu";
 import { useGetModDefinitionQuery } from "@/data/service/api";
 import useAddNewModComponent from "@/pageEditor/hooks/useAddNewModComponent";
 import { type ModMetadata } from "@/types/modComponentTypes";
 import { isInnerDefinitionRegistryId } from "@/types/helpers";
+import ModActionMenu from "@/pageEditor/modListingPanel/ModActionMenu";
 
 export type ModListItemProps = PropsWithChildren<{
   modMetadata: ModMetadata;
   onSave: () => Promise<void>;
   onClearChanges: () => Promise<void>;
   onDeactivate: () => Promise<void>;
-  onClone: () => Promise<void>;
+  onMakeCopy: () => Promise<void>;
 }>;
 
 const ModListItem: React.FC<ModListItemProps> = ({
@@ -56,7 +56,7 @@ const ModListItem: React.FC<ModListItemProps> = ({
   onSave,
   onClearChanges,
   onDeactivate,
-  onClone,
+  onMakeCopy,
 }) => {
   const dispatch = useDispatch();
   const activeModId = useSelector(selectActiveModId);
@@ -115,14 +115,14 @@ const ModListItem: React.FC<ModListItemProps> = ({
             />
           </span>
         )}
-        <ActionMenu
+        <ModActionMenu
           isActive={isActive}
           labelRoot={name}
           onSave={onSave}
           onClearChanges={isUnsavedMod ? undefined : onClearChanges}
           onDeactivate={onDeactivate}
           onAddStarterBrick={addNewModComponent}
-          onClone={onClone}
+          onMakeCopy={onMakeCopy}
           isDirty={isDirty}
         />
       </Accordion.Toggle>

--- a/src/pageEditor/modListingPanel/ModListingPanel.test.tsx
+++ b/src/pageEditor/modListingPanel/ModListingPanel.test.tsx
@@ -109,7 +109,7 @@ describe("ModListingPanel", () => {
   });
 
   describe("mod component actions", () => {
-    it("duplicate mod component", async () => {
+    it("duplicates mod component", async () => {
       const modName = "Test Mod";
 
       const formState = formStateFactory({

--- a/src/pageEditor/modListingPanel/ModListingPanel.test.tsx
+++ b/src/pageEditor/modListingPanel/ModListingPanel.test.tsx
@@ -107,4 +107,42 @@ describe("ModListingPanel", () => {
       "true",
     );
   });
+
+  describe("mod component actions", () => {
+    it("duplicate mod component", async () => {
+      const modName = "Test Mod";
+
+      const formState = formStateFactory({
+        formStateConfig: {
+          modMetadata: createNewUnsavedModMetadata({
+            modName,
+          }),
+        },
+      });
+
+      render(<ModListingPanel />, {
+        setupRedux(dispatch) {
+          dispatch(editorActions.addModComponentFormState(formState));
+        },
+      });
+
+      // Select the mod then mod component
+      await userEvent.click(screen.getByText(modName));
+      await userEvent.click(screen.getByText(formState.label));
+
+      await userEvent.click(
+        screen.getByRole("button", {
+          name: `${formState.label} - Ellipsis`,
+        }),
+      );
+
+      await userEvent.click(
+        screen.getByRole("menuitem", {
+          name: "Duplicate",
+        }),
+      );
+
+      expect(screen.getByText(`${formState.label} (Copy)`)).toBeInTheDocument();
+    });
+  });
 });

--- a/src/pageEditor/store/editor/editorSlice.test.ts
+++ b/src/pageEditor/store/editor/editorSlice.test.ts
@@ -222,11 +222,11 @@ describe("Add/Remove Bricks", () => {
     ).toBeArrayOfSize(initialIntegrationDependencies.length);
   });
 
-  test("Can clone a mod compoenent", async () => {
+  test("Can duplicate a mod component", async () => {
     const dispatch = jest.fn();
     const getState: () => EditorRootState = () => ({ editor });
 
-    await actions.cloneActiveModComponent()(dispatch, getState, undefined);
+    await actions.duplicateActiveModComponent()(dispatch, getState, undefined);
 
     // Dispatch call args (actions) should be:
     //  1. thunk pending
@@ -238,7 +238,7 @@ describe("Add/Remove Bricks", () => {
     const action1 = dispatch.mock.calls[0][0];
     expect(action1).toHaveProperty(
       "type",
-      "editor/cloneActiveModComponent/pending",
+      "editor/duplicateActiveModComponent/pending",
     );
 
     const action2 = dispatch.mock.calls[1][0];
@@ -254,7 +254,7 @@ describe("Add/Remove Bricks", () => {
     const action3 = dispatch.mock.calls[2][0];
     expect(action3).toHaveProperty(
       "type",
-      "editor/cloneActiveModComponent/fulfilled",
+      "editor/duplicateActiveModComponent/fulfilled",
     );
   });
 });


### PR DESCRIPTION
## What does this PR do?

- Closes #9241
- Stacked on https://github.com/pixiebrix/pixiebrix-extension/pull/9240
- Add "Duplicate" action to mod component 3-dot menu in the Page Editor
- Refactoring:
  - Splits `ModActionsMenu` and `ModComponentActionsMenu` to make it easier to reason about which actions appear in each menu
  - Removes unused `disabled` prop, and mark props as required where possible

## Reviewer Notes

- Playwright tests aren't run on CI because this is stacked on another PR. There might be bugs the Playwright will catch

## Demo / Screenshot

![image](https://github.com/user-attachments/assets/7945acf4-38c2-4b75-8401-5e4a2190ff8d)

## Checklist

- [x] This PR requires a documentation change (link to old docs): @Pashaminkovsky @brittanyjoiner15 

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
