### PR TITLE
Fix type error when pinning 2.1.4 extension to app

### DIFF
--- a/src/utils/idbUtils.ts
+++ b/src/utils/idbUtils.ts
@@ -259,6 +259,6 @@ export const withIdbErrorHandling =
 
       throw error;
     } finally {
-      (db as IDBDatabase | null)?.close();
+      (db as IDBPDatabase<DBType> | null)?.close();
     }
   };


### PR DESCRIPTION
## What does this PR do?

- Fixes a minor type error preventing pinning the extension version in app: https://github.com/pixiebrix/pixiebrix-app/pull/5846
- Confirmed this fixes the type issue in app by pinning the version in this branch using `❯ npm run update-extension -- pin-2.1.4`

## Discussion

- Didn't investigate too deeply as to why this type error didn't pop up earlier in extension, likely due to slight tsconfig differences.

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
