### PR TITLE
Drop `fit-textarea` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,6 @@
         "export-to-csv": "^1.4.0",
         "filenamify": "^6.0.0",
         "filter-altered-clicks": "^2.1.1",
-        "fit-textarea": "^3.0.0",
         "formik": "^2.4.6",
         "fuse.js": "^7.0.0",
         "handlebars": "^4.7.8",
@@ -16435,10 +16434,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/fit-textarea": {
-      "version": "3.0.0",
-      "integrity": "sha512-27CNxgJ0bL+ATJbLZuOjtUGfAiwa99kT6omFscYTQ9P/u6Lawekkws6lylTu32VgzkQTnTEXbu+bRaHtwoN02Q=="
     },
     "node_modules/flat": {
       "version": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "export-to-csv": "^1.4.0",
     "filenamify": "^6.0.0",
     "filter-altered-clicks": "^2.1.1",
-    "fit-textarea": "^3.0.0",
     "formik": "^2.4.6",
     "fuse.js": "^7.0.0",
     "handlebars": "^4.7.8",

--- a/scripts/__snapshots__/manifest.test.js.snap
+++ b/scripts/__snapshots__/manifest.test.js.snap
@@ -16,12 +16,6 @@ exports[`customizeManifest release builds beta 1`] = `
     "service_worker": "background.worker.js",
     "type": "module",
   },
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "extension@pixiebrix.com",
-      "strict_min_version": "91.0",
-    },
-  },
   "commands": {
     "toggle-quick-bar": {
       "description": "Toggle Quick Bar",
@@ -90,7 +84,7 @@ exports[`customizeManifest release builds beta 1`] = `
     "48": "icons/beta/logo48.png",
   },
   "manifest_version": 3,
-  "minimum_chrome_version": "116.0",
+  "minimum_chrome_version": "123.0",
   "name": "PixieBrix BETA",
   "optional_permissions": [
     "clipboardWrite",
@@ -168,12 +162,6 @@ exports[`customizeManifest release builds stable 1`] = `
     "service_worker": "background.worker.js",
     "type": "module",
   },
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "extension@pixiebrix.com",
-      "strict_min_version": "91.0",
-    },
-  },
   "commands": {
     "toggle-quick-bar": {
       "description": "Toggle Quick Bar",
@@ -242,7 +230,7 @@ exports[`customizeManifest release builds stable 1`] = `
     "48": "icons/logo48.png",
   },
   "manifest_version": 3,
-  "minimum_chrome_version": "116.0",
+  "minimum_chrome_version": "123.0",
   "name": "PixieBrix",
   "optional_permissions": [
     "clipboardWrite",

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -36,6 +36,11 @@ exports[`Storyshots ActivateWizard/OptionsBody Text Field 1`] = `
           onChange={[Function]}
           onKeyDown={[Function]}
           rows="1"
+          style={
+            {
+              "fieldSizing": "content",
+            }
+          }
           value=""
         />
       </div>
@@ -4045,6 +4050,11 @@ exports[`Storyshots Fields/RemoteSchemaObjectField Primitive Value 1`] = `
                     onChange={[Function]}
                     onKeyDown={[Function]}
                     rows="1"
+                    style={
+                      {
+                        "fieldSizing": "content",
+                      }
+                    }
                     value=""
                   />
                 </div>
@@ -4675,6 +4685,11 @@ exports[`Storyshots Fields/SchemaField Normal Text 1`] = `
             onChange={[Function]}
             onKeyDown={[Function]}
             rows="1"
+            style={
+              {
+                "fieldSizing": "content",
+              }
+            }
             value=""
           />
         </div>
@@ -4755,6 +4770,11 @@ exports[`Storyshots Fields/SchemaField Not Required Text 1`] = `
             onChange={[Function]}
             onKeyDown={[Function]}
             rows="1"
+            style={
+              {
+                "fieldSizing": "content",
+              }
+            }
             value=""
           />
         </div>
@@ -5594,6 +5614,11 @@ exports[`Storyshots Fields/SchemaField Text Area 1`] = `
             onChange={[Function]}
             onKeyDown={[Function]}
             rows="1"
+            style={
+              {
+                "fieldSizing": "content",
+              }
+            }
             value=""
           />
         </div>
@@ -5888,6 +5913,11 @@ exports[`Storyshots Forms/Form builder Default 1`] = `
                 onChange={[Function]}
                 onKeyDown={[Function]}
                 rows="1"
+                style={
+                  {
+                    "fieldSizing": "content",
+                  }
+                }
                 value="A form"
               />
             </div>
@@ -5962,6 +5992,11 @@ exports[`Storyshots Forms/Form builder Default 1`] = `
                 onChange={[Function]}
                 onKeyDown={[Function]}
                 rows="1"
+                style={
+                  {
+                    "fieldSizing": "content",
+                  }
+                }
                 value="A form example with _(you can use markdown)_"
               />
             </div>
@@ -6142,6 +6177,11 @@ exports[`Storyshots Forms/Form builder Default 1`] = `
                   onChange={[Function]}
                   onKeyDown={[Function]}
                   rows="1"
+                  style={
+                    {
+                      "fieldSizing": "content",
+                    }
+                  }
                   value="First name"
                 />
               </div>
@@ -6216,6 +6256,11 @@ exports[`Storyshots Forms/Form builder Default 1`] = `
                   onChange={[Function]}
                   onKeyDown={[Function]}
                   rows="1"
+                  style={
+                    {
+                      "fieldSizing": "content",
+                    }
+                  }
                   value="Your first name"
                 />
               </div>
@@ -6435,6 +6480,11 @@ exports[`Storyshots Forms/Form builder Default 1`] = `
                   onChange={[Function]}
                   onKeyDown={[Function]}
                   rows="1"
+                  style={
+                    {
+                      "fieldSizing": "content",
+                    }
+                  }
                   value="Chuck"
                 />
               </div>
@@ -10100,6 +10150,11 @@ exports[`Storyshots Widgets/CssClassWidget Blank Expression 1`] = `
               onChange={[Function]}
               onKeyDown={[Function]}
               rows="1"
+              style={
+                {
+                  "fieldSizing": "content",
+                }
+              }
               value=""
             />
           </div>
@@ -10445,6 +10500,11 @@ exports[`Storyshots Widgets/CssClassWidget Blank Literal 1`] = `
               onChange={[Function]}
               onKeyDown={[Function]}
               rows="1"
+              style={
+                {
+                  "fieldSizing": "content",
+                }
+              }
               value=""
             />
           </div>
@@ -10790,6 +10850,11 @@ exports[`Storyshots Widgets/CssClassWidget Omitted 1`] = `
               onChange={[Function]}
               onKeyDown={[Function]}
               rows="1"
+              style={
+                {
+                  "fieldSizing": "content",
+                }
+              }
               value=""
             />
           </div>
@@ -11133,6 +11198,11 @@ exports[`Storyshots Widgets/CssClassWidget Variable Expression 1`] = `
               onChange={[Function]}
               onKeyDown={[Function]}
               rows="1"
+              style={
+                {
+                  "fieldSizing": "content",
+                }
+              }
               value="@cssClasses"
             />
           </div>
@@ -11759,6 +11829,11 @@ exports[`Storyshots Widgets/TextWidget Empty 1`] = `
     onChange={[Function]}
     onKeyDown={[Function]}
     rows="1"
+    style={
+      {
+        "fieldSizing": "content",
+      }
+    }
     value=""
   />
 </form>
@@ -11777,6 +11852,11 @@ exports[`Storyshots Widgets/TextWidget Long Line 1`] = `
     onChange={[Function]}
     onKeyDown={[Function]}
     rows="1"
+    style={
+      {
+        "fieldSizing": "content",
+      }
+    }
     value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec congue, magna vel viverra rutrum, mi nisi venenatis arcu, at tincidunt orci sapien a ante. Donec ac massa a urna dictum mollis. Ut feugiat accumsan ipsum eget vehicula. Sed ultricies, lorem sit amet aliquam lobortis, sem erat dictum elit, laoreet rhoncus nulla felis id purus. Etiam consequat tincidunt ipsum vitae pulvinar. Nam at turpis elementum, dignissim nulla ut, eleifend est. Nullam rutrum justo quis sapien semper pretium."
   />
 </form>
@@ -11795,6 +11875,11 @@ exports[`Storyshots Widgets/TextWidget Nunjucks Expression 1`] = `
     onChange={[Function]}
     onKeyDown={[Function]}
     rows="1"
+    style={
+      {
+        "fieldSizing": "content",
+      }
+    }
     value="Hello, {{ @input.name }}!"
   />
 </form>
@@ -11813,6 +11898,11 @@ exports[`Storyshots Widgets/TextWidget Nunjucks Tags 1`] = `
     onChange={[Function]}
     onKeyDown={[Function]}
     rows="1"
+    style={
+      {
+        "fieldSizing": "content",
+      }
+    }
     value="My favorite color is {% if @input.day == "Monday" %}red{% else %}blue{% endif %}"
   />
 </form>
@@ -11831,6 +11921,11 @@ exports[`Storyshots Widgets/TextWidget Raw Text 1`] = `
     onChange={[Function]}
     onKeyDown={[Function]}
     rows="1"
+    style={
+      {
+        "fieldSizing": "content",
+      }
+    }
     value="The quick brown fox jumps over the lazy dog"
   />
 </form>
@@ -11849,6 +11944,11 @@ exports[`Storyshots Widgets/TextWidget Single Line 1`] = `
     onChange={[Function]}
     onKeyDown={[Function]}
     rows="1"
+    style={
+      {
+        "fieldSizing": "content",
+      }
+    }
     value="The quick brown fox jumps over the lazy dog"
   />
 </form>

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -36,11 +36,6 @@ exports[`Storyshots ActivateWizard/OptionsBody Text Field 1`] = `
           onChange={[Function]}
           onKeyDown={[Function]}
           rows="1"
-          style={
-            {
-              "fieldSizing": "content",
-            }
-          }
           value=""
         />
       </div>
@@ -4050,11 +4045,6 @@ exports[`Storyshots Fields/RemoteSchemaObjectField Primitive Value 1`] = `
                     onChange={[Function]}
                     onKeyDown={[Function]}
                     rows="1"
-                    style={
-                      {
-                        "fieldSizing": "content",
-                      }
-                    }
                     value=""
                   />
                 </div>
@@ -4685,11 +4675,6 @@ exports[`Storyshots Fields/SchemaField Normal Text 1`] = `
             onChange={[Function]}
             onKeyDown={[Function]}
             rows="1"
-            style={
-              {
-                "fieldSizing": "content",
-              }
-            }
             value=""
           />
         </div>
@@ -4770,11 +4755,6 @@ exports[`Storyshots Fields/SchemaField Not Required Text 1`] = `
             onChange={[Function]}
             onKeyDown={[Function]}
             rows="1"
-            style={
-              {
-                "fieldSizing": "content",
-              }
-            }
             value=""
           />
         </div>
@@ -5614,11 +5594,6 @@ exports[`Storyshots Fields/SchemaField Text Area 1`] = `
             onChange={[Function]}
             onKeyDown={[Function]}
             rows="1"
-            style={
-              {
-                "fieldSizing": "content",
-              }
-            }
             value=""
           />
         </div>
@@ -5913,11 +5888,6 @@ exports[`Storyshots Forms/Form builder Default 1`] = `
                 onChange={[Function]}
                 onKeyDown={[Function]}
                 rows="1"
-                style={
-                  {
-                    "fieldSizing": "content",
-                  }
-                }
                 value="A form"
               />
             </div>
@@ -5992,11 +5962,6 @@ exports[`Storyshots Forms/Form builder Default 1`] = `
                 onChange={[Function]}
                 onKeyDown={[Function]}
                 rows="1"
-                style={
-                  {
-                    "fieldSizing": "content",
-                  }
-                }
                 value="A form example with _(you can use markdown)_"
               />
             </div>
@@ -6177,11 +6142,6 @@ exports[`Storyshots Forms/Form builder Default 1`] = `
                   onChange={[Function]}
                   onKeyDown={[Function]}
                   rows="1"
-                  style={
-                    {
-                      "fieldSizing": "content",
-                    }
-                  }
                   value="First name"
                 />
               </div>
@@ -6256,11 +6216,6 @@ exports[`Storyshots Forms/Form builder Default 1`] = `
                   onChange={[Function]}
                   onKeyDown={[Function]}
                   rows="1"
-                  style={
-                    {
-                      "fieldSizing": "content",
-                    }
-                  }
                   value="Your first name"
                 />
               </div>
@@ -6480,11 +6435,6 @@ exports[`Storyshots Forms/Form builder Default 1`] = `
                   onChange={[Function]}
                   onKeyDown={[Function]}
                   rows="1"
-                  style={
-                    {
-                      "fieldSizing": "content",
-                    }
-                  }
                   value="Chuck"
                 />
               </div>
@@ -10150,11 +10100,6 @@ exports[`Storyshots Widgets/CssClassWidget Blank Expression 1`] = `
               onChange={[Function]}
               onKeyDown={[Function]}
               rows="1"
-              style={
-                {
-                  "fieldSizing": "content",
-                }
-              }
               value=""
             />
           </div>
@@ -10500,11 +10445,6 @@ exports[`Storyshots Widgets/CssClassWidget Blank Literal 1`] = `
               onChange={[Function]}
               onKeyDown={[Function]}
               rows="1"
-              style={
-                {
-                  "fieldSizing": "content",
-                }
-              }
               value=""
             />
           </div>
@@ -10850,11 +10790,6 @@ exports[`Storyshots Widgets/CssClassWidget Omitted 1`] = `
               onChange={[Function]}
               onKeyDown={[Function]}
               rows="1"
-              style={
-                {
-                  "fieldSizing": "content",
-                }
-              }
               value=""
             />
           </div>
@@ -11198,11 +11133,6 @@ exports[`Storyshots Widgets/CssClassWidget Variable Expression 1`] = `
               onChange={[Function]}
               onKeyDown={[Function]}
               rows="1"
-              style={
-                {
-                  "fieldSizing": "content",
-                }
-              }
               value="@cssClasses"
             />
           </div>
@@ -11829,11 +11759,6 @@ exports[`Storyshots Widgets/TextWidget Empty 1`] = `
     onChange={[Function]}
     onKeyDown={[Function]}
     rows="1"
-    style={
-      {
-        "fieldSizing": "content",
-      }
-    }
     value=""
   />
 </form>
@@ -11852,11 +11777,6 @@ exports[`Storyshots Widgets/TextWidget Long Line 1`] = `
     onChange={[Function]}
     onKeyDown={[Function]}
     rows="1"
-    style={
-      {
-        "fieldSizing": "content",
-      }
-    }
     value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec congue, magna vel viverra rutrum, mi nisi venenatis arcu, at tincidunt orci sapien a ante. Donec ac massa a urna dictum mollis. Ut feugiat accumsan ipsum eget vehicula. Sed ultricies, lorem sit amet aliquam lobortis, sem erat dictum elit, laoreet rhoncus nulla felis id purus. Etiam consequat tincidunt ipsum vitae pulvinar. Nam at turpis elementum, dignissim nulla ut, eleifend est. Nullam rutrum justo quis sapien semper pretium."
   />
 </form>
@@ -11875,11 +11795,6 @@ exports[`Storyshots Widgets/TextWidget Nunjucks Expression 1`] = `
     onChange={[Function]}
     onKeyDown={[Function]}
     rows="1"
-    style={
-      {
-        "fieldSizing": "content",
-      }
-    }
     value="Hello, {{ @input.name }}!"
   />
 </form>
@@ -11898,11 +11813,6 @@ exports[`Storyshots Widgets/TextWidget Nunjucks Tags 1`] = `
     onChange={[Function]}
     onKeyDown={[Function]}
     rows="1"
-    style={
-      {
-        "fieldSizing": "content",
-      }
-    }
     value="My favorite color is {% if @input.day == "Monday" %}red{% else %}blue{% endif %}"
   />
 </form>
@@ -11921,11 +11831,6 @@ exports[`Storyshots Widgets/TextWidget Raw Text 1`] = `
     onChange={[Function]}
     onKeyDown={[Function]}
     rows="1"
-    style={
-      {
-        "fieldSizing": "content",
-      }
-    }
     value="The quick brown fox jumps over the lazy dog"
   />
 </form>
@@ -11944,11 +11849,6 @@ exports[`Storyshots Widgets/TextWidget Single Line 1`] = `
     onChange={[Function]}
     onKeyDown={[Function]}
     rows="1"
-    style={
-      {
-        "fieldSizing": "content",
-      }
-    }
     value="The quick brown fox jumps over the lazy dog"
   />
 </form>

--- a/src/components/fields/schemaFields/widgets/TextWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/TextWidget.tsx
@@ -28,7 +28,6 @@ import { type SchemaFieldProps } from "@/components/fields/schemaFields/propType
 import { useField } from "formik";
 // eslint-disable-next-line no-restricted-imports -- TODO: Fix over time
 import { Form, type FormControlProps } from "react-bootstrap";
-import fitTextarea from "fit-textarea";
 import { trim } from "lodash";
 import FieldRuntimeContext from "@/components/fields/schemaFields/FieldRuntimeContext";
 import { isMustacheOnly } from "@/components/fields/fieldUtils";
@@ -124,12 +123,6 @@ const TextWidget: React.VFC<SchemaFieldProps & FormControlProps> = ({
   const defaultTextAreaRef = useRef<HTMLTextAreaElement>();
   const textAreaRef: MutableRefObject<HTMLTextAreaElement> =
     (inputRef as MutableRefObject<HTMLTextAreaElement>) ?? defaultTextAreaRef;
-
-  useEffect(() => {
-    if (textAreaRef.current) {
-      fitTextarea.watch(textAreaRef.current);
-    }
-  }, [textAreaRef]);
 
   useEffect(() => {
     if (focusInput) {
@@ -243,6 +236,8 @@ const TextWidget: React.VFC<SchemaFieldProps & FormControlProps> = ({
     <Form.Control
       as="textarea"
       rows="1"
+      // Resize the textarea to fit the new value
+      style={{fieldSizing: "content"}}
       {...restInputProps}
       {...formControlProps}
       value={fieldInputValue}

--- a/src/components/fields/schemaFields/widgets/TextWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/TextWidget.tsx
@@ -236,8 +236,6 @@ const TextWidget: React.VFC<SchemaFieldProps & FormControlProps> = ({
     <Form.Control
       as="textarea"
       rows="1"
-      // Resize the textarea to fit the new value
-      style={{fieldSizing: "content"}}
       {...restInputProps}
       {...formControlProps}
       value={fieldInputValue}

--- a/src/components/fields/schemaFields/widgets/varPopup/VarPopup.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarPopup.tsx
@@ -102,10 +102,6 @@ const VarPopup: React.FunctionComponent<VarPopupProps> = ({
           setValue(newTemplate);
 
           textElement.setSelectionRange(newCursorPosition, newCursorPosition);
-
-          // Resize the textarea to fit the new value
-          // @ts-expect-error Missing from TS library, can be removed once they add it
-          textElement.style.fieldSizing = "content";
           break;
         }
 

--- a/src/components/fields/schemaFields/widgets/varPopup/VarPopup.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarPopup.tsx
@@ -22,7 +22,6 @@ import {
   replaceLikelyVariable,
 } from "./likelyVariableUtils";
 import VarMenu from "./VarMenu";
-import fitTextarea from "fit-textarea";
 import useAttachPopup from "@/components/fields/schemaFields/widgets/varPopup/useAttachPopup";
 import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
@@ -105,13 +104,8 @@ const VarPopup: React.FunctionComponent<VarPopupProps> = ({
           textElement.setSelectionRange(newCursorPosition, newCursorPosition);
 
           // Resize the textarea to fit the new value
-          setTimeout(() => {
-            if (textElement == null) {
-              return;
-            }
-
-            fitTextarea(textElement);
-          }, 100);
+          // @ts-expect-error Missing from TS library, can be removed once they add it
+          textElement.style.fieldSizing = "content";
           break;
         }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,13 +5,7 @@
   "short_name": "PixieBrix",
   "description": "Customize, extend, and integrate your favorite SaaS apps without writing a line of code!",
   "homepage_url": "https://www.pixiebrix.com",
-  "minimum_chrome_version": "116.0",
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "extension@pixiebrix.com",
-      "strict_min_version": "91.0"
-    }
-  },
+  "minimum_chrome_version": "123.0",
   "icons": {
     "16": "icons/logo16.png",
     "32": "icons/logo32.png",

--- a/src/utils/global.scss
+++ b/src/utils/global.scss
@@ -24,3 +24,11 @@ html {
   /* https://github.com/pixiebrix/pixiebrix-extension/issues/3597 */
   overflow-wrap: anywhere;
 }
+
+// Automatically grow textareas to fit their content
+textarea {
+  field-sizing: content;
+
+  // This keeps the textarea from growing horizontally
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
## What does this PR do?

Small PR, removes my own dependency for performance

- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/8972

## Notes

- This bumps the minimum Chrome version to v123 (the latest is v130 now)
- Change untested

Feel free to close or postpone if it's not time yet.