### PR TITLE
Add SandboxTimeoutError metadata to error message instead of extra properties

### DIFF
--- a/src/sandbox/postMessage.ts
+++ b/src/sandbox/postMessage.ts
@@ -96,17 +96,6 @@ function removePendingMessageMetadata(id: UUID) {
 
 export class SandboxTimeoutError extends Error {
   override name = "SandboxTimeoutError";
-
-  constructor(
-    message: string,
-    public readonly sandboxMessage: PendingMessageMetadata | undefined,
-    public readonly pendingSandboxMessages: PendingMessageMetadata[],
-    options?: ErrorOptions,
-  ) {
-    super(message, options);
-    this.pendingSandboxMessages = pendingSandboxMessages;
-    this.sandboxMessage = sandboxMessage;
-  }
 }
 
 /** Use the postMessage API but expect a response from the target */
@@ -155,9 +144,7 @@ export default async function postMessage<TReturn extends Payload = Payload>({
     const messageMetadata = removePendingMessageMetadata(messageKey);
     if (isSpecificError(error, TimeoutError)) {
       throw new SandboxTimeoutError(
-        error.message,
-        messageMetadata,
-        [...pendingMessageMetadataMap.values()],
+        `Sandbox message timed out: type=${type}, sent=${messageMetadata?.timestamp}, payloadSize=${messageMetadata?.payloadSize}B, pendingMessageCount=${pendingMessageMetadataMap.size}`,
         {
           cause: error,
         },


### PR DESCRIPTION
## What does this PR do?

- Part of #9150 
- After adding additional error metadata in #9208, we realized that some of the additional metadata we added is getting striped by the Datadog vendor code. To avoid unnecessary complexity and time, I suggest that we add the additional metadata to the error message itself and move on.
- For reviewer reference, I have debugged the issue and confirmed that it is the vendor code that is stripping the additional error properties. We also seem to be unable to call reportError from within this context directly