### PR TITLE
Add idb error handling for Internal error opening backing store

### DIFF
--- a/src/utils/idbUtils.ts
+++ b/src/utils/idbUtils.ts
@@ -169,7 +169,7 @@ export function isMaybeTemporaryIDBError(error: unknown): boolean {
   return isIDBConnectionError(error) || isIDBLargeValueError(error);
 }
 
-export function isPermanentIDBError(error: unknown): boolean {
+function isPermanentIDBError(error: unknown): boolean {
   return isIDBLargeValueError(error) || isIDBErrorOpeningBackingStore(error);
 }
 

--- a/src/utils/idbUtils.ts
+++ b/src/utils/idbUtils.ts
@@ -143,9 +143,8 @@ export function isIDBLargeValueError(error: unknown): boolean {
 }
 
 /**
- * Corrupt chrome profile. Not sure how this happens, but it seems to happen to users
- * on citrix machines. This error seems to be unrecoverable and the only solution is to
- * delete the database.
+ * Error occurring due to corrupt chrome profile but unclear how this happens.
+ * This error seems to be unrecoverable and the only solution is to delete the database.
  * https://jasonsavard.com/forum/discussion/4233/unknownerror-internal-error-opening-backing-store-for-indexeddb-open
  *
  * @param error the error object
@@ -167,10 +166,6 @@ function isIDBErrorOpeningBackingStore(error: unknown): boolean {
  */
 export function isMaybeTemporaryIDBError(error: unknown): boolean {
   return isIDBConnectionError(error) || isIDBLargeValueError(error);
-}
-
-function isPermanentIDBError(error: unknown): boolean {
-  return isIDBLargeValueError(error) || isIDBErrorOpeningBackingStore(error);
 }
 
 // Rather than use reportError from @/telemetry/reportError, IDB errors are directly reported
@@ -251,7 +246,7 @@ export const withIdbErrorHandling =
       );
     } catch (error) {
       // If all retries have failed and the latest error is a permanent error, we delete the database.
-      if (isPermanentIDBError(error)) {
+      if (isIDBLargeValueError(error) || isIDBErrorOpeningBackingStore(error)) {
         console.error(
           `Deleting ${databaseName} database due to permanent IndexDB error.`,
         );


### PR DESCRIPTION
## What does this PR do?

- Fixes an unrecoverable idb error
- See: https://www.notion.so/pixiebrix/SLC-IDB-Hypercare-2024-10-08-11943b21a25380679973e73faa948ad9?pvs=4

## Discussion

- It seems like it's safe to delete the database if this error occurs, but we have yet to actually confirm if this change fixes the issue the users are experiencing.
- We took a look at the source code for this error. see discussion in this slack thread: https://pixiebrix.slack.com/archives/C07MJ3LJ66B/p1728403288315069

## Checklist

_Leave all that are relevant and check off as completed_

- [ ] This PR requires a security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change
- [x] Added jest or playwright tests and/or storybook stories

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
