### PR TITLE
#9250 Refactor ModActionItem remove unnecessary props

### DIFF
--- a/src/pageEditor/modListingPanel/ModActionMenu.tsx
+++ b/src/pageEditor/modListingPanel/ModActionMenu.tsx
@@ -28,36 +28,36 @@ import styles from "./ActionMenu.module.scss";
 import EllipsisMenu, {
   type EllipsisMenuItem,
 } from "@/components/ellipsisMenu/EllipsisMenu";
-import { type AddNewModComponent } from "@/pageEditor/hooks/useAddNewModComponent";
+import useAddNewModComponent from "@/pageEditor/hooks/useAddNewModComponent";
 import { useAvailableFormStateAdapters } from "@/pageEditor/starterBricks/adapter";
 import useDeactivateMod from "@/pageEditor/hooks/useDeactivateMod";
-import { type RegistryId } from "@/types/registryTypes";
 import useSaveMod from "@/pageEditor/hooks/useSaveMod";
+import { type ModMetadata } from "@/types/modComponentTypes";
 
 type OptionalAction = (() => Promise<void>) | undefined;
 
 type ActionMenuProps = {
-  modId: RegistryId;
+  modMetadata: ModMetadata;
   isDirty: boolean;
   isActive: boolean;
   labelRoot: string;
   onMakeCopy: () => Promise<void>;
-  onAddStarterBrick: AddNewModComponent;
   onClearChanges: OptionalAction;
 };
 
 const ModActionMenu: React.FC<ActionMenuProps> = ({
-  modId,
+  modMetadata,
   isActive,
   labelRoot,
   isDirty,
-  onAddStarterBrick,
   onMakeCopy,
   onClearChanges = null,
 }) => {
+  const { id: modId } = modMetadata;
   const modComponentFormStateAdapters = useAvailableFormStateAdapters();
   const deactivateMod = useDeactivateMod();
   const saveMod = useSaveMod();
+  const addNewModComponent = useAddNewModComponent(modMetadata);
 
   const menuItems: EllipsisMenuItem[] = [
     {
@@ -74,11 +74,10 @@ const ModActionMenu: React.FC<ActionMenuProps> = ({
       submenu: modComponentFormStateAdapters.map((adapter) => ({
         title: adapter.label,
         action() {
-          onAddStarterBrick(adapter);
+          addNewModComponent(adapter);
         },
         icon: <FontAwesomeIcon icon={adapter.icon} fixedWidth />,
       })),
-      hide: !onAddStarterBrick,
     },
     {
       title: "Make a copy",
@@ -96,6 +95,7 @@ const ModActionMenu: React.FC<ActionMenuProps> = ({
 
   return (
     <div className={styles.root}>
+      {/* TODO: did we really want to always show SaveButton? That is the current behavior as of 2.1.5-beta.1 */}
       <SaveButton
         ariaLabel={labelRoot ? `${labelRoot} - Save` : undefined}
         onClick={async () => {

--- a/src/pageEditor/modListingPanel/ModActionMenu.tsx
+++ b/src/pageEditor/modListingPanel/ModActionMenu.tsx
@@ -37,20 +37,18 @@ import useClearModChanges from "@/pageEditor/hooks/useClearModChanges";
 import { isInnerDefinitionRegistryId } from "@/types/helpers";
 import { actions } from "@/pageEditor/store/editor/editorSlice";
 import { useDispatch, useSelector } from "react-redux";
-import { selectModIsDirty } from "@/pageEditor/store/editor/editorSelectors";
+import {
+  selectActiveModId,
+  selectModIsDirty,
+} from "@/pageEditor/store/editor/editorSelectors";
 
-type ActionMenuProps = {
+const ModActionMenu: React.FC<{
   modMetadata: ModMetadata;
-  isActive: boolean;
   labelRoot: string;
-};
-
-const ModActionMenu: React.FC<ActionMenuProps> = ({
-  modMetadata,
-  isActive,
-  labelRoot,
-}) => {
+}> = ({ modMetadata, labelRoot }) => {
   const { id: modId } = modMetadata;
+  const activeModId = useSelector(selectActiveModId);
+
   const dispatch = useDispatch();
   const modComponentFormStateAdapters = useAvailableFormStateAdapters();
 
@@ -61,6 +59,7 @@ const ModActionMenu: React.FC<ActionMenuProps> = ({
 
   const isUnsavedMod = isInnerDefinitionRegistryId(modId);
   const isDirty = useSelector(selectModIsDirty(modId));
+  const isActive = activeModId === modId;
 
   const menuItems: EllipsisMenuItem[] = [
     {

--- a/src/pageEditor/modListingPanel/ModActionMenu.tsx
+++ b/src/pageEditor/modListingPanel/ModActionMenu.tsx
@@ -101,7 +101,6 @@ const ModActionMenu: React.FC<{
 
   return (
     <div className={styles.root}>
-      {/* TODO: did we really want to always show SaveButton? That is the current behavior as of 2.1.5-beta.1 */}
       <SaveButton
         ariaLabel={labelRoot ? `${labelRoot} - Save` : undefined}
         onClick={async () => {

--- a/src/pageEditor/modListingPanel/ModActionMenu.tsx
+++ b/src/pageEditor/modListingPanel/ModActionMenu.tsx
@@ -30,14 +30,16 @@ import EllipsisMenu, {
 } from "@/components/ellipsisMenu/EllipsisMenu";
 import { type AddNewModComponent } from "@/pageEditor/hooks/useAddNewModComponent";
 import { useAvailableFormStateAdapters } from "@/pageEditor/starterBricks/adapter";
+import useDeactivateMod from "@/pageEditor/hooks/useDeactivateMod";
+import { type RegistryId } from "@/types/registryTypes";
 
 type OptionalAction = (() => Promise<void>) | undefined;
 
 type ActionMenuProps = {
+  modId: RegistryId;
   isDirty: boolean;
   isActive: boolean;
   labelRoot: string;
-  onDeactivate: () => Promise<void>;
   onMakeCopy: () => Promise<void>;
   onAddStarterBrick: AddNewModComponent;
   // Actions only defined if there are changes
@@ -46,17 +48,18 @@ type ActionMenuProps = {
 };
 
 const ModActionMenu: React.FC<ActionMenuProps> = ({
+  modId,
   isActive,
   labelRoot,
   isDirty,
   onAddStarterBrick,
-  onDeactivate,
   onMakeCopy,
   // Convert to null because EllipsisMenuItem expects null vs. undefined
   onSave = null,
   onClearChanges = null,
 }) => {
   const modComponentFormStateAdapters = useAvailableFormStateAdapters();
+  const deactivateMod = useDeactivateMod();
 
   const menuItems: EllipsisMenuItem[] = [
     {
@@ -87,8 +90,9 @@ const ModActionMenu: React.FC<ActionMenuProps> = ({
     {
       title: "Deactivate",
       icon: <FontAwesomeIcon icon={faTimes} fixedWidth />,
-      action: onDeactivate,
-      hide: !onDeactivate,
+      async action() {
+        await deactivateMod({ modId });
+      },
     },
   ];
 

--- a/src/pageEditor/modListingPanel/ModActionMenu.tsx
+++ b/src/pageEditor/modListingPanel/ModActionMenu.tsx
@@ -35,13 +35,14 @@ import useSaveMod from "@/pageEditor/hooks/useSaveMod";
 import { type ModMetadata } from "@/types/modComponentTypes";
 import useClearModChanges from "@/pageEditor/hooks/useClearModChanges";
 import { isInnerDefinitionRegistryId } from "@/types/helpers";
+import { actions } from "@/pageEditor/store/editor/editorSlice";
+import { useDispatch } from "react-redux";
 
 type ActionMenuProps = {
   modMetadata: ModMetadata;
   isDirty: boolean;
   isActive: boolean;
   labelRoot: string;
-  onMakeCopy: () => Promise<void>;
 };
 
 const ModActionMenu: React.FC<ActionMenuProps> = ({
@@ -49,9 +50,9 @@ const ModActionMenu: React.FC<ActionMenuProps> = ({
   isActive,
   labelRoot,
   isDirty,
-  onMakeCopy,
 }) => {
   const { id: modId } = modMetadata;
+  const dispatch = useDispatch();
   const modComponentFormStateAdapters = useAvailableFormStateAdapters();
 
   const deactivateMod = useDeactivateMod();
@@ -86,7 +87,9 @@ const ModActionMenu: React.FC<ActionMenuProps> = ({
     {
       title: "Make a copy",
       icon: <FontAwesomeIcon icon={faClone} fixedWidth />,
-      action: onMakeCopy,
+      async action() {
+        dispatch(actions.showCreateModModal({ keepLocalCopy: true }));
+      },
     },
     {
       title: "Deactivate",

--- a/src/pageEditor/modListingPanel/ModActionMenu.tsx
+++ b/src/pageEditor/modListingPanel/ModActionMenu.tsx
@@ -32,6 +32,7 @@ import { type AddNewModComponent } from "@/pageEditor/hooks/useAddNewModComponen
 import { useAvailableFormStateAdapters } from "@/pageEditor/starterBricks/adapter";
 import useDeactivateMod from "@/pageEditor/hooks/useDeactivateMod";
 import { type RegistryId } from "@/types/registryTypes";
+import useSaveMod from "@/pageEditor/hooks/useSaveMod";
 
 type OptionalAction = (() => Promise<void>) | undefined;
 
@@ -42,8 +43,6 @@ type ActionMenuProps = {
   labelRoot: string;
   onMakeCopy: () => Promise<void>;
   onAddStarterBrick: AddNewModComponent;
-  // Actions only defined if there are changes
-  onSave: OptionalAction;
   onClearChanges: OptionalAction;
 };
 
@@ -54,12 +53,11 @@ const ModActionMenu: React.FC<ActionMenuProps> = ({
   isDirty,
   onAddStarterBrick,
   onMakeCopy,
-  // Convert to null because EllipsisMenuItem expects null vs. undefined
-  onSave = null,
   onClearChanges = null,
 }) => {
   const modComponentFormStateAdapters = useAvailableFormStateAdapters();
   const deactivateMod = useDeactivateMod();
+  const saveMod = useSaveMod();
 
   const menuItems: EllipsisMenuItem[] = [
     {
@@ -98,13 +96,13 @@ const ModActionMenu: React.FC<ActionMenuProps> = ({
 
   return (
     <div className={styles.root}>
-      {onSave != null && (
-        <SaveButton
-          ariaLabel={labelRoot ? `${labelRoot} - Save` : undefined}
-          onClick={onSave}
-          disabled={!isDirty}
-        />
-      )}
+      <SaveButton
+        ariaLabel={labelRoot ? `${labelRoot} - Save` : undefined}
+        onClick={async () => {
+          await saveMod(modId);
+        }}
+        disabled={!isDirty}
+      />
       {isActive && (
         <EllipsisMenu
           portal

--- a/src/pageEditor/modListingPanel/ModActionMenu.tsx
+++ b/src/pageEditor/modListingPanel/ModActionMenu.tsx
@@ -36,11 +36,11 @@ import { type ModMetadata } from "@/types/modComponentTypes";
 import useClearModChanges from "@/pageEditor/hooks/useClearModChanges";
 import { isInnerDefinitionRegistryId } from "@/types/helpers";
 import { actions } from "@/pageEditor/store/editor/editorSlice";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { selectModIsDirty } from "@/pageEditor/store/editor/editorSelectors";
 
 type ActionMenuProps = {
   modMetadata: ModMetadata;
-  isDirty: boolean;
   isActive: boolean;
   labelRoot: string;
 };
@@ -49,7 +49,6 @@ const ModActionMenu: React.FC<ActionMenuProps> = ({
   modMetadata,
   isActive,
   labelRoot,
-  isDirty,
 }) => {
   const { id: modId } = modMetadata;
   const dispatch = useDispatch();
@@ -61,6 +60,7 @@ const ModActionMenu: React.FC<ActionMenuProps> = ({
   const addNewModComponent = useAddNewModComponent(modMetadata);
 
   const isUnsavedMod = isInnerDefinitionRegistryId(modId);
+  const isDirty = useSelector(selectModIsDirty(modId));
 
   const menuItems: EllipsisMenuItem[] = [
     {

--- a/src/pageEditor/modListingPanel/ModComponents.tsx
+++ b/src/pageEditor/modListingPanel/ModComponents.tsx
@@ -33,14 +33,12 @@ import {
   selectNotDeletedModComponentFormStates,
   selectNotDeletedActivatedModComponents,
 } from "@/pageEditor/store/editor/editorSelectors";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import ModComponentListItem from "./ModComponentListItem";
-import { actions } from "@/pageEditor/store/editor/editorSlice";
 import { useDebounce } from "use-debounce";
 import filterSidebarItems from "@/pageEditor/modListingPanel/filterSidebarItems";
 
 const ModComponents: React.FunctionComponent = () => {
-  const dispatch = useDispatch();
   const activeModComponentId = useSelector(selectActiveModComponentId);
   const activeModId = useSelector(selectActiveModId);
   const expandedModId = useSelector(selectExpandedModId);
@@ -89,13 +87,7 @@ const ModComponents: React.FunctionComponent = () => {
       const { modMetadata, modComponents } = sidebarItem;
 
       return (
-        <ModListItem
-          key={modMetadata.id}
-          modMetadata={modMetadata}
-          onMakeCopy={async () => {
-            dispatch(actions.showCreateModModal({ keepLocalCopy: true }));
-          }}
-        >
+        <ModListItem key={modMetadata.id} modMetadata={modMetadata}>
           {modComponents.map((modComponentSidebarItem) => (
             <ModComponentListItem
               key={getModComponentItemId(modComponentSidebarItem)}

--- a/src/pageEditor/modListingPanel/ModComponents.tsx
+++ b/src/pageEditor/modListingPanel/ModComponents.tsx
@@ -34,7 +34,6 @@ import {
   selectNotDeletedActivatedModComponents,
 } from "@/pageEditor/store/editor/editorSelectors";
 import { useDispatch, useSelector } from "react-redux";
-import useClearModChanges from "@/pageEditor/hooks/useClearModChanges";
 import ModComponentListItem from "./ModComponentListItem";
 import { actions } from "@/pageEditor/store/editor/editorSlice";
 import { useDebounce } from "use-debounce";
@@ -85,8 +84,6 @@ const ModComponents: React.FunctionComponent = () => {
     ],
   );
 
-  const clearModChanges = useClearModChanges();
-
   const listItems = filteredSidebarItems.map((sidebarItem) => {
     if (isModSidebarItem(sidebarItem)) {
       const { modMetadata, modComponents } = sidebarItem;
@@ -95,9 +92,6 @@ const ModComponents: React.FunctionComponent = () => {
         <ModListItem
           key={modMetadata.id}
           modMetadata={modMetadata}
-          onClearChanges={async () => {
-            await clearModChanges(modMetadata.id);
-          }}
           onMakeCopy={async () => {
             dispatch(actions.showCreateModModal({ keepLocalCopy: true }));
           }}

--- a/src/pageEditor/modListingPanel/ModComponents.tsx
+++ b/src/pageEditor/modListingPanel/ModComponents.tsx
@@ -34,7 +34,6 @@ import {
   selectNotDeletedActivatedModComponents,
 } from "@/pageEditor/store/editor/editorSelectors";
 import { useDispatch, useSelector } from "react-redux";
-import useSaveMod from "@/pageEditor/hooks/useSaveMod";
 import useClearModChanges from "@/pageEditor/hooks/useClearModChanges";
 import ModComponentListItem from "./ModComponentListItem";
 import { actions } from "@/pageEditor/store/editor/editorSlice";
@@ -86,7 +85,6 @@ const ModComponents: React.FunctionComponent = () => {
     ],
   );
 
-  const saveMod = useSaveMod();
   const clearModChanges = useClearModChanges();
 
   const listItems = filteredSidebarItems.map((sidebarItem) => {
@@ -97,9 +95,6 @@ const ModComponents: React.FunctionComponent = () => {
         <ModListItem
           key={modMetadata.id}
           modMetadata={modMetadata}
-          onSave={async () => {
-            await saveMod(modMetadata.id);
-          }}
           onClearChanges={async () => {
             await clearModChanges(modMetadata.id);
           }}

--- a/src/pageEditor/modListingPanel/ModComponents.tsx
+++ b/src/pageEditor/modListingPanel/ModComponents.tsx
@@ -36,7 +36,6 @@ import {
 import { useDispatch, useSelector } from "react-redux";
 import useSaveMod from "@/pageEditor/hooks/useSaveMod";
 import useClearModChanges from "@/pageEditor/hooks/useClearModChanges";
-import useDeactivateMod from "@/pageEditor/hooks/useDeactivateMod";
 import ModComponentListItem from "./ModComponentListItem";
 import { actions } from "@/pageEditor/store/editor/editorSlice";
 import { useDebounce } from "use-debounce";
@@ -89,7 +88,6 @@ const ModComponents: React.FunctionComponent = () => {
 
   const saveMod = useSaveMod();
   const clearModChanges = useClearModChanges();
-  const deactivateMod = useDeactivateMod();
 
   const listItems = filteredSidebarItems.map((sidebarItem) => {
     if (isModSidebarItem(sidebarItem)) {
@@ -104,9 +102,6 @@ const ModComponents: React.FunctionComponent = () => {
           }}
           onClearChanges={async () => {
             await clearModChanges(modMetadata.id);
-          }}
-          onDeactivate={async () => {
-            await deactivateMod({ modId: modMetadata.id });
           }}
           onMakeCopy={async () => {
             dispatch(actions.showCreateModModal({ keepLocalCopy: true }));

--- a/src/pageEditor/modListingPanel/ModListItem.test.tsx
+++ b/src/pageEditor/modListingPanel/ModListItem.test.tsx
@@ -38,7 +38,7 @@ describe("ModListItem", () => {
     render(
       <Accordion defaultActiveKey={modMetadata.id}>
         <ListGroup>
-          <ModListItem modMetadata={modMetadata} onMakeCopy={jest.fn()}>
+          <ModListItem modMetadata={modMetadata}>
             <div>test children</div>
           </ModListItem>
         </ListGroup>
@@ -63,7 +63,7 @@ describe("ModListItem", () => {
     render(
       <Accordion>
         <ListGroup>
-          <ModListItem modMetadata={modMetadata} onMakeCopy={jest.fn()}>
+          <ModListItem modMetadata={modMetadata}>
             <div>test children</div>
           </ModListItem>
         </ListGroup>
@@ -97,7 +97,7 @@ describe("ModListItem", () => {
     render(
       <Accordion defaultActiveKey={modMetadata.id}>
         <ListGroup>
-          <ModListItem modMetadata={modMetadata} onMakeCopy={jest.fn()}>
+          <ModListItem modMetadata={modMetadata}>
             <div>test children</div>
           </ModListItem>
         </ListGroup>

--- a/src/pageEditor/modListingPanel/ModListItem.test.tsx
+++ b/src/pageEditor/modListingPanel/ModListItem.test.tsx
@@ -40,7 +40,6 @@ describe("ModListItem", () => {
         <ListGroup>
           <ModListItem
             modMetadata={modMetadata}
-            onSave={jest.fn()}
             onClearChanges={jest.fn()}
             onMakeCopy={jest.fn()}
           >
@@ -70,7 +69,6 @@ describe("ModListItem", () => {
         <ListGroup>
           <ModListItem
             modMetadata={modMetadata}
-            onSave={jest.fn()}
             onClearChanges={jest.fn()}
             onMakeCopy={jest.fn()}
           >
@@ -109,7 +107,6 @@ describe("ModListItem", () => {
         <ListGroup>
           <ModListItem
             modMetadata={modMetadata}
-            onSave={jest.fn()}
             onClearChanges={jest.fn()}
             onMakeCopy={jest.fn()}
           >

--- a/src/pageEditor/modListingPanel/ModListItem.test.tsx
+++ b/src/pageEditor/modListingPanel/ModListItem.test.tsx
@@ -38,11 +38,7 @@ describe("ModListItem", () => {
     render(
       <Accordion defaultActiveKey={modMetadata.id}>
         <ListGroup>
-          <ModListItem
-            modMetadata={modMetadata}
-            onClearChanges={jest.fn()}
-            onMakeCopy={jest.fn()}
-          >
+          <ModListItem modMetadata={modMetadata} onMakeCopy={jest.fn()}>
             <div>test children</div>
           </ModListItem>
         </ListGroup>
@@ -67,11 +63,7 @@ describe("ModListItem", () => {
     render(
       <Accordion>
         <ListGroup>
-          <ModListItem
-            modMetadata={modMetadata}
-            onClearChanges={jest.fn()}
-            onMakeCopy={jest.fn()}
-          >
+          <ModListItem modMetadata={modMetadata} onMakeCopy={jest.fn()}>
             <div>test children</div>
           </ModListItem>
         </ListGroup>
@@ -105,11 +97,7 @@ describe("ModListItem", () => {
     render(
       <Accordion defaultActiveKey={modMetadata.id}>
         <ListGroup>
-          <ModListItem
-            modMetadata={modMetadata}
-            onClearChanges={jest.fn()}
-            onMakeCopy={jest.fn()}
-          >
+          <ModListItem modMetadata={modMetadata} onMakeCopy={jest.fn()}>
             <div>test children</div>
           </ModListItem>
         </ListGroup>

--- a/src/pageEditor/modListingPanel/ModListItem.test.tsx
+++ b/src/pageEditor/modListingPanel/ModListItem.test.tsx
@@ -42,7 +42,6 @@ describe("ModListItem", () => {
             modMetadata={modMetadata}
             onSave={jest.fn()}
             onClearChanges={jest.fn()}
-            onDeactivate={jest.fn()}
             onMakeCopy={jest.fn()}
           >
             <div>test children</div>
@@ -73,7 +72,6 @@ describe("ModListItem", () => {
             modMetadata={modMetadata}
             onSave={jest.fn()}
             onClearChanges={jest.fn()}
-            onDeactivate={jest.fn()}
             onMakeCopy={jest.fn()}
           >
             <div>test children</div>
@@ -113,7 +111,6 @@ describe("ModListItem", () => {
             modMetadata={modMetadata}
             onSave={jest.fn()}
             onClearChanges={jest.fn()}
-            onDeactivate={jest.fn()}
             onMakeCopy={jest.fn()}
           >
             <div>test children</div>

--- a/src/pageEditor/modListingPanel/ModListItem.tsx
+++ b/src/pageEditor/modListingPanel/ModListItem.tsx
@@ -37,7 +37,6 @@ import {
 } from "@/pageEditor/store/editor/editorSelectors";
 import * as semver from "semver";
 import { useGetModDefinitionQuery } from "@/data/service/api";
-import useAddNewModComponent from "@/pageEditor/hooks/useAddNewModComponent";
 import { type ModMetadata } from "@/types/modComponentTypes";
 import { isInnerDefinitionRegistryId } from "@/types/helpers";
 import ModActionMenu from "@/pageEditor/modListingPanel/ModActionMenu";
@@ -60,7 +59,6 @@ const ModListItem: React.FC<ModListItemProps> = ({
   const activeModComponentFormState = useSelector(
     selectActiveModComponentFormState,
   );
-  const addNewModComponent = useAddNewModComponent(modMetadata);
 
   const { id: modId, name: savedName, version: activatedVersion } = modMetadata;
   const isActive = activeModId === modId;
@@ -112,11 +110,10 @@ const ModListItem: React.FC<ModListItemProps> = ({
           </span>
         )}
         <ModActionMenu
-          modId={modId}
+          modMetadata={modMetadata}
           isActive={isActive}
           labelRoot={name}
           onClearChanges={isUnsavedMod ? undefined : onClearChanges}
-          onAddStarterBrick={addNewModComponent}
           onMakeCopy={onMakeCopy}
           isDirty={isDirty}
         />

--- a/src/pageEditor/modListingPanel/ModListItem.tsx
+++ b/src/pageEditor/modListingPanel/ModListItem.tsx
@@ -46,7 +46,6 @@ export type ModListItemProps = PropsWithChildren<{
   modMetadata: ModMetadata;
   onSave: () => Promise<void>;
   onClearChanges: () => Promise<void>;
-  onDeactivate: () => Promise<void>;
   onMakeCopy: () => Promise<void>;
 }>;
 
@@ -55,7 +54,6 @@ const ModListItem: React.FC<ModListItemProps> = ({
   children,
   onSave,
   onClearChanges,
-  onDeactivate,
   onMakeCopy,
 }) => {
   const dispatch = useDispatch();
@@ -116,11 +114,11 @@ const ModListItem: React.FC<ModListItemProps> = ({
           </span>
         )}
         <ModActionMenu
+          modId={modId}
           isActive={isActive}
           labelRoot={name}
           onSave={onSave}
           onClearChanges={isUnsavedMod ? undefined : onClearChanges}
-          onDeactivate={onDeactivate}
           onAddStarterBrick={addNewModComponent}
           onMakeCopy={onMakeCopy}
           isDirty={isDirty}

--- a/src/pageEditor/modListingPanel/ModListItem.tsx
+++ b/src/pageEditor/modListingPanel/ModListItem.tsx
@@ -97,11 +97,7 @@ const ModListItem: React.FC<ModListItemProps> = ({ modMetadata, children }) => {
             />
           </span>
         )}
-        <ModActionMenu
-          modMetadata={modMetadata}
-          isActive={isActive}
-          labelRoot={name}
-        />
+        <ModActionMenu modMetadata={modMetadata} labelRoot={name} />
       </Accordion.Toggle>
       <Accordion.Collapse eventKey={modId}>
         <>{children}</>

--- a/src/pageEditor/modListingPanel/ModListItem.tsx
+++ b/src/pageEditor/modListingPanel/ModListItem.tsx
@@ -42,14 +42,9 @@ import ModActionMenu from "@/pageEditor/modListingPanel/ModActionMenu";
 
 export type ModListItemProps = PropsWithChildren<{
   modMetadata: ModMetadata;
-  onMakeCopy: () => Promise<void>;
 }>;
 
-const ModListItem: React.FC<ModListItemProps> = ({
-  modMetadata,
-  children,
-  onMakeCopy,
-}) => {
+const ModListItem: React.FC<ModListItemProps> = ({ modMetadata, children }) => {
   const dispatch = useDispatch();
   const activeModId = useSelector(selectActiveModId);
   const expandedModId = useSelector(selectExpandedModId);
@@ -108,7 +103,6 @@ const ModListItem: React.FC<ModListItemProps> = ({
           modMetadata={modMetadata}
           isActive={isActive}
           labelRoot={name}
-          onMakeCopy={onMakeCopy}
           isDirty={isDirty}
         />
       </Accordion.Toggle>

--- a/src/pageEditor/modListingPanel/ModListItem.tsx
+++ b/src/pageEditor/modListingPanel/ModListItem.tsx
@@ -44,7 +44,6 @@ import ModActionMenu from "@/pageEditor/modListingPanel/ModActionMenu";
 
 export type ModListItemProps = PropsWithChildren<{
   modMetadata: ModMetadata;
-  onSave: () => Promise<void>;
   onClearChanges: () => Promise<void>;
   onMakeCopy: () => Promise<void>;
 }>;
@@ -52,7 +51,6 @@ export type ModListItemProps = PropsWithChildren<{
 const ModListItem: React.FC<ModListItemProps> = ({
   modMetadata,
   children,
-  onSave,
   onClearChanges,
   onMakeCopy,
 }) => {
@@ -117,7 +115,6 @@ const ModListItem: React.FC<ModListItemProps> = ({
           modId={modId}
           isActive={isActive}
           labelRoot={name}
-          onSave={onSave}
           onClearChanges={isUnsavedMod ? undefined : onClearChanges}
           onAddStarterBrick={addNewModComponent}
           onMakeCopy={onMakeCopy}

--- a/src/pageEditor/modListingPanel/ModListItem.tsx
+++ b/src/pageEditor/modListingPanel/ModListItem.tsx
@@ -38,19 +38,16 @@ import {
 import * as semver from "semver";
 import { useGetModDefinitionQuery } from "@/data/service/api";
 import { type ModMetadata } from "@/types/modComponentTypes";
-import { isInnerDefinitionRegistryId } from "@/types/helpers";
 import ModActionMenu from "@/pageEditor/modListingPanel/ModActionMenu";
 
 export type ModListItemProps = PropsWithChildren<{
   modMetadata: ModMetadata;
-  onClearChanges: () => Promise<void>;
   onMakeCopy: () => Promise<void>;
 }>;
 
 const ModListItem: React.FC<ModListItemProps> = ({
   modMetadata,
   children,
-  onClearChanges,
   onMakeCopy,
 }) => {
   const dispatch = useDispatch();
@@ -75,8 +72,6 @@ const ModListItem: React.FC<ModListItemProps> = ({
   const dirtyName = useSelector(selectDirtyMetadataForModId(modId))?.name;
   const name = dirtyName ?? savedName ?? "Loading...";
   const isDirty = useSelector(selectModIsDirty(modId));
-
-  const isUnsavedMod = isInnerDefinitionRegistryId(modMetadata.id);
 
   const hasUpdate =
     latestModVersion != null &&
@@ -113,7 +108,6 @@ const ModListItem: React.FC<ModListItemProps> = ({
           modMetadata={modMetadata}
           isActive={isActive}
           labelRoot={name}
-          onClearChanges={isUnsavedMod ? undefined : onClearChanges}
           onMakeCopy={onMakeCopy}
           isDirty={isDirty}
         />

--- a/src/pageEditor/modListingPanel/ModListItem.tsx
+++ b/src/pageEditor/modListingPanel/ModListItem.tsx
@@ -33,7 +33,6 @@ import {
   selectActiveModId,
   selectDirtyMetadataForModId,
   selectExpandedModId,
-  selectModIsDirty,
 } from "@/pageEditor/store/editor/editorSelectors";
 import * as semver from "semver";
 import { useGetModDefinitionQuery } from "@/data/service/api";
@@ -66,7 +65,6 @@ const ModListItem: React.FC<ModListItemProps> = ({ modMetadata, children }) => {
 
   const dirtyName = useSelector(selectDirtyMetadataForModId(modId))?.name;
   const name = dirtyName ?? savedName ?? "Loading...";
-  const isDirty = useSelector(selectModIsDirty(modId));
 
   const hasUpdate =
     latestModVersion != null &&
@@ -103,7 +101,6 @@ const ModListItem: React.FC<ModListItemProps> = ({ modMetadata, children }) => {
           modMetadata={modMetadata}
           isActive={isActive}
           labelRoot={name}
-          isDirty={isDirty}
         />
       </Accordion.Toggle>
       <Accordion.Collapse eventKey={modId}>

--- a/src/pageEditor/modListingPanel/ModListItem.tsx
+++ b/src/pageEditor/modListingPanel/ModListItem.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { type PropsWithChildren } from "react";
+import React from "react";
 import styles from "./Entry.module.scss";
 import { ModHasUpdateIcon } from "@/pageEditor/modListingPanel/ModComponentIcons";
 import { Accordion, ListGroup } from "react-bootstrap";
@@ -39,11 +39,9 @@ import { useGetModDefinitionQuery } from "@/data/service/api";
 import { type ModMetadata } from "@/types/modComponentTypes";
 import ModActionMenu from "@/pageEditor/modListingPanel/ModActionMenu";
 
-export type ModListItemProps = PropsWithChildren<{
+const ModListItem: React.FC<{
   modMetadata: ModMetadata;
-}>;
-
-const ModListItem: React.FC<ModListItemProps> = ({ modMetadata, children }) => {
+}> = ({ modMetadata, children }) => {
   const dispatch = useDispatch();
   const activeModId = useSelector(selectActiveModId);
   const expandedModId = useSelector(selectExpandedModId);


### PR DESCRIPTION
## What does this PR do?

- Part of #9250 (preliminary refactor)
- Removes the majority of props on ModActionItem that are better suited to instead be defined within the scope of the component itself
- No functional changes to the product