### PR TITLE
Group/organize editor slice reducer methods

### DIFF
--- a/src/pageEditor/modals/addBrickModal/AddBrickModal.test.tsx
+++ b/src/pageEditor/modals/addBrickModal/AddBrickModal.test.tsx
@@ -57,7 +57,7 @@ describe("AddBrickModal", () => {
         dispatch(actions.addModComponentFormState(formState));
         dispatch(actions.setActiveModComponentId(formState.uuid));
         dispatch(
-          actions.showAddBlockModal({
+          actions.showAddBrickModal({
             path: "",
             flavor: PipelineFlavor.AllBricks,
             index: 0,
@@ -89,7 +89,7 @@ describe("AddBrickModal", () => {
         dispatch(actions.addModComponentFormState(formState));
         dispatch(actions.setActiveModComponentId(formState.uuid));
         dispatch(
-          actions.showAddBlockModal({
+          actions.showAddBrickModal({
             path: "",
             flavor: PipelineFlavor.AllBricks,
             index: 0,
@@ -115,7 +115,7 @@ describe("AddBrickModal", () => {
         dispatch(actions.addModComponentFormState(formState));
         dispatch(actions.setActiveModComponentId(formState.uuid));
         dispatch(
-          actions.showAddBlockModal({
+          actions.showAddBrickModal({
             path: PIPELINE_BRICKS_FIELD_NAME,
             flavor: PipelineFlavor.AllBricks,
             index: 0,

--- a/src/pageEditor/tabs/editTab/EditTab.tsx
+++ b/src/pageEditor/tabs/editTab/EditTab.tsx
@@ -62,15 +62,15 @@ const EditTab: React.FC<{
 
   const isDataPanelExpanded = useSelector(selectIsDataPanelExpanded);
 
-  function copyBlock(instanceId: UUID) {
+  function copyBrick(instanceId: UUID) {
     // eslint-disable-next-line security/detect-object-injection -- UUID
-    const blockToCopy = pipelineMap[instanceId]?.blockConfig;
-    if (blockToCopy) {
-      dispatch(actions.copyBlockConfig(blockToCopy));
+    const brickToCopy = pipelineMap[instanceId]?.blockConfig;
+    if (brickToCopy) {
+      dispatch(actions.copyBrickConfig(brickToCopy));
     }
   }
 
-  function removeBlock(nodeIdToRemove: UUID) {
+  function removeBrick(nodeIdToRemove: UUID) {
     dispatch(actions.removeNode(nodeIdToRemove));
   }
 
@@ -95,7 +95,7 @@ const EditTab: React.FC<{
                   activeNodeId,
                   "activeNodeId is required to copy a node",
                 );
-                copyBlock(activeNodeId);
+                copyBrick(activeNodeId);
               }}
               tooltipText="Copy Brick"
               buttonClassName={styles.copyButton}
@@ -109,7 +109,7 @@ const EditTab: React.FC<{
                   activeNodeId,
                   "activeNodeId is required to remove a node",
                 );
-                removeBlock(activeNodeId);
+                removeBrick(activeNodeId);
               }}
               tooltipText="Remove Brick"
               buttonClassName={styles.removeButton}
@@ -151,7 +151,7 @@ const EditTab: React.FC<{
             type="button"
             onClick={() => {
               dispatch(
-                actions.setDataSectionExpanded({
+                actions.setDataPanelExpanded({
                   isExpanded: !isDataPanelExpanded,
                 }),
               );

--- a/src/pageEditor/tabs/editTab/editorNodeConfigPanel/CommentsPreview.test.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeConfigPanel/CommentsPreview.test.tsx
@@ -74,7 +74,7 @@ describe("CommentsPreview", () => {
     const { getReduxStore } = renderCommentsPreview(expectedComments);
     const store = getReduxStore();
 
-    store.dispatch(actions.setDataSectionExpanded({ isExpanded: false }));
+    store.dispatch(actions.setDataPanelExpanded({ isExpanded: false }));
 
     expect(getDataPanelExtended(store.getState())).toBeFalse();
 

--- a/src/pageEditor/tabs/editTab/editorNodeConfigPanel/CommentsPreview.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeConfigPanel/CommentsPreview.tsx
@@ -34,7 +34,7 @@ const CommentsPreview: React.FunctionComponent<{
   const handleClick = () => {
     selectTab(DataPanelTabKey.Comments);
     dispatch(
-      actions.setDataSectionExpanded({
+      actions.setDataPanelExpanded({
         isExpanded: true,
       }),
     );

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
@@ -387,7 +387,7 @@ const usePipelineNodes = (): {
         tooltipText: "Add a brick",
         onClick() {
           dispatch(
-            actions.showAddBlockModal({
+            actions.showAddBrickModal({
               path: pipelinePath,
               flavor,
               index: index + 1,
@@ -499,7 +499,7 @@ const usePipelineNodes = (): {
             tooltipText: "Add a brick",
             onClick() {
               dispatch(
-                actions.showAddBlockModal({
+                actions.showAddBrickModal({
                   path: fullSubPath,
                   flavor,
                   index: 0,
@@ -702,7 +702,7 @@ const usePipelineNodes = (): {
         tooltipText: "Add a brick",
         onClick() {
           dispatch(
-            actions.showAddBlockModal({
+            actions.showAddBrickModal({
               path: PIPELINE_BRICKS_FIELD_NAME,
               flavor: pipelineFlavor,
               index: 0,


### PR DESCRIPTION
## What does this PR do?

- Groups/organizes editor slice reducer action methods. No functional changes
- Baby steps to refactoring/re-architecting Page Editor state. The goal of this PR is to make it easier to see which reducer methods are interrelated. 
- Cleans up some legacy name usage

## Discussion

- The editor reducer methods are only part of the story -- they're the base/primitive operations. The hooks/thunks have to perform complex sequences of reducer action calls, e.g.: see https://github.com/pixiebrix/pixiebrix-extension/blob/abf016ed45542c3e43951ae99824e966174818a1/src/pageEditor/hooks/useCreateModFromUnsavedMod.ts#L82-L82. Some of that complexity is essential, some accidental

## Future Work

I'll key these up with @grahamlangford as we talk about evolving the Page Editor tech debt

- Improve/clarify method naming, e.g.: `markClean`
- Simplifying assumptions to Page Editor
  - Drop affordance for editing starter brick definition packages (Just show as locked): https://github.com/pixiebrix/pixiebrix-extension/pull/9294
  - Drop affordance to attempt to share inline starter brick definitions across mod components. (A consideration, though, is how the runtime de-dupes starter bricks. If the starter brick is identical, only 1 starter brick instance is added to the page, and there may be conflicts on which mod component runs)
- Data Architecture improvements
  - Drop mod-level data from mod component form states (mod option definitions, mod option values)
- Runtime Improvements
  - Replace the entire mod on the page instead of mod components that have been clicked into
 
For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
