### PR TITLE
Fix text highlighting bug in IsolatedComponents starting in Chrome 131

### DIFF
--- a/src/components/IsolatedComponent.scss
+++ b/src/components/IsolatedComponent.scss
@@ -15,5 +15,10 @@ body {
 
 // Don't inherit the selection color
 :host::selection {
-  background: initial;
+  // Needs to be revert instead of initial because, per MDN,
+  // "On inherited properties, the initial value may be unexpected"
+  // See https://developer.mozilla.org/en-US/docs/Web/CSS/initial
+  // See https://chromestatus.com/feature/5090853643354112
+  // See https://developer.mozilla.org/en-US/docs/Web/CSS/revert
+  background: revert;
 }


### PR DESCRIPTION
## What does this PR do?

- Fixes bug in our IsolatedComponents css caused by a change in how Chrome handles CSS Highlight Inheritance
- See https://chromestatus.com/feature/5090853643354112 for further details

## Demo

https://www.loom.com/share/576b7a8eee5341ec961e3a37b4f06194?sid=baf1edb4-8308-4309-be66-1b9ee4513591

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
