### PR TITLE
Rename `_recipe` and `_deployment` fields on `ModComponent` 

### DIFF
--- a/end-to-end-tests/pageObjects/pageEditor/pageEditorPage.ts
+++ b/end-to-end-tests/pageObjects/pageEditor/pageEditorPage.ts
@@ -112,7 +112,7 @@ export class PageEditorPage extends BasePageObject {
   }
 
   /**
-   * Save the current active mod. Prefer saveStandaloneMod for standalone mods.
+   * Save the current active mod
    */
   async saveActiveMod() {
     // TODO: this method is currently meant for mods that aren't meant to be

--- a/src/activation/mapModComponentDefinitionToActivatedModComponent.ts
+++ b/src/activation/mapModComponentDefinitionToActivatedModComponent.ts
@@ -79,7 +79,7 @@ export function mapModComponentDefinitionToActivatedModComponent<
     id: uuidv4(),
     // Default to `v1` for backward compatability
     apiVersion: modDefinition.apiVersion ?? "v1",
-    _recipe: pickModDefinitionMetadata(modDefinition),
+    modMetadata: pickModDefinitionMetadata(modDefinition),
     // Definitions are pushed down into the mod components. That's OK because `resolveDefinitions` determines
     // uniqueness based on the content of the definition. Therefore, bricks will be re-used as necessary
     definitions: modDefinition.definitions ?? {},
@@ -99,7 +99,7 @@ export function mapModComponentDefinitionToActivatedModComponent<
   // here makes testing harder because we then have to account for the normalized value in assertions.
 
   if (deployment) {
-    activatedModComponent._deployment = {
+    activatedModComponent.deploymentMetadata = {
       id: deployment.id,
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- This should be defined in practice
       timestamp: deployment.updated_at!,

--- a/src/background/deploymentUpdater.test.ts
+++ b/src/background/deploymentUpdater.test.ts
@@ -386,9 +386,9 @@ describe("syncDeployments", () => {
     // A mod without a deployment. Exclude _deployment entirely to handle the case where the property is missing
     const manualModComponent = activatedModComponentFactory({
       extensionPointId: starterBrick.metadata!.id,
-      _recipe: modMetadataFactory(),
+      modMetadata: modMetadataFactory(),
     });
-    delete manualModComponent._deployment;
+    delete manualModComponent.deploymentMetadata;
 
     await saveModComponentState({
       activatedModComponents: [manualModComponent],
@@ -433,17 +433,16 @@ describe("syncDeployments", () => {
     const { deployment, modDefinition } = activatableDeploymentFactory();
     const registryId = deployment.package.package_id;
 
-    // A mod component without a recipe. Exclude _recipe entirely to handle the case where the property is missing
-    const modComponent = modComponentFactory({
-      _recipe: {
+    const modComponent = activatedModComponentFactory({
+      deploymentMetadata: undefined,
+      modMetadata: {
         id: deployment.package.package_id,
         name: deployment.package.name,
         version: normalizeSemVerString("0.0.1"),
         updated_at: deployment.updated_at!,
         sharing: personalSharingDefinitionFactory(),
       },
-    }) as ActivatedModComponent;
-    delete modComponent._deployment;
+    });
 
     await saveModComponentState({
       activatedModComponents: [modComponent],
@@ -466,7 +465,7 @@ describe("syncDeployments", () => {
 
     const { activatedModComponents } = await getModComponentState();
     expect(activatedModComponents).toBeArrayOfSize(1);
-    expect(activatedModComponents[0]!._recipe!.version).toBe(
+    expect(activatedModComponents[0]!.modMetadata.version).toBe(
       deployment.package.version,
     );
   });
@@ -484,18 +483,17 @@ describe("syncDeployments", () => {
     };
     registryFindMock.mockResolvedValue(brick);
 
-    // A mod component without a recipe. Exclude _recipe entirely to handle the case where the property is missing
-    const modComponent = modComponentFactory({
+    const modComponent = activatedModComponentFactory({
       extensionPointId: starterBrick.metadata!.id,
-      _recipe: {
+      deploymentMetadata: undefined,
+      modMetadata: {
         id: deployment.package.package_id,
         name: deployment.package.name,
         version: normalizeSemVerString("0.0.1"),
         updated_at: deployment.updated_at!,
         sharing: personalSharingDefinitionFactory(),
       },
-    }) as ActivatedModComponent;
-    delete modComponent._deployment;
+    });
 
     await saveModComponentState({
       activatedModComponents: [modComponent],
@@ -527,7 +525,7 @@ describe("syncDeployments", () => {
     const { modComponentFormStates } = (await getEditorState()) ?? {};
     // Expect draft mod component to be removed
     expect(modComponentFormStates).toBeArrayOfSize(0);
-    expect(activatedModComponents[0]!._recipe!.version).toBe(
+    expect(activatedModComponents[0]!.modMetadata.version).toBe(
       deployment.package.version,
     );
   });
@@ -761,7 +759,7 @@ describe("syncDeployments", () => {
     };
 
     const manuallyActivatedModComponent = activatedModComponentFactory({
-      _recipe: modMetadataFactory(),
+      modMetadata: modMetadataFactory(),
     });
 
     const deploymentStarterBrickDefinition = starterBrickDefinitionFactory();
@@ -774,8 +772,11 @@ describe("syncDeployments", () => {
 
     const deploymentModComponent = modComponentFactory({
       extensionPointId: deploymentStarterBrickDefinition.metadata!.id,
-      _deployment: { id: uuidv4(), timestamp: "2021-10-07T12:52:16.189Z" },
-      _recipe: modMetadataFactory(),
+      deploymentMetadata: {
+        id: uuidv4(),
+        timestamp: "2021-10-07T12:52:16.189Z",
+      },
+      modMetadata: modMetadataFactory(),
     }) as ActivatedModComponent;
 
     registryFindMock.mockImplementation(async (id) => {
@@ -863,7 +864,7 @@ describe("syncDeployments", () => {
     await syncDeployments();
     const { activatedModComponents } = await getModComponentState();
     expect(activatedModComponents).toHaveLength(1);
-    expect(activatedModComponents[0]!._recipe!.id).toBe(
+    expect(activatedModComponents[0]!.modMetadata.id).toBe(
       deployment.package.package_id,
     );
 
@@ -894,7 +895,7 @@ describe("syncDeployments", () => {
     const { activatedModComponents: expectedModComponents } =
       await getModComponentState();
     expect(expectedModComponents).toHaveLength(1);
-    expect(expectedModComponents[0]!._recipe!.id).toBe(
+    expect(expectedModComponents[0]!.modMetadata.id).toBe(
       updatedDeployment.package.package_id,
     );
   });

--- a/src/background/modUpdater.test.ts
+++ b/src/background/modUpdater.test.ts
@@ -47,6 +47,10 @@ import type { ModDefinition } from "@/types/modDefinitionTypes";
 import type { ActivatedModComponent } from "@/types/modComponentTypes";
 import { uninstallContextMenu } from "@/background/contextMenus/uninstallContextMenu";
 import { TEST_deleteFeatureFlagsCache } from "@/auth/featureFlagStorage";
+import {
+  personalDeploymentMetadataFactory,
+  teamDeploymentMetadataFactory,
+} from "@/testUtils/factories/modInstanceFactories";
 
 const axiosMock = new MockAdapter(axios);
 jest.mock("@/telemetry/reportError");
@@ -69,29 +73,29 @@ describe("getActivatedMarketplaceModVersions function", () => {
     await saveModComponentState({ activatedModComponents: [] });
 
     publicActivatedMod = activatedModComponentFactory({
-      _recipe: modMetadataFactory({
+      modMetadata: modMetadataFactory({
         sharing: publicSharingDefinitionFactory(),
       }),
     });
 
     privateActivatedMod = activatedModComponentFactory({
-      _recipe: modMetadataFactory({
+      modMetadata: modMetadataFactory({
         sharing: personalSharingDefinitionFactory(),
       }),
     });
 
     publicActivatedDeployment = activatedModComponentFactory({
-      _recipe: modMetadataFactory({
+      modMetadata: modMetadataFactory({
         sharing: publicSharingDefinitionFactory(),
       }),
-      _deployment: {} as ActivatedModComponent["_deployment"],
+      deploymentMetadata: teamDeploymentMetadataFactory(),
     });
 
     privateActivatedDeployment = activatedModComponentFactory({
-      _recipe: modMetadataFactory({
+      modMetadata: modMetadataFactory({
         sharing: personalSharingDefinitionFactory(),
       }),
-      _deployment: {} as ActivatedModComponent["_deployment"],
+      deploymentMetadata: personalDeploymentMetadataFactory(),
     });
   });
 
@@ -113,15 +117,15 @@ describe("getActivatedMarketplaceModVersions function", () => {
     const result = await getActivatedMarketplaceModVersions();
     expect(result).toEqual([
       {
-        name: publicActivatedMod._recipe!.id,
-        version: publicActivatedMod._recipe!.version,
+        name: publicActivatedMod.modMetadata.id,
+        version: publicActivatedMod.modMetadata.version,
       },
     ]);
   });
 
   it("returns expected object with registry id keys and version number values", async () => {
     const anotherPublicActivatedMod = activatedModComponentFactory({
-      _recipe: modMetadataFactory({
+      modMetadata: modMetadataFactory({
         sharing: publicSharingDefinitionFactory(),
       }),
     });
@@ -134,12 +138,12 @@ describe("getActivatedMarketplaceModVersions function", () => {
 
     expect(result).toEqual([
       {
-        name: publicActivatedMod._recipe!.id,
-        version: publicActivatedMod._recipe!.version,
+        name: publicActivatedMod.modMetadata.id,
+        version: publicActivatedMod.modMetadata.version,
       },
       {
-        name: anotherPublicActivatedMod._recipe!.id,
-        version: anotherPublicActivatedMod._recipe!.version,
+        name: anotherPublicActivatedMod.modMetadata.id,
+        version: anotherPublicActivatedMod.modMetadata.version,
       },
     ]);
   });
@@ -151,12 +155,12 @@ describe("fetchModUpdates function", () => {
   beforeEach(async () => {
     activatedMods = [
       activatedModComponentFactory({
-        _recipe: modMetadataFactory({
+        modMetadata: modMetadataFactory({
           sharing: publicSharingDefinitionFactory(),
         }),
       }),
       activatedModComponentFactory({
-        _recipe: modMetadataFactory({
+        modMetadata: modMetadataFactory({
           sharing: publicSharingDefinitionFactory(),
         }),
       }),
@@ -176,12 +180,12 @@ describe("fetchModUpdates function", () => {
     expect(payload).toEqual({
       versions: [
         {
-          name: activatedMods[0]!._recipe!.id,
-          version: activatedMods[0]!._recipe!.version,
+          name: activatedMods[0]!.modMetadata.id,
+          version: activatedMods[0]!.modMetadata.version,
         },
         {
-          name: activatedMods[1]!._recipe!.id,
-          version: activatedMods[1]!._recipe!.version,
+          name: activatedMods[1]!.modMetadata.id,
+          version: activatedMods[1]!.modMetadata.version,
         },
       ],
     });
@@ -205,10 +209,10 @@ describe("updateMod function", () => {
   beforeEach(async () => {
     const modToDeactivate = modMetadataFactory(modToUpdate.metadata);
     modComponentToDeactivate1 = activatedModComponentFactory({
-      _recipe: modToDeactivate,
+      modMetadata: modToDeactivate,
     });
     modComponentToDeactivate2 = activatedModComponentFactory({
-      _recipe: modToDeactivate,
+      modMetadata: modToDeactivate,
     });
     const anotherMod = modMetadataFactory({});
 
@@ -217,7 +221,7 @@ describe("updateMod function", () => {
         modComponentToDeactivate1,
         modComponentToDeactivate2,
         activatedModComponentFactory({
-          _recipe: anotherMod,
+          modMetadata: anotherMod,
         }),
       ],
     });
@@ -339,7 +343,7 @@ describe("updateModsIfUpdatesAvailable", () => {
     const resultingOptionsState = await getModComponentState();
     expect(resultingOptionsState.activatedModComponents).toHaveLength(1);
     expect(
-      resultingOptionsState.activatedModComponents[0]!._recipe!.version,
+      resultingOptionsState.activatedModComponents[0]!.modMetadata.version,
     ).toBe("2.0.1");
   });
 });

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { compact, debounce, throttle, uniq } from "lodash";
+import { debounce, throttle, uniq } from "lodash";
 import { getModComponentState } from "@/store/modComponents/modComponentStorage";
 import {
   getLinkedApiClient,

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -294,7 +294,7 @@ async function collectUserSummary(): Promise<UserSummary> {
     const { activatedModComponents } = await getModComponentState();
     numActiveExtensions = activatedModComponents.length;
     numActiveBlueprints = uniq(
-      compact(activatedModComponents.map((x) => x._recipe?.id)),
+      activatedModComponents.map((x) => x.modMetadata.id),
     ).length;
     numActiveExtensionPoints = uniq(
       activatedModComponents.map((x) => x.extensionPointId),

--- a/src/background/utils/deactivateMod.test.ts
+++ b/src/background/utils/deactivateMod.test.ts
@@ -40,7 +40,7 @@ describe("deactivateMod", () => {
       activatedModComponents: [
         ...mapModInstanceToActivatedModComponents(modToDeactivate),
         activatedModComponentFactory({
-          _recipe: anotherMod,
+          modMetadata: anotherMod,
         }),
       ],
     });
@@ -60,7 +60,7 @@ describe("deactivateMod", () => {
 
     expect(nextModComponentState.activatedModComponents).toHaveLength(1);
     expect(
-      nextModComponentState.activatedModComponents[0]!._recipe!.id,
+      nextModComponentState.activatedModComponents[0]!.modMetadata.id,
     ).not.toEqual(modToDeactivate.definition.metadata.id);
   });
 });

--- a/src/background/welcomeMods.ts
+++ b/src/background/welcomeMods.ts
@@ -236,7 +236,7 @@ async function activateMods(
   const newMods = modDefinitions.filter(
     (modDefinition) =>
       !optionsState.activatedModComponents.some(
-        (mod) => mod._recipe?.id === modDefinition.metadata.id,
+        (mod) => mod.modMetadata.id === modDefinition.metadata.id,
       ),
   );
 

--- a/src/contentScript/lifecycle.test.ts
+++ b/src/contentScript/lifecycle.test.ts
@@ -36,6 +36,7 @@ import {
 import { type getModComponentState } from "@/store/modComponents/modComponentStorage";
 import { getPlatform } from "@/platform/platformContext";
 import { StarterBrickTypes } from "@/types/starterBrickTypes";
+import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 
 let starterBrickRegistry: any;
 let lifecycleModule: any;
@@ -75,7 +76,8 @@ const activatedModComponentFactory = define<
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/starter-brick-${n}`),
-  _recipe: undefined,
+  modMetadata: modMetadataFactory,
+  deploymentMetadata: undefined,
   label: "Test Mod Component",
   config: define<TriggerConfig>({
     action: () => [] as BrickPipeline,

--- a/src/contentScript/loadActivationEnhancementsCore.test.ts
+++ b/src/contentScript/loadActivationEnhancementsCore.test.ts
@@ -109,14 +109,9 @@ describe("marketplace enhancements", () => {
     isLinkedMock.mockResolvedValue(true);
     window.location.assign("https://www.pixiebrix.com/");
 
-    const components = array(
-      modComponentFactory,
-      2,
-    )({
-      _recipe: modMetadataFactory,
-    });
+    const components = array(modComponentFactory, 2)();
 
-    const modIds = components.map((x) => x._recipe?.id);
+    const modIds = components.map((x) => x.modMetadata.id);
 
     document.body.innerHTML = `
     <div>

--- a/src/contentScript/loadActivationEnhancementsCore.test.ts
+++ b/src/contentScript/loadActivationEnhancementsCore.test.ts
@@ -22,10 +22,7 @@ import { getDocument } from "@/starterBricks/starterBrickTestUtils";
 import { validateRegistryId } from "@/types/helpers";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import { getActivatingMods } from "@/background/messenger/external/_implementation";
-import {
-  modComponentFactory,
-  modMetadataFactory,
-} from "@/testUtils/factories/modComponentFactories";
+import { modComponentFactory } from "@/testUtils/factories/modComponentFactories";
 import {
   loadActivationEnhancements,
   TEST_unloadActivationEnhancements,

--- a/src/data/service/api.ts
+++ b/src/data/service/api.ts
@@ -63,7 +63,6 @@ export const appApi = createApi({
     "MarketplaceTags",
     "EditablePackages",
     "Invitations",
-    "StandaloneModDefinitions",
     "Package",
     "PackageVersion",
     "StarterBlueprints",

--- a/src/extensionConsole/pages/deployments/DeploymentsContext.test.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentsContext.test.tsx
@@ -290,7 +290,9 @@ describe("DeploymentsContext", () => {
       options: { activatedModComponents: initialActivatedModComponents },
     } = getReduxStore().getState() as { options: ModComponentState };
     expect(initialActivatedModComponents).toHaveLength(1);
-    expect(initialActivatedModComponents[0]!._deployment).toBeUndefined();
+    expect(
+      initialActivatedModComponents[0]!.deploymentMetadata,
+    ).toBeUndefined();
 
     expect(screen.queryAllByTestId("Component")).toHaveLength(1);
     expect(screen.queryAllByTestId("Error")).toHaveLength(0);
@@ -306,7 +308,9 @@ describe("DeploymentsContext", () => {
       options: { activatedModComponents },
     } = getReduxStore().getState() as { options: ModComponentState };
     expect(activatedModComponents).toHaveLength(1);
-    expect(activatedModComponents[0]!._deployment?.id).toBe(deployment.id);
+    expect(activatedModComponents[0]!.deploymentMetadata?.id).toBe(
+      deployment.id,
+    );
   });
 
   it("remounting the DeploymentsProvider doesn't refetch the deployments", async () => {

--- a/src/extensionConsole/pages/mods/utils/buildModsList.test.ts
+++ b/src/extensionConsole/pages/mods/utils/buildModsList.test.ts
@@ -151,7 +151,7 @@ describe("buildModsList", () => {
           activatedModComponentFactory,
           count,
         )({
-          _recipe: metadata,
+          modMetadata: metadata,
         }),
       ),
     );

--- a/src/extensionConsole/pages/packageEditor/EditPage.tsx
+++ b/src/extensionConsole/pages/packageEditor/EditPage.tsx
@@ -65,7 +65,7 @@ function useParsePackage(config: string | null): ParsedPackageInfo {
       return {
         isMod: true,
         isActivated: activatedModComponents.some(
-          (x) => x._recipe?.id === configJSON.metadata?.id,
+          (x) => x.modMetadata.id === configJSON.metadata?.id,
         ),
         config: configJSON,
       };

--- a/src/extensionConsole/pages/settings/useDiagnostics.ts
+++ b/src/extensionConsole/pages/settings/useDiagnostics.ts
@@ -21,7 +21,7 @@ import useExtensionPermissions, {
   type DetailedPermissions,
 } from "@/permissions/useExtensionPermissions";
 import { type SerializedModComponent } from "@/types/modComponentTypes";
-import { compact, uniqBy } from "lodash";
+import { uniqBy } from "lodash";
 import { type StorageEstimate } from "@/types/browserTypes";
 import { count as registrySize } from "@/registry/packageRegistry";
 import { count as logSize } from "@/telemetry/logging";
@@ -54,11 +54,10 @@ async function collectDiagnostics({
       eventCount: await eventsSize(),
     },
     extensions: {
-      blueprints: uniqBy(
-        compact(modComponents.map((x) => x.modMetadata)),
+      mods: uniqBy(
+        modComponents.map((x) => x.modMetadata),
         (x) => x.id,
       ),
-      extensions: modComponents.filter((x) => !x.modMetadata),
     },
   };
 }

--- a/src/extensionConsole/pages/settings/useDiagnostics.ts
+++ b/src/extensionConsole/pages/settings/useDiagnostics.ts
@@ -55,10 +55,10 @@ async function collectDiagnostics({
     },
     extensions: {
       blueprints: uniqBy(
-        compact(modComponents.map((x) => x._recipe)),
+        compact(modComponents.map((x) => x.modMetadata)),
         (x) => x.id,
       ),
-      extensions: modComponents.filter((x) => !x._recipe),
+      extensions: modComponents.filter((x) => !x.modMetadata),
     },
   };
 }

--- a/src/integrations/util/collectExistingConfiguredDependenciesForMod.test.ts
+++ b/src/integrations/util/collectExistingConfiguredDependenciesForMod.test.ts
@@ -61,15 +61,15 @@ describe("collectExistingConfiguredDependenciesForMod", () => {
     });
     const activatedModComponents = [
       activatedModComponentFactory({
-        _recipe: modMetadata,
+        modMetadata,
         integrationDependencies: [integrationDependency1],
       }),
       activatedModComponentFactory({
-        _recipe: modMetadata,
+        modMetadata,
         integrationDependencies: [integrationDependency2],
       }),
       activatedModComponentFactory({
-        _recipe: modMetadata,
+        modMetadata,
         integrationDependencies: [
           integrationDependency1,
           integrationDependency2,
@@ -116,11 +116,11 @@ describe("collectExistingConfiguredDependenciesForMod", () => {
     });
     const activatedModComponents = [
       activatedModComponentFactory({
-        _recipe: modMetadata,
+        modMetadata,
         integrationDependencies: [integrationDependency1],
       }),
       activatedModComponentFactory({
-        _recipe: modMetadata,
+        modMetadata,
         integrationDependencies: [integrationDependency2],
       }),
     ];
@@ -161,15 +161,15 @@ describe("collectExistingConfiguredDependenciesForMod", () => {
     });
     const activatedModComponents = [
       activatedModComponentFactory({
-        _recipe: modMetadata,
+        modMetadata,
         integrationDependencies: [integrationDependency1],
       }),
       activatedModComponentFactory({
-        _recipe: modMetadata,
+        modMetadata,
         integrationDependencies: [integrationDependency2],
       }),
       activatedModComponentFactory({
-        _recipe: modMetadata,
+        modMetadata,
         integrationDependencies: [
           integrationDependency1,
           integrationDependency2,

--- a/src/modDefinitions/util/pickModDefinitionMetadata.ts
+++ b/src/modDefinitions/util/pickModDefinitionMetadata.ts
@@ -25,11 +25,11 @@ import { isInternalRegistryId } from "@/utils/registryUtils";
  *
  * If the mod definition was transformed from a standalone mod component definition, returns undefined.
  *
- * @see ModComponentBase._recipe
+ * @see ModComponentBase.modMetadata
  */
 export function pickModDefinitionMetadata(
   modDefinition: ModDefinition,
-): ModComponentBase["_recipe"] {
+): ModComponentBase["modMetadata"] | undefined {
   if (isInternalRegistryId(modDefinition.metadata.id)) {
     return undefined;
   }

--- a/src/pageEditor/hooks/useDeactivateMod.tsx
+++ b/src/pageEditor/hooks/useDeactivateMod.tsx
@@ -27,7 +27,7 @@ import { selectModComponentFormStates } from "@/pageEditor/store/editor/editorSe
 import { uniq } from "lodash";
 import { useModals } from "@/components/ConfirmationModal";
 import { actions } from "@/pageEditor/store/editor/editorSlice";
-import { getModComponentId, getModId } from "@/pageEditor/utils";
+import { getModComponentId } from "@/pageEditor/utils";
 import { clearLog } from "@/background/messenger/api";
 
 type Config = {
@@ -57,7 +57,7 @@ function useDeactivateMod(): (useDeactivateConfig: Config) => Promise<void> {
 
       const modComponentIds = uniq(
         [...activatedModComponents, ...modComponentFormStates]
-          .filter((x) => getModId(x) === modId)
+          .filter((x) => x.modMetadata.id === modId)
           .map((x) => getModComponentId(x)),
       );
       await Promise.all(

--- a/src/pageEditor/hooks/useSaveMod.ts
+++ b/src/pageEditor/hooks/useSaveMod.ts
@@ -67,7 +67,7 @@ export function isModEditable(
 function selectModMetadata(
   unsavedModDefinition: UnsavedModDefinition,
   response: PackageUpsertResponse,
-): ModComponentBase["_recipe"] {
+): ModComponentBase["modMetadata"] {
   return {
     ...unsavedModDefinition.metadata,
     sharing: pick(response, ["public", "organizations"]),

--- a/src/pageEditor/modListingPanel/ActivatedModComponentListItem.tsx
+++ b/src/pageEditor/modListingPanel/ActivatedModComponentListItem.tsx
@@ -80,7 +80,7 @@ const ActivatedModComponentListItem: React.FunctionComponent<{
   const modId = activeModId ?? activeModComponentFormState?.modMetadata.id;
   // Set the alternate background if this item isn't active, but either its mod or another item in its mod is active
   const hasActiveModBackground =
-    !isActive && modId && modComponent._recipe?.id === modId;
+    !isActive && modId && modComponent.modMetadata.id === modId;
 
   const selectHandler = useCallback(
     async (modComponent: ModComponentBase) => {
@@ -94,9 +94,9 @@ const ActivatedModComponentListItem: React.FunctionComponent<{
           await modComponentToFormState(modComponent);
 
         // Initialize mod options schema if needed
-        if (modComponent._recipe) {
+        if (modComponent.modMetadata) {
           const { data: modDefinition } = await getModDefinition(
-            { modId: modComponent._recipe.id },
+            { modId: modComponent.modMetadata.id },
             true,
           );
           if (modDefinition) {

--- a/src/pageEditor/modListingPanel/arrangeSidebarItems.test.ts
+++ b/src/pageEditor/modListingPanel/arrangeSidebarItems.test.ts
@@ -35,7 +35,7 @@ const modMetadataBar = modMetadataFactory({
 // Mod Components
 const cleanModComponentFooA = modComponentFactory({
   label: "A",
-  _recipe: modMetadataFoo,
+  modMetadata: modMetadataFoo,
 });
 
 const formStateModComponentFooA = menuItemFormStateFactory({
@@ -51,7 +51,7 @@ const formStateModComponentFooB = menuItemFormStateFactory({
 
 const cleanModComponentBarD = modComponentFactory({
   label: "D",
-  _recipe: modMetadataBar,
+  modMetadata: modMetadataBar,
 });
 
 const formStateModComponentBarE = menuItemFormStateFactory({
@@ -61,7 +61,7 @@ const formStateModComponentBarE = menuItemFormStateFactory({
 
 const cleanModComponentBarF: ModComponentBase = modComponentFactory({
   label: "F",
-  _recipe: modMetadataBar,
+  modMetadata: modMetadataBar,
 });
 
 describe("arrangeSidebarItems()", () => {

--- a/src/pageEditor/modListingPanel/arrangeSidebarItems.ts
+++ b/src/pageEditor/modListingPanel/arrangeSidebarItems.ts
@@ -24,7 +24,6 @@ import {
   type ModSidebarItem,
   type SidebarItem,
 } from "@/pageEditor/modListingPanel/common";
-import { assertNotNullish } from "@/utils/nullishUtils";
 
 type ArrangeSidebarItemsArgs = {
   modComponentFormStates: ModComponentFormState[];
@@ -56,17 +55,14 @@ function arrangeSidebarItems({
   );
 
   for (const cleanModComponent of cleanModComponentsWithoutFormStates) {
-    assertNotNullish(
-      cleanModComponent._recipe,
-      "Expected mod component to have mod metadata",
-    );
-
-    const modSidebarItem = modSidebarItems[cleanModComponent._recipe.id] ?? {
-      modMetadata: cleanModComponent._recipe,
+    const modSidebarItem = modSidebarItems[
+      cleanModComponent.modMetadata.id
+    ] ?? {
+      modMetadata: cleanModComponent.modMetadata,
       modComponents: [],
     };
     modSidebarItem.modComponents.push(cleanModComponent);
-    modSidebarItems[cleanModComponent._recipe.id] = modSidebarItem;
+    modSidebarItems[cleanModComponent.modMetadata.id] = modSidebarItem;
   }
 
   for (const modSidebarItem of Object.values(modSidebarItems)) {

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -95,12 +95,12 @@ function findModComponentIndex(
   modDefinition: ModDefinition,
   modComponent: ModComponentBase,
 ): number {
-  if (modDefinition.metadata.version !== modComponent._recipe?.version) {
+  if (modDefinition.metadata.version !== modComponent.modMetadata.version) {
     console.warn(
       "Mod component was activated using a different version of the mod",
       {
         modDefinitionVersion: modDefinition.metadata.version,
-        modComponentModVersion: modComponent._recipe?.version,
+        modComponentModVersion: modComponent.modMetadata.version,
       },
     );
   }

--- a/src/pageEditor/starterBricks/base.ts
+++ b/src/pageEditor/starterBricks/base.ts
@@ -71,7 +71,6 @@ import {
 } from "@/types/availabilityTypes";
 import { normalizeAvailability } from "@/bricks/available";
 import { registry } from "@/background/messenger/api";
-import { assertNotNullish } from "@/utils/nullishUtils";
 
 export interface WizardStep {
   step: string;
@@ -133,11 +132,6 @@ export function baseFromModComponent<T extends StarterBrickType>(
   | "variablesDefinition"
   | "modMetadata"
 > & { type: T } {
-  assertNotNullish(
-    config._recipe,
-    "Standalone mod components are not supported",
-  );
-
   return {
     uuid: config.id,
     apiVersion: config.apiVersion,
@@ -150,7 +144,7 @@ export function baseFromModComponent<T extends StarterBrickType>(
     variablesDefinition:
       config.variablesDefinition ?? emptyModVariablesDefinitionFactory(),
     type,
-    modMetadata: config._recipe,
+    modMetadata: config.modMetadata,
   };
 }
 
@@ -198,7 +192,7 @@ export function baseSelectModComponent({
   | "id"
   | "apiVersion"
   | "extensionPointId"
-  | "_recipe"
+  | "modMetadata"
   | "label"
   | "integrationDependencies"
   | "permissions"
@@ -209,7 +203,7 @@ export function baseSelectModComponent({
     id: uuid,
     apiVersion,
     extensionPointId: starterBrick.metadata.id,
-    _recipe: modMetadata,
+    modMetadata,
     label,
     integrationDependencies,
     permissions,

--- a/src/pageEditor/store/analysisManager.ts
+++ b/src/pageEditor/store/analysisManager.ts
@@ -76,7 +76,7 @@ async function selectActiveModFormStates(
     const activatedModComponents = selectActivatedModComponents(state);
     const otherModComponents = activatedModComponents.filter(
       (x) =>
-        x._recipe?.id === activeModComponentFormState.modMetadata.id &&
+        x.modMetadata?.id === activeModComponentFormState.modMetadata.id &&
         !dirtyIds.has(x.id),
     );
     const otherModComponentFormStates = await Promise.all(

--- a/src/pageEditor/store/analysisManager.ts
+++ b/src/pageEditor/store/analysisManager.ts
@@ -76,7 +76,7 @@ async function selectActiveModFormStates(
     const activatedModComponents = selectActivatedModComponents(state);
     const otherModComponents = activatedModComponents.filter(
       (x) =>
-        x.modMetadata?.id === activeModComponentFormState.modMetadata.id &&
+        x.modMetadata.id === activeModComponentFormState.modMetadata.id &&
         !dirtyIds.has(x.id),
     );
     const otherModComponentFormStates = await Promise.all(

--- a/src/pageEditor/store/editor/baseFormStateTypes.ts
+++ b/src/pageEditor/store/editor/baseFormStateTypes.ts
@@ -27,6 +27,7 @@ import { type StarterBrickType } from "@/types/starterBrickTypes";
 import { type Permissions } from "webextension-polyfill";
 import {
   type ModComponentBase,
+  type ModComponentBaseV3,
   type ModMetadata,
 } from "@/types/modComponentTypes";
 import {
@@ -136,9 +137,9 @@ export interface BaseFormStateV1<
   /**
    * Information about the mod used to activate the mod component, or `undefined`
    * if the mod component is not part of a mod.
-   * @see ModComponentBase._recipe
+   * @see ModComponentBase.metadata
    */
-  recipe: ModComponentBase["_recipe"] | undefined;
+  recipe: ModComponentBaseV3["_recipe"] | undefined;
 
   /**
    * Information about the mod options or `undefined`
@@ -191,14 +192,12 @@ export type BaseFormStateV3<
   modComponent: TModComponent;
 
   /**
-   * @since 2.0.5
-   * Part of the Page Editor renaming effort
-   * `recipe` to `modMetadata`
    * Information about the mod used to activate the mod component, or `undefined`
    * if the mod component is not part of a mod.
-   * @see ModComponentBase._recipe
+   * @see ModComponentBase.modMetadata
+   * @since 2.0.5
    */
-  modMetadata: ModComponentBase["_recipe"] | undefined;
+  modMetadata: ModComponentBase["modMetadata"] | undefined;
 };
 
 /**

--- a/src/pageEditor/store/editor/editorSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors.ts
@@ -278,14 +278,15 @@ export const selectActivatedModMetadatas = createSelector(
   selectActivatedModComponents,
   selectDirtyModMetadata,
   (formStates, activatedModComponents, dirtyModMetadataById) => {
-    const formStateModMetadatas: Array<ModComponentBase["_recipe"]> = formStates
-      .filter((formState) => Boolean(formState.modMetadata))
-      .map((formState) => formState.modMetadata);
+    const formStateModMetadatas: Array<ModComponentBase["modMetadata"]> =
+      formStates
+        .filter((formState) => Boolean(formState.modMetadata))
+        .map((formState) => formState.modMetadata);
     const activatedModComponentModMetadatas: Array<
-      ModComponentBase["_recipe"]
+      ModComponentBase["modMetadata"]
     > = activatedModComponents
-      .filter((component) => Boolean(component._recipe))
-      .map((component) => component._recipe);
+      .filter((component) => Boolean(component.modMetadata))
+      .map((component) => component.modMetadata);
 
     const baseMetadatas = compact(
       uniqBy(

--- a/src/pageEditor/store/editor/editorSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors.ts
@@ -23,7 +23,7 @@ import {
   type RootState,
 } from "@/pageEditor/store/editor/pageEditorTypes";
 import { selectActivatedModComponents } from "@/store/modComponents/modComponentSelectors";
-import { compact, flatMap, isEmpty, sortBy, uniqBy } from "lodash";
+import { flatMap, isEmpty, sortBy, uniqBy } from "lodash";
 import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
 import {
   type BrickPipelineUIState,
@@ -279,20 +279,14 @@ export const selectActivatedModMetadatas = createSelector(
   selectDirtyModMetadata,
   (formStates, activatedModComponents, dirtyModMetadataById) => {
     const formStateModMetadatas: Array<ModComponentBase["modMetadata"]> =
-      formStates
-        .filter((formState) => Boolean(formState.modMetadata))
-        .map((formState) => formState.modMetadata);
+      formStates.map((formState) => formState.modMetadata);
     const activatedModComponentModMetadatas: Array<
       ModComponentBase["modMetadata"]
-    > = activatedModComponents
-      .filter((component) => Boolean(component.modMetadata))
-      .map((component) => component.modMetadata);
+    > = activatedModComponents.map((component) => component.modMetadata);
 
-    const baseMetadatas = compact(
-      uniqBy(
-        [...formStateModMetadatas, ...activatedModComponentModMetadatas],
-        (x) => x?.id,
-      ),
+    const baseMetadatas = uniqBy(
+      [...formStateModMetadatas, ...activatedModComponentModMetadatas],
+      (x) => x.id,
     );
 
     return baseMetadatas.map((metadata) => {

--- a/src/pageEditor/store/editor/editorSlice.ts
+++ b/src/pageEditor/store/editor/editorSlice.ts
@@ -335,23 +335,20 @@ export const editorSlice = createSlice({
       // Ensure the form state is writeable for normalization
       const modComponentFormState = cloneDeep(action.payload);
 
-      // Check if the new form state has modMetadata
-      if (modComponentFormState.modMetadata) {
-        const modId = modComponentFormState.modMetadata.id;
+      const modId = modComponentFormState.modMetadata.id;
 
-        // Find existing activated mod components with the same mod id
-        const existingModComponents = state.modComponentFormStates.filter(
-          (formState) => formState.modMetadata.id === modId,
+      // Find existing activated mod components with the same mod id
+      const existingModComponents = state.modComponentFormStates.filter(
+        (formState) => formState.modMetadata.id === modId,
+      );
+
+      // If there are existing components, collect their option arguments, and assign.
+      // NOTE: we don't need to have logic here for optionsDefinition and variablesDefinition because those
+      // are stored/owned at the mod-level in the Page Editor
+      if (existingModComponents.length > 0) {
+        modComponentFormState.optionsArgs = collectModOptions(
+          existingModComponents,
         );
-
-        // If there are existing components, collect their option arguments, and assign.
-        // NOTE: we don't need to have logic here for optionsDefinition and variablesDefinition because those
-        // are stored/owned at the mod-level in the Page Editor
-        if (existingModComponents.length > 0) {
-          modComponentFormState.optionsArgs = collectModOptions(
-            existingModComponents,
-          );
-        }
       }
 
       state.modComponentFormStates.push(

--- a/src/pageEditor/store/editor/editorSlice.ts
+++ b/src/pageEditor/store/editor/editorSlice.ts
@@ -131,7 +131,7 @@ const duplicateActiveModComponent = createAsyncThunk<
       /**
        * Optional destination mod to create the duplicate in.
        */
-      destinationModMetadata?: ModComponentBase["_recipe"];
+      destinationModMetadata?: ModComponentBase["modMetadata"];
     }
   | undefined,
   { state: EditorRootState }

--- a/src/pageEditor/store/editor/selectGetCleanComponentsAndDirtyFormStatesForMod.test.ts
+++ b/src/pageEditor/store/editor/selectGetCleanComponentsAndDirtyFormStatesForMod.test.ts
@@ -101,7 +101,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
       for (let i = 0; i < cleanCount; i++) {
         const starterBrickId = newStarterBrickId();
         const activatedModComponent = activatedModComponentFactory({
-          _recipe: primaryModMetadata,
+          modMetadata: primaryModMetadata,
           extensionPointId: starterBrickId,
           definitions: {
             [starterBrickId]: {
@@ -119,7 +119,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
       for (let i = 0; i < cleanFormCount; i++) {
         const starterBrickId = newStarterBrickId();
         const activatedModComponent = activatedModComponentFactory({
-          _recipe: primaryModMetadata,
+          modMetadata: primaryModMetadata,
           extensionPointId: starterBrickId,
           definitions: {
             [starterBrickId]: {
@@ -139,7 +139,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
       for (let i = 0; i < dirtyCount; i++) {
         const starterBrickId = newStarterBrickId();
         const activatedModComponent = activatedModComponentFactory({
-          _recipe: primaryModMetadata,
+          modMetadata: primaryModMetadata,
           extensionPointId: starterBrickId,
           definitions: {
             [starterBrickId]: {
@@ -159,7 +159,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
       for (let i = 0; i < deletedCount; i++) {
         const starterBrickId = newStarterBrickId();
         const activatedModComponent = activatedModComponentFactory({
-          _recipe: primaryModMetadata,
+          modMetadata: primaryModMetadata,
           extensionPointId: starterBrickId,
           definitions: {
             [starterBrickId]: {
@@ -189,7 +189,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
       const extraCleanModComponents: ActivatedModComponent[] = [];
       for (let i = 0; i < extraClean; i++) {
         const activatedModComponent = activatedModComponentFactory({
-          _recipe: otherModMetadata,
+          modMetadata: otherModMetadata,
         });
         extraCleanModComponents.push(activatedModComponent);
       }
@@ -199,7 +199,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
       for (let i = 0; i < extraDirty; i++) {
         const starterBrickId = newStarterBrickId();
         const activatedModComponent = activatedModComponentFactory({
-          _recipe: otherModMetadata,
+          modMetadata: otherModMetadata,
           extensionPointId: starterBrickId,
           definitions: {
             [starterBrickId]: {

--- a/src/pageEditor/store/editor/selectGetCleanComponentsAndDirtyFormStatesForMod.ts
+++ b/src/pageEditor/store/editor/selectGetCleanComponentsAndDirtyFormStatesForMod.ts
@@ -37,7 +37,7 @@ export const selectGetCleanComponentsAndDirtyFormStatesForMod = createSelector(
 
       const cleanModComponents = activatedModComponents.filter(
         (modComponent) =>
-          modComponent._recipe?.id === modId &&
+          modComponent.modMetadata.id === modId &&
           !dirtyModComponentFormStates.some(
             (formState) => formState.uuid === modComponent.id,
           ),

--- a/src/pageEditor/tabs/modMetadata/ModMetadataEditor.test.tsx
+++ b/src/pageEditor/tabs/modMetadata/ModMetadataEditor.test.tsx
@@ -49,7 +49,7 @@ describe("ModMetadataEditor", () => {
     const formState = formStateFactory({ formStateConfig: { modMetadata } });
 
     const modComponent = activatedModComponentFactory({
-      _recipe: modMetadata,
+      modMetadata,
     });
 
     useOptionalModDefinitionMock.mockReturnValue(
@@ -78,7 +78,7 @@ describe("ModMetadataEditor", () => {
     const formState = formStateFactory({ formStateConfig: { modMetadata } });
 
     const modComponent = activatedModComponentFactory({
-      _recipe: modMetadata,
+      modMetadata,
     });
 
     useOptionalModDefinitionMock.mockReturnValue(

--- a/src/pageEditor/tabs/modMetadata/ModMetadataEditor.tsx
+++ b/src/pageEditor/tabs/modMetadata/ModMetadataEditor.tsx
@@ -69,7 +69,7 @@ const selectFirstModComponent = createSelector(
   selectActivatedModComponents,
   selectActiveModId,
   (modComponents, activeModId) =>
-    modComponents.find((x) => x._recipe?.id === activeModId),
+    modComponents.find((x) => x.modMetadata?.id === activeModId),
 );
 
 const OldModVersionAlert: React.FunctionComponent<{
@@ -115,7 +115,7 @@ const ModMetadataEditor: React.VoidFunctionComponent = () => {
     selectFirstModComponentFormStateForActiveMod,
   );
 
-  const activatedModVersion = modDefinitionComponent?._recipe?.version;
+  const activatedModVersion = modDefinitionComponent?.modMetadata.version;
   const latestModVersion = modDefinition?.metadata?.version;
   const showOldModVersionWarning =
     activatedModVersion &&
@@ -126,7 +126,7 @@ const ModMetadataEditor: React.VoidFunctionComponent = () => {
   // Prefer the metadata from the activated mod component
   const currentMetadata =
     dirtyMetadata ??
-    modDefinitionComponent?._recipe ??
+    modDefinitionComponent?.modMetadata ??
     modDefinition?.metadata ??
     firstComponentFormStateForMod?.modMetadata;
 

--- a/src/pageEditor/tabs/modMetadata/ModMetadataEditor.tsx
+++ b/src/pageEditor/tabs/modMetadata/ModMetadataEditor.tsx
@@ -69,7 +69,7 @@ const selectFirstModComponent = createSelector(
   selectActivatedModComponents,
   selectActiveModId,
   (modComponents, activeModId) =>
-    modComponents.find((x) => x.modMetadata?.id === activeModId),
+    modComponents.find((x) => x.modMetadata.id === activeModId),
 );
 
 const OldModVersionAlert: React.FunctionComponent<{

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -69,9 +69,7 @@ export function getModComponentId(
 export function getModId(
   modComponentOrFormState: ModComponentBase | ModComponentFormState,
 ): RegistryId | undefined {
-  return isModComponentBase(modComponentOrFormState)
-    ? modComponentOrFormState._recipe?.id
-    : modComponentOrFormState.modMetadata.id;
+  return modComponentOrFormState.modMetadata.id;
 }
 
 /**

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -35,7 +35,6 @@ import {
   type ModMetadata,
 } from "@/types/modComponentTypes";
 import { type UUID } from "@/types/stringTypes";
-import { type RegistryId } from "@/types/registryTypes";
 import { type Brick } from "@/types/brickTypes";
 import { sortedFields } from "@/components/fields/schemaFields/schemaFieldUtils";
 import { castTextLiteralOrThrow } from "@/utils/expressionUtils";

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -66,12 +66,6 @@ export function getModComponentId(
     : modComponentOrFormState.uuid;
 }
 
-export function getModId(
-  modComponentOrFormState: ModComponentBase | ModComponentFormState,
-): RegistryId | undefined {
-  return modComponentOrFormState.modMetadata.id;
-}
-
 /**
  * Return pipeline prop names for a configured brick.
  *

--- a/src/sidebar/modLauncher/ActiveSidebarModsListItem.tsx
+++ b/src/sidebar/modLauncher/ActiveSidebarModsListItem.tsx
@@ -78,10 +78,10 @@ const ActiveSidebarModsListItem: React.FunctionComponent<{
   // Apply emoji icon or mod icon if available
   if (emojiIcon) {
     icon = emojiIcon;
-  } else if (modComponent?._recipe) {
+  } else if (modComponent?.modMetadata) {
     icon = (
       <MarketplaceListingIcon
-        packageId={modComponent._recipe.id}
+        packageId={modComponent.modMetadata.id}
         defaultIcon={faCube}
       />
     );

--- a/src/starterBricks/button/buttonStarterBrick.test.ts
+++ b/src/starterBricks/button/buttonStarterBrick.test.ts
@@ -39,6 +39,7 @@ import {
   type ButtonStarterBrickConfig,
 } from "@/starterBricks/button/buttonStarterBrickTypes";
 import { StarterBrickTypes } from "@/types/starterBrickTypes";
+import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 
 jest.mock("@/runtime/reducePipeline");
 
@@ -83,7 +84,7 @@ const modComponentFactory = define<HydratedModComponent>({
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/starter-brick-${n}`),
-  _recipe: undefined,
+  modMetadata: modMetadataFactory,
   label: "Test Button",
   config: define<ButtonStarterBrickConfig>({
     caption: "Hello World",

--- a/src/starterBricks/button/buttonStarterBrick.ts
+++ b/src/starterBricks/button/buttonStarterBrick.ts
@@ -766,7 +766,7 @@ export abstract class ButtonStarterBrickABC extends StarterBrickABC<ButtonStarte
             errors.push(error);
             reportError(error, {
               context: {
-                deploymentId: modComponent._deployment?.id,
+                deploymentId: modComponent.deploymentMetadata?.id,
                 starterBrickId: modComponent.extensionPointId,
                 modComponentId: modComponent.id,
               },

--- a/src/starterBricks/contextMenu/contextMenuStarterBrick.test.ts
+++ b/src/starterBricks/contextMenu/contextMenuStarterBrick.test.ts
@@ -36,6 +36,7 @@ import {
   type ContextMenuConfig,
 } from "@/starterBricks/contextMenu/contextMenuTypes";
 import { StarterBrickTypes } from "@/types/starterBrickTypes";
+import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 
 const uninstallContextMenuMock = jest.mocked(uninstallContextMenu);
 const ensureContextMenuMock = jest.mocked(ensureContextMenu);
@@ -69,7 +70,7 @@ const modComponentFactory = define<HydratedModComponent<ContextMenuConfig>>({
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/starter-brick-${n}`),
-  _recipe: undefined,
+  modMetadata: modMetadataFactory,
   label: "Test Extension",
   config: define<ContextMenuConfig>({
     title: "Test Menu Item",

--- a/src/starterBricks/contextMenu/contextMenuStarterBrick.ts
+++ b/src/starterBricks/contextMenu/contextMenuStarterBrick.ts
@@ -242,7 +242,7 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
   async registerMenuItem(
     modComponent: Pick<
       HydratedModComponent<ContextMenuConfig>,
-      "id" | "config" | "_deployment"
+      "id" | "config" | "deploymentMetadata"
     >,
     handler: (clickData: Menus.OnClickData) => Promise<void>,
   ): Promise<void> {
@@ -278,7 +278,7 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
       } catch (error) {
         reportError(error, {
           context: {
-            deploymentId: modComponent._deployment?.id,
+            deploymentId: modComponent.deploymentMetadata?.id,
             starterBrickId: modComponent.extensionPointId,
             modComponentId: modComponent.id,
           },

--- a/src/starterBricks/dynamicQuickBar/dynamicQuickBarStarterBrick.test.ts
+++ b/src/starterBricks/dynamicQuickBar/dynamicQuickBarStarterBrick.test.ts
@@ -47,6 +47,7 @@ import {
   type DynamicQuickBarConfig,
 } from "@/starterBricks/dynamicQuickBar/dynamicQuickBarTypes";
 import { StarterBrickTypes } from "@/types/starterBrickTypes";
+import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 
 const rootReaderId = validateRegistryId("test/root-reader");
 
@@ -75,7 +76,7 @@ const modComponentFactory = define<HydratedModComponent<DynamicQuickBarConfig>>(
     id: uuidSequence,
     extensionPointId: (n: number) =>
       validateRegistryId(`test/starter-brick-${n}`),
-    _recipe: undefined,
+    modMetadata: modMetadataFactory,
     label: "Test Extension",
     config: define<DynamicQuickBarConfig>({
       rootAction: () => ({

--- a/src/starterBricks/helpers.ts
+++ b/src/starterBricks/helpers.ts
@@ -193,8 +193,7 @@ export function shouldModComponentRunForStateChange(
     // Ignore state changes from shared state and unrelated mods/mod components
     return (
       detail?.extensionId === modComponent.id ||
-      (modComponent.modMetadata?.id != null &&
-        modComponent.modMetadata?.id === detail?.blueprintId)
+      modComponent.modMetadata.id === detail?.blueprintId
     );
   }
 

--- a/src/starterBricks/helpers.ts
+++ b/src/starterBricks/helpers.ts
@@ -193,8 +193,8 @@ export function shouldModComponentRunForStateChange(
     // Ignore state changes from shared state and unrelated mods/mod components
     return (
       detail?.extensionId === modComponent.id ||
-      (modComponent._recipe?.id != null &&
-        modComponent._recipe?.id === detail?.blueprintId)
+      (modComponent.modMetadata?.id != null &&
+        modComponent.modMetadata?.id === detail?.blueprintId)
     );
   }
 

--- a/src/starterBricks/quickBar/quickBarStarterBrick.test.ts
+++ b/src/starterBricks/quickBar/quickBarStarterBrick.test.ts
@@ -48,6 +48,7 @@ import {
   type QuickBarConfig,
 } from "@/starterBricks/quickBar/quickBarTypes";
 import { StarterBrickTypes } from "@/types/starterBrickTypes";
+import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 
 const rootReaderId = validateRegistryId("test/root-reader");
 
@@ -85,7 +86,7 @@ const modComponentFactory = define<HydratedModComponent<QuickBarConfig>>({
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/starter-brick-${n}`),
-  _recipe: undefined,
+  modMetadata: modMetadataFactory,
   label: "Test Mod Component",
   config: define<QuickBarConfig>({
     title: "Test Action",

--- a/src/starterBricks/sidebar/sidebarStarterBrick.test.ts
+++ b/src/starterBricks/sidebar/sidebarStarterBrick.test.ts
@@ -77,7 +77,7 @@ const modComponentFactory = define<HydratedModComponent<SidebarConfig>>({
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/starter-brick-${n}`),
-  _recipe: undefined,
+  modMetadata: modMetadataFactory,
   label: "Test Extension",
   config: define<SidebarConfig>({
     heading: "Test Action",
@@ -178,7 +178,6 @@ describe("sidebarExtension", () => {
 
     const modComponent = modComponentFactory({
       extensionPointId: starterBrick.id,
-      _recipe: modMetadataFactory(),
     });
 
     starterBrick.registerModComponent(modComponent);
@@ -193,7 +192,7 @@ describe("sidebarExtension", () => {
       mergeStrategy: MergeStrategies.REPLACE,
       modComponentRef: {
         modComponentId: modComponent.id,
-        modId: modComponent._recipe!.id,
+        modId: modComponent.modMetadata.id,
       },
     });
 
@@ -216,7 +215,7 @@ describe("sidebarExtension", () => {
       mergeStrategy: MergeStrategies.REPLACE,
       modComponentRef: {
         modComponentId: modComponent.id,
-        modId: modComponent._recipe!.id,
+        modId: modComponent.modMetadata.id,
       },
     });
 
@@ -256,7 +255,6 @@ describe("sidebarExtension", () => {
 
     const extension = modComponentFactory({
       extensionPointId: starterBrick.id,
-      _recipe: modMetadataFactory(),
     });
 
     starterBrick.registerModComponent(extension);
@@ -280,7 +278,7 @@ describe("sidebarExtension", () => {
         mergeStrategy: MergeStrategies.REPLACE,
         modComponentRef: {
           modComponentId: extension.id,
-          modId: extension._recipe!.id,
+          modId: extension.modMetadata.id,
         },
       });
     }

--- a/src/starterBricks/sidebar/sidebarStarterBrick.ts
+++ b/src/starterBricks/sidebar/sidebarStarterBrick.ts
@@ -259,8 +259,8 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
     } catch (error) {
       this.logger
         .childLogger({
-          deploymentId: modComponent._deployment?.id,
-          modId: modComponent._recipe?.id,
+          deploymentId: modComponent.deploymentMetadata?.id,
+          modId: modComponent.modMetadata.id,
           modComponentId: modComponent.id,
         })
         .error(error);

--- a/src/starterBricks/trigger/triggerStarterBrick.test.ts
+++ b/src/starterBricks/trigger/triggerStarterBrick.test.ts
@@ -587,9 +587,12 @@ describe("triggerStarterBrick", () => {
     await starterBrick.runModComponents({ reason: RunReason.MANUAL }); // Will run successfully
     await starterBrick.runModComponents({ reason: RunReason.MANUAL }); // Will also run successfully
 
-    // Does not report successful event only once
+    // Report successful event only once
     expect(reportEventMock).toHaveBeenCalledExactlyOnceWith("TriggerRun", {
+      label: modComponent.label,
       modComponentId: modComponent.id,
+      modId: modComponent.modMetadata.id,
+      modVersion: modComponent.modMetadata.version,
       trigger: Triggers.LOAD,
     });
 

--- a/src/starterBricks/trigger/triggerStarterBrick.test.ts
+++ b/src/starterBricks/trigger/triggerStarterBrick.test.ts
@@ -57,6 +57,7 @@ import {
 } from "@/starterBricks/trigger/triggerStarterBrickTypes";
 import { getPlatform } from "@/platform/platformContext";
 import { StarterBrickTypes } from "@/types/starterBrickTypes";
+import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 
 let hidden = false;
 
@@ -111,7 +112,7 @@ const modComponentFactory = define<HydratedModComponent<TriggerConfig>>({
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/starter-brick-${n}`),
-  _recipe: undefined,
+  modMetadata: modMetadataFactory,
   label: "Test Extension",
   config: define<TriggerConfig>({
     action: () => [] as BrickPipeline,

--- a/src/starterBricks/types.ts
+++ b/src/starterBricks/types.ts
@@ -261,11 +261,9 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
     // `registerModVariables` is safe to call multiple times for the same modId because the variable definitions
     // will be consistent across components.
     for (const modComponent of modComponents) {
-      if (modComponent._recipe) {
-        // `_recipe` is still optional on the type, but should always be present now that internal ids are generated
-        // for draft mod components. However, there's old test code that doesn't set `_recipe` on the mod component.
+      if (modComponent.modMetadata) {
         this.platform.state.registerModVariables(
-          modComponent._recipe.id,
+          modComponent.modMetadata.id,
           modComponent.variablesDefinition,
         );
       }
@@ -297,11 +295,9 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
       this.modComponents.push(modComponent);
     }
 
-    if (modComponent._recipe) {
-      // `_recipe` is still optional on the type, but should always be present now that internal ids are generated
-      // for draft mod components. However, there's old test code that doesn't set `_recipe` on the mod component.
+    if (modComponent.modMetadata) {
       this.platform.state.registerModVariables(
-        modComponent._recipe.id,
+        modComponent.modMetadata.id,
         modComponent.variablesDefinition,
       );
     }

--- a/src/starterBricks/types.ts
+++ b/src/starterBricks/types.ts
@@ -261,12 +261,10 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
     // `registerModVariables` is safe to call multiple times for the same modId because the variable definitions
     // will be consistent across components.
     for (const modComponent of modComponents) {
-      if (modComponent.modMetadata) {
-        this.platform.state.registerModVariables(
-          modComponent.modMetadata.id,
-          modComponent.variablesDefinition,
-        );
-      }
+      this.platform.state.registerModVariables(
+        modComponent.modMetadata.id,
+        modComponent.variablesDefinition,
+      );
     }
 
     console.debug("synchronizeComponents for extension point %s", this.id, {

--- a/src/store/editorStorage.ts
+++ b/src/store/editorStorage.ts
@@ -114,7 +114,7 @@ export async function removeDraftModComponentsForMod(
     removeModData(draft, modId);
 
     for (const modComponentFormState of state.modComponentFormStates) {
-      if (modComponentFormState.modMetadata?.id === modId) {
+      if (modComponentFormState.modMetadata.id === modId) {
         removedDraftModComponents.push(modComponentFormState.uuid);
         removeModComponentFormState(draft, modComponentFormState.uuid);
       }

--- a/src/store/modComponents/modComponentMigrations.ts
+++ b/src/store/modComponents/modComponentMigrations.ts
@@ -235,31 +235,6 @@ function migrateModComponentStateV5toV6(
   };
 }
 
-export function TEST_unmigrateActivatedModComponentV4toV2(
-  modComponent: ActivatedModComponentV4,
-): ActivatedModComponentV2 {
-  return {
-    ...omit(modComponent, ["modMetadata", "deploymentMetadata"]),
-    _recipe: modComponent.modMetadata,
-    _deployment: modComponent.deploymentMetadata,
-  };
-}
-
-export function TEST_unmigrateModComponentStateV6toV5(
-  state: ModComponentStateV6 & PersistedState,
-): ModComponentStateV5 & PersistedState {
-  return {
-    ...state,
-    activatedModComponents: state.activatedModComponents.map(
-      (modComponent) => ({
-        ...omit(modComponent, ["modMetadata", "deploymentMetadata"]),
-        _recipe: modComponent.modMetadata,
-        _deployment: modComponent.deploymentMetadata,
-      }),
-    ),
-  };
-}
-
 export function inferModComponentStateVersion(
   state: ModComponentStateVersions,
 ): number {

--- a/src/store/modComponents/modComponentMigrations.ts
+++ b/src/store/modComponents/modComponentMigrations.ts
@@ -37,10 +37,7 @@ import { omit, toLower } from "lodash";
 import { migrateIntegrationDependenciesV1toV2 } from "@/store/editorMigrations";
 import { nowTimestamp } from "@/utils/timeUtils";
 import { type Nullishable } from "@/utils/nullishUtils";
-import {
-  type ActivatedModComponentV2,
-  type ActivatedModComponentV4,
-} from "@/types/modComponentTypes";
+import { type ActivatedModComponentV2 } from "@/types/modComponentTypes";
 import { normalizeSemVerString, validateRegistryId } from "@/types/helpers";
 import { getUserScope } from "@/auth/authUtils";
 
@@ -73,7 +70,7 @@ const migrations: MigrationManifest = {
 
     return state;
   },
-  // V4 migration defined below
+  // V4 migration defined via createMigrationsManifest
   5(
     state: ModComponentStateV4 & PersistedState,
   ): ModComponentStateV5 & PersistedState {
@@ -83,7 +80,6 @@ const migrations: MigrationManifest = {
 
     return state;
   },
-  // V4 migration defined below
   6(
     state: ModComponentStateV5 & PersistedState,
   ): ModComponentStateV6 & PersistedState {

--- a/src/store/modComponents/modComponentSelectors.ts
+++ b/src/store/modComponents/modComponentSelectors.ts
@@ -40,9 +40,7 @@ export const selectGetModComponentsForMod = createSelector(
     // When activatedModComponents changes, the createSelector call will return a new function with the memoized
     // method referencing the new activatedModComponents
     memoize((modId: RegistryId) =>
-      activatedModComponents.filter(
-        (activatedModComponent) => activatedModComponent._recipe?.id === modId,
-      ),
+      activatedModComponents.filter((x) => x.modMetadata.id === modId),
     ),
 );
 

--- a/src/store/modComponents/modComponentSlice.ts
+++ b/src/store/modComponents/modComponentSlice.ts
@@ -77,8 +77,7 @@ const modComponentSlice = createSlice({
   name: "extensions",
   initialState,
   reducers: {
-    // Helper method to directly update extensions in tests. Can't use activateStandaloneModDefinition because
-    // StandaloneModDefinition doesn't have the _recipe field
+    // Helper method to directly update mod components in tests
     UNSAFE_setModComponents(
       state,
       { payload }: PayloadAction<ActivatedModComponent[]>,

--- a/src/store/modComponents/modComponentSlice.ts
+++ b/src/store/modComponents/modComponentSlice.ts
@@ -95,7 +95,7 @@ const modComponentSlice = createSlice({
         payload,
       }: PayloadAction<{
         modComponentId: UUID;
-        modMetadata: ModComponentBase["_recipe"];
+        modMetadata: ModComponentBase["modMetadata"];
       }>,
     ) {
       const { modComponentId, modMetadata } = payload;
@@ -104,7 +104,7 @@ const modComponentSlice = createSlice({
       );
 
       if (modComponent != null) {
-        modComponent._recipe = modMetadata;
+        modComponent.modMetadata = modMetadata;
       }
     },
 
@@ -200,7 +200,7 @@ const modComponentSlice = createSlice({
           optionsArgs,
           integrationDependencies,
           updateTimestamp,
-          _recipe,
+          modMetadata,
         },
       } = payload;
 
@@ -220,8 +220,8 @@ const modComponentSlice = createSlice({
         id,
         apiVersion,
         extensionPointId,
-        _recipe,
-        _deployment: undefined,
+        modMetadata,
+        deploymentMetadata: undefined,
         label,
         definitions,
         optionsArgs,
@@ -279,14 +279,14 @@ const modComponentSlice = createSlice({
      */
     updateModMetadata(
       state,
-      action: PayloadAction<ModComponentBase["_recipe"]>,
+      action: PayloadAction<ModComponentBase["modMetadata"]>,
     ) {
       const metadata = action.payload;
       const modComponents = state.activatedModComponents.filter(
-        (extension) => extension._recipe?.id === metadata?.id,
+        (extension) => extension.modMetadata.id === metadata?.id,
       );
       for (const modComponent of modComponents) {
-        modComponent._recipe = metadata;
+        modComponent.modMetadata = metadata;
       }
     },
 
@@ -296,7 +296,7 @@ const modComponentSlice = createSlice({
     removeModById(state, { payload: modId }: PayloadAction<RegistryId>) {
       const [, extensions] = partition(
         state.activatedModComponents,
-        (x) => x._recipe?.id === modId,
+        (x) => x.modMetadata.id === modId,
       );
 
       state.activatedModComponents = extensions;

--- a/src/store/modComponents/modComponentStorage.ts
+++ b/src/store/modComponents/modComponentStorage.ts
@@ -85,7 +85,7 @@ export const persistModComponentOptionsConfig = {
   // Change the type of localStorage to our overridden version so that it can be exported
   // See: @/store/StorageInterface.ts
   storage: localStorage as StorageInterface,
-  version: 5,
+  version: 6,
   // https://github.com/rt2zz/redux-persist#migrations
   migrate,
 };

--- a/src/store/modComponents/modComponentStorage.ts
+++ b/src/store/modComponents/modComponentStorage.ts
@@ -54,7 +54,7 @@ export async function getModComponentState(): Promise<ModComponentState> {
 export async function getActivatedModIds(): Promise<Set<RegistryId>> {
   const { activatedModComponents = [] } = await getModComponentState();
   return new Set(
-    compact(activatedModComponents.map(({ _recipe }) => _recipe?.id)),
+    compact(activatedModComponents.map(({ modMetadata }) => modMetadata.id)),
   );
 }
 

--- a/src/store/modComponents/modComponentTypes.ts
+++ b/src/store/modComponents/modComponentTypes.ts
@@ -169,7 +169,10 @@ export function isModComponentStateV5(
     return false;
   }
 
-  return Array.isArray(state.activatedModComponents);
+  return (
+    Array.isArray(state.activatedModComponents) &&
+    state.activatedModComponents.every((x) => !("modMetadata" in x))
+  );
 }
 
 export function isModComponentStateV6(

--- a/src/store/modComponents/modComponentTypes.ts
+++ b/src/store/modComponents/modComponentTypes.ts
@@ -171,3 +171,16 @@ export function isModComponentStateV5(
 
   return Array.isArray(state.activatedModComponents);
 }
+
+export function isModComponentStateV6(
+  state: ModComponentStateVersions,
+): state is ModComponentStateV6 {
+  if (!("activatedModComponents" in state)) {
+    return false;
+  }
+
+  return (
+    Array.isArray(state.activatedModComponents) &&
+    state.activatedModComponents.every((x) => "modMetadata" in x)
+  );
+}

--- a/src/store/modComponents/modComponentTypes.ts
+++ b/src/store/modComponents/modComponentTypes.ts
@@ -18,6 +18,7 @@
 import {
   type ActivatedModComponentV1,
   type ActivatedModComponentV2,
+  type ActivatedModComponentV4,
   type SerializedModComponentV1,
 } from "@/types/modComponentTypes";
 
@@ -70,14 +71,22 @@ export type ModComponentStateV5 = {
   activatedModComponents: ActivatedModComponentV2[];
 };
 
+/**
+ * @deprecated - Do not use versioned state types directly
+ */
+export type ModComponentStateV6 = {
+  activatedModComponents: ActivatedModComponentV4[];
+};
+
 export type ModComponentStateVersions =
   | ModComponentStateV0
   | ModComponentStateV1
   | ModComponentStateV2
   | ModComponentStateV3
-  | ModComponentStateV5;
+  | ModComponentStateV5
+  | ModComponentStateV6;
 
-export type ModComponentState = ModComponentStateV5;
+export type ModComponentState = ModComponentStateV6;
 
 export type ModComponentsRootState = {
   options: ModComponentState;

--- a/src/store/modComponents/modInstanceSelectors.ts
+++ b/src/store/modComponents/modInstanceSelectors.ts
@@ -34,7 +34,7 @@ export const selectModInstances = createSelector(
     }
 
     return Object.values(
-      groupBy(activatedModComponents, (x) => x._recipe?.id),
+      groupBy(activatedModComponents, (x) => x.modMetadata.id),
     ).map((modComponents) =>
       mapActivatedModComponentsToModInstance(modComponents),
     );

--- a/src/store/modComponents/modInstanceUtils.ts
+++ b/src/store/modComponents/modInstanceUtils.ts
@@ -43,7 +43,7 @@ import { type DeploymentMetadata } from "@/types/deploymentTypes";
  */
 type ModInstanceActivatedModComponent = SetRequired<
   ActivatedModComponent,
-  "_recipe" | "definitions" | "integrationDependencies" | "permissions"
+  "definitions" | "integrationDependencies" | "permissions"
 >;
 
 /**
@@ -110,7 +110,7 @@ export function mapModInstanceToActivatedModComponents(
           modComponentDefinition.permissions ?? emptyPermissionsFactory(),
         // Default to `v1` for backward compatability
         apiVersion: definition.apiVersion ?? "v1",
-        _recipe: modMetadata,
+        modMetadata,
         // All definitions are pushed down into the mod components. That's OK because `resolveDefinitions` determines
         // uniqueness based on the content of the definition. Therefore, bricks will be re-used as necessary
         definitions: definition.definitions ?? {},
@@ -130,7 +130,7 @@ export function mapModInstanceToActivatedModComponents(
       }
 
       if (deploymentMetadata) {
-        base._deployment = deploymentMetadata;
+        base.deploymentMetadata = deploymentMetadata;
       }
 
       return base;
@@ -158,14 +158,15 @@ export function mapActivatedModComponentsToModInstance(
   assertNotNullish(firstComponent, "activatedModComponents is empty");
 
   // Mod registry id consistency is checked when mapping over the components
-  const modMetadata = firstComponent._recipe;
+  const { modMetadata } = firstComponent;
+  // Impossible from typings, but keeping assertion to localize error if the migration was incorrect
   assertNotNullish(modMetadata, "Mod metadata is required");
 
   return {
     id: generateModInstanceId(),
     modComponentIds: modComponents.map(({ id }) => id),
-    deploymentMetadata: firstComponent._deployment
-      ? migrateDeploymentMetadata(firstComponent._deployment)
+    deploymentMetadata: firstComponent.deploymentMetadata
+      ? migrateDeploymentMetadata(firstComponent.deploymentMetadata)
       : undefined,
     optionsArgs: collectModOptions(modComponents),
     integrationsArgs: collectIntegrationDependencies(modComponents),
@@ -186,7 +187,7 @@ export function mapActivatedModComponentsToModInstance(
       extensionPoints: modComponents.map((modComponent) => {
         assertModComponentNotHydrated(modComponent);
 
-        if (modComponent._recipe?.id !== modMetadata.id) {
+        if (modComponent.modMetadata.id !== modMetadata.id) {
           throw new Error("Mod component does not match mod metadata");
         }
 

--- a/src/telemetry/deployments.ts
+++ b/src/telemetry/deployments.ts
@@ -16,29 +16,23 @@ export function selectEventData(
 
   // For team deployments and blueprints, include additional information to track use consistently across installations.
   // The extension on each activation
-  if (modComponent._deployment) {
+  if (modComponent.deploymentMetadata) {
     return {
       label: modComponent.label,
       modComponentId: modComponent.id,
-      deploymentId: modComponent._deployment?.id,
+      deploymentId: modComponent.deploymentMetadata.id,
       starterBrickId: isRegistryId(modComponent.extensionPointId)
         ? modComponent.extensionPointId
         : undefined,
-      modId: modComponent._recipe?.id,
-      modVersion: modComponent._recipe?.version,
-    };
-  }
-
-  if (modComponent._recipe) {
-    return {
-      label: modComponent.label,
-      modComponentId: modComponent.id,
-      modId: modComponent._recipe?.id,
-      modVersion: modComponent._recipe?.version,
+      modId: modComponent.modMetadata?.id,
+      modVersion: modComponent.modMetadata?.version,
     };
   }
 
   return {
+    label: modComponent.label,
     modComponentId: modComponent.id,
+    modId: modComponent.modMetadata.id,
+    modVersion: modComponent.modMetadata.version,
   };
 }

--- a/src/telemetry/deployments.ts
+++ b/src/telemetry/deployments.ts
@@ -24,8 +24,8 @@ export function selectEventData(
       starterBrickId: isRegistryId(modComponent.extensionPointId)
         ? modComponent.extensionPointId
         : undefined,
-      modId: modComponent.modMetadata?.id,
-      modVersion: modComponent.modMetadata?.version,
+      modId: modComponent.modMetadata.id,
+      modVersion: modComponent.modMetadata.version,
     };
   }
 

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -98,7 +98,6 @@ export const Events = {
   PAGE_EDITOR_MOD_COMPONENT_ERROR: "PageEditorExtensionError",
   PAGE_EDITOR_REMOVE: "PageEditorRemove",
   PAGE_EDITOR_CLEAR_CHANGES: "PageEditorReset",
-  PAGE_EDITOR_STANDALONE_MOD_COMPONENT_UPDATE: "PageEditorSave",
   PAGE_EDITOR_VIEW_TEMPLATES: "PageEditorViewTemplates",
   PAGE_EDITOR_MOD_CREATE: "PageEditorModCreate",
   PAGE_EDITOR_MOD_UPDATE: "PageEditorModUpdate",
@@ -140,8 +139,6 @@ export const Events = {
 
   SNOOZE_UPDATES: "SnoozeUpdates",
   SETTINGS_EXPERIMENTAL_CONFIGURE: "SettingsExperimentalConfigure",
-
-  STANDALONE_MOD_DELETE: "ExtensionCloudDelete",
 
   START_MOD_ACTIVATE: "StartInstallBlueprint",
 

--- a/src/testUtils/factories/modComponentFactories.ts
+++ b/src/testUtils/factories/modComponentFactories.ts
@@ -75,7 +75,7 @@ export const modMetadataFactory = extend<Metadata, ModMetadata>(
   },
 );
 
-const modComponentConfigFactory = define<ModComponentBase["config"]>({
+export const modComponentConfigFactory = define<ModComponentBase["config"]>({
   apiVersion: "v3" as ApiVersion,
   kind: DefinitionKinds.BRICK,
   metadata: (n: number) =>
@@ -113,7 +113,7 @@ export const modComponentFactory = define<ModComponentBase>({
   apiVersion: "v3" as ApiVersion,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/starter-brick-${n}`),
-  // @since 2.1.4 includes mod metadata
+  // @since 2.1.5 includes mod metadata
   modMetadata: modMetadataFactory,
   deploymentMetadata: undefined,
   label: "Test label",

--- a/src/testUtils/factories/modComponentFactories.ts
+++ b/src/testUtils/factories/modComponentFactories.ts
@@ -114,8 +114,8 @@ export const modComponentFactory = define<ModComponentBase>({
   extensionPointId: (n: number) =>
     validateRegistryId(`test/starter-brick-${n}`),
   // @since 2.1.4 includes mod metadata
-  _recipe: modMetadataFactory,
-  _deployment: undefined,
+  modMetadata: modMetadataFactory,
+  deploymentMetadata: undefined,
   label: "Test label",
   integrationDependencies(): IntegrationDependency[] {
     return [];

--- a/src/types/modComponentTypes.ts
+++ b/src/types/modComponentTypes.ts
@@ -45,7 +45,7 @@ import { type ModVariablesDefinition } from "@/types/modDefinitionTypes";
  * e.g. on the mods screen.
  *
  * @see optionsSlice
- * @see ModComponentBase._recipe
+ * @see ModComponentBase.modMetadata
  * @see Metadata
  */
 // XXX: previously we didn't export because the usage was clearer as ModComponentBase[_recipe]. However, the ergonomics
@@ -84,8 +84,8 @@ export type ModComponentBaseV1<Config extends UnknownObject = UnknownObject> = {
   extensionPointId: RegistryId | InnerDefinitionRef;
 
   /**
-   * Metadata about the deployment used to install the ModComponent, or `undefined` if the ModComponent was not installed
-   * via a deployment.
+   * Metadata about the deployment used to activate the ModComponent, or `undefined` if the ModComponent was not
+   * installed via a deployment.
    */
   _deployment?: DeploymentMetadata;
 
@@ -177,9 +177,27 @@ export type ModComponentBaseV3<Config extends UnknownObject = UnknownObject> =
     variablesDefinition?: ModVariablesDefinition;
   };
 
+/**
+ * @deprecated - Do not use versioned state types directly
+ */
+export type ModComponentBaseV4<Config extends UnknownObject = UnknownObject> =
+  Except<ModComponentBaseV3<Config>, "_recipe" | "_deployment"> & {
+    /**
+     * Metadata about the mod used to activate the ModComponent.
+     * @since 2.1.5
+     */
+    modMetadata: ModMetadata;
+
+    /**
+     * Metadata about the deployment used to activate the ModComponent, or `undefined` if the ModComponent was not
+     * installed via a deployment.
+     */
+    deploymentMetadata?: DeploymentMetadata | undefined;
+  };
+
 // XXX: technically Config could be JsonObject, but that's annoying to work with at callsites.
 export type ModComponentBase<Config extends UnknownObject = UnknownObject> =
-  ModComponentBaseV3<Config>;
+  ModComponentBaseV4<Config>;
 
 export type SerializedModComponentV1<
   Config extends UnknownObject = UnknownObject,
@@ -196,6 +214,12 @@ export type SerializedModComponentV2<
 export type SerializedModComponentV3<
   Config extends UnknownObject = UnknownObject,
 > = ModComponentBaseV3<Config> & {
+  _serializedModComponentBrand: never;
+};
+
+export type SerializedModComponentV4<
+  Config extends UnknownObject = UnknownObject,
+> = ModComponentBaseV4<Config> & {
   _serializedModComponentBrand: never;
 };
 
@@ -247,6 +271,10 @@ export type ActivatedModComponentV3<
   Config extends UnknownObject = UnknownObject,
 > = SerializedModComponentV3<Config> & ActivatedModComponentBase;
 
+export type ActivatedModComponentV4<
+  Config extends UnknownObject = UnknownObject,
+> = SerializedModComponentV4<Config> & ActivatedModComponentBase;
+
 /**
  * A ModComponent that has been activated locally
  * @see ModComponentBase
@@ -254,7 +282,7 @@ export type ActivatedModComponentV3<
  */
 export type ActivatedModComponent<
   Config extends UnknownObject = UnknownObject,
-> = ActivatedModComponentV3<Config>;
+> = ActivatedModComponentV4<Config>;
 
 /**
  * An `ModComponentBase` with all inner brick definitions hydrated.

--- a/src/utils/deploymentUtils.test.ts
+++ b/src/utils/deploymentUtils.test.ts
@@ -101,8 +101,8 @@ describe("makeUpdatedFilter", () => {
 
     const modInstance = mapActivatedModComponentsToModInstance([
       activatedModComponentFactory({
-        _deployment: undefined,
-        _recipe: {
+        deploymentMetadata: undefined,
+        modMetadata: {
           ...modDefinition.metadata,
           updated_at: validateTimestamp(deployment.updated_at!),
           // `sharing` doesn't impact the predicate. Pass an arbitrary value
@@ -120,8 +120,8 @@ describe("makeUpdatedFilter", () => {
 
     const modInstance = mapActivatedModComponentsToModInstance([
       activatedModComponentFactory({
-        _deployment: undefined,
-        _recipe: {
+        deploymentMetadata: undefined,
+        modMetadata: {
           ...modDefinition.metadata,
           // The factory produces version "1.0.1"
           version: normalizeSemVerString("1.0.1"),
@@ -171,7 +171,7 @@ describe("isDeploymentActive", () => {
     const deployment = deploymentFactory();
 
     const modComponent = modComponentFactory({
-      _deployment: {
+      deploymentMetadata: {
         id: deployment.id,
         timestamp: deployment.updated_at!,
         // Legacy deployments don't have an `active` field
@@ -187,7 +187,7 @@ describe("isDeploymentActive", () => {
       const deployment = deploymentFactory();
 
       const modComponent = modComponentFactory({
-        _deployment: {
+        deploymentMetadata: {
           id: deployment.id,
           timestamp: deployment.updated_at!,
           active,

--- a/src/utils/deploymentUtils.ts
+++ b/src/utils/deploymentUtils.ts
@@ -35,16 +35,16 @@ import type { ModInstance } from "@/types/modInstanceTypes";
 /**
  * Returns `true` if a managed deployment is active (i.e., has not been remotely paused by an admin)
  * @since 1.4.0
- * @see ModComponentBase._deployment
+ * @see ModComponentBase.deploymentMetadata
  */
 export function isDeploymentActive(extensionLike: {
-  _deployment?: ModComponentBase["_deployment"];
+  deploymentMetadata?: ModComponentBase["deploymentMetadata"];
 }): boolean {
   return (
     // Check for null/undefined to preserve backward compatability
     // Prior to extension version 1.4.0, there was no `active` field, because there was no ability to pause deployments
-    extensionLike._deployment?.active == null ||
-    extensionLike._deployment.active
+    extensionLike.deploymentMetadata?.active == null ||
+    extensionLike.deploymentMetadata.active
   );
 }
 

--- a/src/utils/modUtils.ts
+++ b/src/utils/modUtils.ts
@@ -65,6 +65,7 @@ import { createPrivateSharing } from "@/utils/registryUtils";
  * Returns a synthetic mod id for a standalone mod component for use in the runtime
  * @param modComponentId the standalone mod component id
  * @see INNER_SCOPE
+ * @deprecated standalone mod components have been retired
  */
 export function getStandaloneModComponentRuntimeModId(
   modComponentId: UUID,
@@ -77,12 +78,11 @@ export function getStandaloneModComponentRuntimeModId(
 /**
  * Returns a modId suitable for use in the runtime.
  * @since 2.0.6
+ * @deprecated standalone mod components have been retired
  */
 function getRuntimeModId(modComponent: ModComponentBase): RegistryId {
-  return (
-    modComponent._recipe?.id ??
-    getStandaloneModComponentRuntimeModId(modComponent.id)
-  );
+  assertNotNullish(modComponent.modMetadata, "Expected modMetadata");
+  return modComponent.modMetadata.id;
 }
 
 /**
@@ -113,9 +113,9 @@ export function mapModComponentToMessageContext(
     modComponentLabel: modComponent.label ?? undefined,
     modComponentId: modComponent.id,
     starterBrickId: modComponent.extensionPointId,
-    deploymentId: modComponent._deployment?.id,
-    modId: getRuntimeModId(modComponent),
-    modVersion: modComponent._recipe?.version,
+    deploymentId: modComponent.deploymentMetadata?.id,
+    modId: modComponent.modMetadata.id,
+    modVersion: modComponent.modMetadata.version,
   };
 }
 

--- a/src/utils/modUtils.ts
+++ b/src/utils/modUtils.ts
@@ -81,7 +81,6 @@ export function getStandaloneModComponentRuntimeModId(
  * @deprecated standalone mod components have been retired
  */
 function getRuntimeModId(modComponent: ModComponentBase): RegistryId {
-  assertNotNullish(modComponent.modMetadata, "Expected modMetadata");
   return modComponent.modMetadata.id;
 }
 


### PR DESCRIPTION
## What does this PR do?

- https://www.notion.so/pixiebrix/Re-Slicing-Eliminate-Standalone-mods-from-UI-694e4c85e61441809e14aec18f6b6109?pvs=4#10a43b21a253809b9eeefe0918880910
- Renames `ModComponent._recipe` to `ModComponent.modMetadata` and makes non-nullable
- Renames `ModComponent._deployment` to `ModComponent.deploymentMetadata`
- Removes unnecessary uses of `filter` to check for presence of metadata. See Future Work for follow up work

## Discussion

- Do we want to mark as `deploymentMetadata` instead of `deploymentMetadata?`. PR currently uses `?` which is current/old behavior. But we could use the migration in the PR as an opportunity to ensure the property exists but the value might be undefined

## Future Work

- Drop `standaloneModComponentRefFactory` and search for "standalone" in codebase and remove unnecessary branches/code: https://github.com/pixiebrix/pixiebrix-extension/pull/9256

## Testing Strategy

- Manually tested in local dev environment

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
