### PR TITLE
#9323: consolidate mod component form state editor slice reducers

### DIFF
--- a/src/components/form/ConnectedFieldTemplate.test.tsx
+++ b/src/components/form/ConnectedFieldTemplate.test.tsx
@@ -114,7 +114,7 @@ describe("ConnectedFieldTemplate", () => {
         {
           initialValues: formState,
           setupRedux(dispatch) {
-            dispatch(actions.selectActivatedModComponentFormState(formState));
+            dispatch(actions.addModComponentFormState(formState));
             dispatch(
               analysisSlice.actions.finishAnalysis({
                 modComponentId: formState.uuid,
@@ -177,7 +177,7 @@ describe("ConnectedFieldTemplate", () => {
             },
           },
           setupRedux(dispatch) {
-            dispatch(actions.selectActivatedModComponentFormState(formState));
+            dispatch(actions.addModComponentFormState(formState));
             dispatch(
               analysisSlice.actions.finishAnalysis({
                 modComponentId: formState.uuid,
@@ -236,7 +236,7 @@ describe("ConnectedFieldTemplate", () => {
         {
           initialValues: formState,
           setupRedux(dispatch) {
-            dispatch(actions.selectActivatedModComponentFormState(formState));
+            dispatch(actions.addModComponentFormState(formState));
             dispatch(
               analysisSlice.actions.finishAnalysis({
                 modComponentId: formState.uuid,
@@ -335,7 +335,7 @@ describe("ConnectedFieldTemplate", () => {
         {
           initialValues: formState,
           setupRedux(dispatch) {
-            dispatch(actions.selectActivatedModComponentFormState(formState));
+            dispatch(actions.addModComponentFormState(formState));
             dispatch(
               analysisSlice.actions.finishAnalysis({
                 modComponentId: formState.uuid,

--- a/src/pageEditor/hooks/useCheckModStarterBrickInvariants.test.ts
+++ b/src/pageEditor/hooks/useCheckModStarterBrickInvariants.test.ts
@@ -219,10 +219,7 @@ describe("useCheckModStarterBrickInvariants", () => {
           }
 
           for (const formState of activatedFormStates) {
-            dispatch(
-              editorActions.selectActivatedModComponentFormState(formState),
-            );
-            dispatch(editorActions.syncModComponentFormState(formState));
+            dispatch(editorActions.addModComponentFormState(formState));
           }
 
           for (const formState of newFormStates) {

--- a/src/pageEditor/hooks/useClearModComponentChanges.ts
+++ b/src/pageEditor/hooks/useClearModComponentChanges.ts
@@ -27,6 +27,7 @@ import { Events } from "@/telemetry/events";
 import { type UUID } from "@/types/stringTypes";
 
 import { selectActivatedModComponents } from "@/store/modComponents/modComponentSelectors";
+import { clearModComponentTraces } from "@/telemetry/trace";
 
 type Config = {
   modComponentId: UUID;
@@ -65,17 +66,23 @@ function useClearModComponentChanges(): (
         modComponentId,
       });
 
+      void clearModComponentTraces(modComponentId);
+
       try {
         const activatedModComponent = activatedModComponents.find(
           (x) => x.id === modComponentId,
         );
         if (activatedModComponent == null) {
-          dispatch(actions.removeModComponentFormState(modComponentId));
+          dispatch(actions.markModComponentFormStateAsDeleted(modComponentId));
         } else {
-          const formState = await modComponentToFormState(
-            activatedModComponent,
+          dispatch(
+            actions.setModComponentFormState({
+              modComponentFormState: await modComponentToFormState(
+                activatedModComponent,
+              ),
+              dirty: false,
+            }),
           );
-          dispatch(actions.resetActivatedModComponentFormState(formState));
         }
       } catch (error) {
         reportError(error);

--- a/src/pageEditor/hooks/useCreateModFromUnsavedMod.ts
+++ b/src/pageEditor/hooks/useCreateModFromUnsavedMod.ts
@@ -127,9 +127,6 @@ function useCreateModFromUnsavedMod(): UseCreateModFromUnsavedModReturn {
             }
 
             dispatch(
-              editorActions.syncModComponentFormState(newComponentFormState),
-            );
-            dispatch(
               modComponentActions.saveModComponent({
                 modComponent: {
                   ...newModComponent,
@@ -137,7 +134,19 @@ function useCreateModFromUnsavedMod(): UseCreateModFromUnsavedModReturn {
                 },
               }),
             );
-            dispatch(editorActions.markClean(newComponentFormState.uuid));
+
+            // TODO: remove use of setModComponentFormState: https://github.com/pixiebrix/pixiebrix-extension/issues/9323
+            dispatch(
+              editorActions.setModComponentFormState({
+                modComponentFormState: newComponentFormState,
+                dirty: false,
+              }),
+            );
+            dispatch(
+              editorActions.markModComponentFormStateAsClean(
+                newComponentFormState.uuid,
+              ),
+            );
           }
 
           const newModId = newModDefinition.metadata.id;

--- a/src/pageEditor/hooks/useDeleteDraftModComponent.test.ts
+++ b/src/pageEditor/hooks/useDeleteDraftModComponent.test.ts
@@ -45,7 +45,7 @@ test("useDeleteModComponent", async () => {
   const { dispatch } = getReduxStore();
 
   expect(dispatch).toHaveBeenCalledWith(
-    editorActions.removeModComponentFormState(modComponentId),
+    editorActions.markModComponentFormStateAsDeleted(modComponentId),
   );
 
   expect(removeDraftModComponents).toHaveBeenCalledWith(

--- a/src/pageEditor/hooks/useDeleteDraftModComponent.tsx
+++ b/src/pageEditor/hooks/useDeleteDraftModComponent.tsx
@@ -89,7 +89,9 @@ function useDeleteDraftModComponent(): (
 
       try {
         // Remove the mod component form state from the Page Editor
-        dispatch(editorActions.removeModComponentFormState(modComponentId));
+        dispatch(
+          editorActions.markModComponentFormStateAsDeleted(modComponentId),
+        );
 
         // Stop running the draft on the page
         removeDraftModComponents(allFramesInInspectedTab, modComponentId);

--- a/src/pageEditor/hooks/useUpsertModComponentFormState.ts
+++ b/src/pageEditor/hooks/useUpsertModComponentFormState.ts
@@ -35,7 +35,7 @@ import { adapterForComponent } from "@/pageEditor/starterBricks/adapter";
 import { nowTimestamp } from "@/utils/timeUtils";
 
 const { saveModComponent } = modComponentSlice.actions;
-const { markClean } = editorSlice.actions;
+const { markModComponentFormStateAsClean } = editorSlice.actions;
 
 function selectErrorMessage(error: unknown): string {
   // FIXME: should this logic be in getErrorMessage?
@@ -149,7 +149,7 @@ function useUpsertModComponentFormState(): SaveCallback {
           }),
         );
 
-        dispatch(markClean(modComponentFormState.uuid));
+        dispatch(markModComponentFormStateAsClean(modComponentFormState.uuid));
       } catch (error) {
         return onStepError(error, "saving mod");
       }

--- a/src/pageEditor/modListingPanel/ActivatedModComponentListItem.tsx
+++ b/src/pageEditor/modListingPanel/ActivatedModComponentListItem.tsx
@@ -88,12 +88,13 @@ const ActivatedModComponentListItem: React.FunctionComponent<{
           modComponentId: modComponent.id,
         });
 
-        const modComponentFormState =
-          await modComponentToFormState(modComponent);
-
         dispatch(
-          actions.selectActivatedModComponentFormState(modComponentFormState),
+          actions.addModComponentFormState({
+            modComponentFormState: await modComponentToFormState(modComponent),
+            dirty: false,
+          }),
         );
+
         dispatch(actions.checkActiveModComponentAvailability());
 
         if (type === StarterBrickTypes.SIDEBAR_PANEL) {

--- a/src/pageEditor/modListingPanel/DraftModComponentListItem.test.tsx
+++ b/src/pageEditor/modListingPanel/DraftModComponentListItem.test.tsx
@@ -64,7 +64,9 @@ describe("DraftModComponentListItem", () => {
             // Add new element to deactivate the previous one
             dispatch(editorActions.addModComponentFormState(formState));
             // Remove the active element and stay with one inactive item
-            dispatch(editorActions.removeModComponentFormState(formState.uuid));
+            dispatch(
+              editorActions.markModComponentFormStateAsDeleted(formState.uuid),
+            );
           },
         },
       ).asFragment(),

--- a/src/pageEditor/modListingPanel/modals/MoveOrCopyToModModal.tsx
+++ b/src/pageEditor/modListingPanel/modals/MoveOrCopyToModModal.tsx
@@ -96,7 +96,7 @@ const MoveOrCopyToModModal: React.FC = () => {
     if (!isCopyAction) {
       // Remove the original mod component to complete the move action
       dispatch(
-        editorActions.removeModComponentFormState(
+        editorActions.markModComponentFormStateAsDeleted(
           activeModComponentFormState.uuid,
         ),
       );

--- a/src/pageEditor/panes/ModComponentEditorPane.tsx
+++ b/src/pageEditor/panes/ModComponentEditorPane.tsx
@@ -50,7 +50,12 @@ const EditorPaneContent: React.VoidFunctionComponent<{
   // XXX: anti-pattern: callback to update the redux store based on the formik state
   const syncReduxState = useDebouncedCallback(
     (values: ModComponentFormState) => {
-      dispatch(editorActions.syncModComponentFormState(values));
+      dispatch(
+        editorActions.setModComponentFormState({
+          modComponentFormState: values,
+          dirty: true,
+        }),
+      );
       dispatch(actions.checkActiveModComponentAvailability());
     },
     REDUX_SYNC_WAIT_MILLIS,

--- a/src/pageEditor/store/analysisManager.ts
+++ b/src/pageEditor/store/analysisManager.ts
@@ -152,12 +152,12 @@ pageEditorAnalysisManager.registerAnalysisEffect(
 
 pageEditorAnalysisManager.registerAnalysisEffect(() => new SelectorAnalysis(), {
   // Slow Selector Analysis currently checks the starter brick definition
-  matcher: isAnyOf(editorActions.syncModComponentFormState),
+  matcher: isAnyOf(editorActions.setModComponentFormState),
 });
 
 pageEditorAnalysisManager.registerAnalysisEffect(() => new TemplateAnalysis(), {
   matcher: isAnyOf(
-    editorActions.syncModComponentFormState,
+    editorActions.setModComponentFormState,
     ...nodeListMutationActions,
   ),
 });
@@ -166,7 +166,7 @@ pageEditorAnalysisManager.registerAnalysisEffect(
   () => new PageStateAnalysis(),
   {
     matcher: isAnyOf(
-      editorActions.syncModComponentFormState,
+      editorActions.setModComponentFormState,
       ...nodeListMutationActions,
     ),
   },
@@ -176,7 +176,7 @@ pageEditorAnalysisManager.registerAnalysisEffect(
   () => new ModComponentUrlPatternAnalysis(),
   {
     matcher: isAnyOf(
-      editorActions.syncModComponentFormState,
+      editorActions.setModComponentFormState,
       ...nodeListMutationActions,
     ),
   },
@@ -186,7 +186,7 @@ pageEditorAnalysisManager.registerAnalysisEffect(
   () => new RequestPermissionAnalysis(),
   {
     matcher: isAnyOf(
-      editorActions.syncModComponentFormState,
+      editorActions.setModComponentFormState,
       ...nodeListMutationActions,
     ),
   },
@@ -194,7 +194,7 @@ pageEditorAnalysisManager.registerAnalysisEffect(
 
 pageEditorAnalysisManager.registerAnalysisEffect(() => new RegexAnalysis(), {
   matcher: isAnyOf(
-    editorActions.syncModComponentFormState,
+    editorActions.setModComponentFormState,
     ...nodeListMutationActions,
   ),
 });
@@ -203,7 +203,7 @@ pageEditorAnalysisManager.registerAnalysisEffect(
   () => new HttpRequestAnalysis(),
   {
     matcher: isAnyOf(
-      editorActions.syncModComponentFormState,
+      editorActions.setModComponentFormState,
       ...nodeListMutationActions,
     ),
   },
@@ -242,7 +242,7 @@ pageEditorAnalysisManager.registerAnalysisEffect(
   () => new ConditionAnalysis(),
   {
     matcher: isAnyOf(
-      editorActions.syncModComponentFormState,
+      editorActions.setModComponentFormState,
       ...nodeListMutationActions,
     ),
   },
@@ -253,7 +253,7 @@ pageEditorAnalysisManager.registerAnalysisEffect(
   () => new OutputKeyAnalysis(),
   {
     matcher: isAnyOf(
-      editorActions.syncModComponentFormState,
+      editorActions.setModComponentFormState,
       ...nodeListMutationActions,
     ),
   },
@@ -269,7 +269,7 @@ pageEditorAnalysisManager.registerAnalysisEffect(
     matcher: isAnyOf(
       // Must run whenever the active mod component changes in order to see changes from other mod components.
       editorActions.setActiveModComponentId,
-      editorActions.syncModComponentFormState,
+      editorActions.setModComponentFormState,
       ...nodeListMutationActions,
     ),
   },
@@ -293,7 +293,7 @@ pageEditorAnalysisManager.registerAnalysisEffect(
       editorActions.showVariablePopover,
       // Include setActiveModComponentId so that variable analysis is ready when user first types
       editorActions.setActiveModComponentId,
-      editorActions.syncModComponentFormState,
+      editorActions.setModComponentFormState,
       runtimeActions.setModComponentTrace,
       ...nodeListMutationActions,
     ),

--- a/src/pageEditor/store/editor/editorSlice.test.ts
+++ b/src/pageEditor/store/editor/editorSlice.test.ts
@@ -82,7 +82,7 @@ describe("DataPanel state", () => {
   beforeEach(() => {
     state = editorSlice.reducer(
       initialState,
-      actions.selectActivatedModComponentFormState(formStateFactory()),
+      actions.addModComponentFormState(formStateFactory()),
     );
   });
 
@@ -153,7 +153,7 @@ describe("Add/Remove Bricks", () => {
 
     editor = editorSlice.reducer(
       initialState,
-      actions.selectActivatedModComponentFormState(source),
+      actions.addModComponentFormState(source),
     );
   });
 
@@ -335,7 +335,7 @@ describe("Mod Options editing", () => {
       // Need the object to be extensible
       ...editorSlice.reducer(
         stateAfterAddition,
-        actions.removeModComponentFormState(additionalComponentId),
+        actions.markModComponentFormStateAsDeleted(additionalComponentId),
       ),
     };
 

--- a/src/pageEditor/store/editor/editorSlice.ts
+++ b/src/pageEditor/store/editor/editorSlice.ts
@@ -20,7 +20,6 @@ import {
   createSlice,
   type PayloadAction,
 } from "@reduxjs/toolkit";
-import { clearModComponentTraces } from "@/telemetry/trace";
 import { FOUNDATION_NODE_ID } from "@/pageEditor/store/editor/uiState";
 import { type BrickConfig } from "@/bricks/types";
 import {
@@ -51,7 +50,7 @@ import {
   setActiveModComponentId,
   editModMetadata,
   editModOptionsDefinitions,
-  removeModComponentFormState,
+  markModComponentFormStateAsDeleted,
   removeModData,
   setActiveModId,
   setActiveNodeId,
@@ -505,7 +504,7 @@ export const editorSlice = createSlice({
         .map((x) => x.uuid);
 
       for (const modComponentId of modComponentIds) {
-        removeModComponentFormState(state, modComponentId);
+        markModComponentFormStateAsDeleted(state, modComponentId);
       }
 
       // Call last because removeModComponentFormState sets entries on deletedModComponentFormStatesByModId
@@ -516,126 +515,111 @@ export const editorSlice = createSlice({
     /// MOD COMPONENT OPERATIONS
     ///
 
-    // XXX: reconcile with selectActivatedModComponentFormState
+    /**
+     * Add a new form state corresponding to a draft mod component that does not have an associated activated
+     * mod instance. Sets as selected.
+     *
+     * Sets the form state as dirty by default.
+     */
     addModComponentFormState(
       state,
-      action: PayloadAction<ModComponentFormState>,
+      // Expose simpler payload type for most common use cases
+      action: PayloadAction<
+        | ModComponentFormState
+        | { modComponentFormState: ModComponentFormState; dirty: boolean }
+      >,
     ) {
       // Ensure the form state is writeable for normalization
-      const modComponentFormState = cloneDeep(action.payload);
+      const { modComponentFormState, dirty } = cloneDeep(
+        "modComponentFormState" in action.payload
+          ? action.payload
+          : // Default dirty to true
+            { modComponentFormState: action.payload, dirty: true },
+      );
+
+      const modComponentId = modComponentFormState.uuid;
+
+      if (state.modComponentFormStates.some((x) => x.uuid === modComponentId)) {
+        throw new Error("Form state already exists for mod component");
+      }
 
       const modId = modComponentFormState.modMetadata.id;
 
       // Find existing activated mod components with the same mod id
-      const existingModComponents = state.modComponentFormStates.filter(
+      const existingModFormStates = state.modComponentFormStates.filter(
         (formState) => formState.modMetadata.id === modId,
       );
 
       // If there are existing components, collect their option arguments, and assign.
       // NOTE: we don't need to have logic here for optionsDefinition and variablesDefinition because those
       // are stored/owned at the mod-level in the Page Editor
-      if (existingModComponents.length > 0) {
+      if (existingModFormStates.length > 0) {
         modComponentFormState.optionsArgs = collectModOptions(
-          existingModComponents,
+          existingModFormStates,
         );
       }
 
-      state.modComponentFormStates.push(
-        modComponentFormState as Draft<ModComponentFormState>,
-      );
-      state.dirty[modComponentFormState.uuid] = true;
+      state.modComponentFormStates.push(modComponentFormState);
+      state.dirty[modComponentId] = dirty;
 
       setActiveModComponentId(state, modComponentFormState);
     },
 
-    // XXX: reconcile with addModComponentFormState
-    selectActivatedModComponentFormState(
+    /**
+     * Set/replace an existing draft form state. For use in:
+     * - Synchronizing the Formik state with the Redux state
+     * - Clearing/reverting changes to a form state
+     * - Jest tests that don't render a configuration editor UI
+     *
+     * @throws Error if a form state with a matching id does not exist
+     */
+    setModComponentFormState(
       state,
-      action: PayloadAction<ModComponentFormState>,
+      action: PayloadAction<{
+        modComponentFormState: ModComponentFormState;
+        dirty: boolean;
+      }>,
     ) {
-      const modComponentFormState =
-        action.payload as Draft<ModComponentFormState>;
+      const { modComponentFormState, dirty } = action.payload;
+      const { uuid: modComponentId } = modComponentFormState;
+
       const index = state.modComponentFormStates.findIndex(
-        (x) => x.uuid === modComponentFormState.uuid,
+        (x) => x.uuid === modComponentId,
       );
-      if (index >= 0) {
-        state.modComponentFormStates[index] = modComponentFormState;
-      } else {
-        state.modComponentFormStates.push(modComponentFormState);
+      if (index < 0) {
+        throw new Error(`Unknown draft mod component: ${modComponentId}`);
       }
 
-      setActiveModComponentId(state, modComponentFormState);
-    },
-
-    resetActivatedModComponentFormState(
-      state,
-      actions: PayloadAction<ModComponentFormState>,
-    ) {
-      const modComponentFormState =
-        actions.payload as Draft<ModComponentFormState>;
-      const index = state.modComponentFormStates.findIndex(
-        (x) => x.uuid === modComponentFormState.uuid,
-      );
-      if (index >= 0) {
-        state.modComponentFormStates[index] = modComponentFormState;
-      } else {
-        state.modComponentFormStates.push(modComponentFormState);
-      }
-
-      state.dirty[modComponentFormState.uuid] = false;
-      state.error = null;
-      state.beta = false;
-      state.selectionSeq++;
-
-      // Make sure we're not keeping any private data around from Page Editor sessions
-      void clearModComponentTraces(modComponentFormState.uuid);
+      state.modComponentFormStates[index] = modComponentFormState;
+      state.dirty[modComponentId] = dirty;
 
       syncBrickConfigurationUIStates(state, modComponentFormState);
     },
 
-    markClean(state, action: PayloadAction<UUID>) {
+    /**
+     * Marks the form state as clean, i.e., it has no unsaved changes.
+     */
+    markModComponentFormStateAsClean(state, action: PayloadAction<UUID>) {
+      const modComponentId = action.payload;
+
       const modComponentFormState = state.modComponentFormStates.find(
-        (x) => action.payload === x.uuid,
+        (x) => modComponentId === x.uuid,
       );
 
       assertNotNullish(
         modComponentFormState,
-        `Unknown draft mod component: ${action.payload}`,
+        `Unknown draft mod component: ${modComponentId}`,
       );
 
       modComponentFormState.installed = true;
-      state.dirty[modComponentFormState.uuid] = false;
-      // Force a reload so the _new flags are correct on the readers
-      state.selectionSeq++;
+      state.dirty[modComponentId] = false;
     },
 
     /**
-     * Sync the formik mod component form state in the Page Editor with redux.
+     * Mark the form state as deleted from the mod.
      */
-    syncModComponentFormState(
-      state,
-      action: PayloadAction<ModComponentFormState>,
-    ) {
-      const modComponentFormState = action.payload;
-      const index = state.modComponentFormStates.findIndex(
-        (x) => x.uuid === modComponentFormState.uuid,
-      );
-      if (index < 0) {
-        throw new Error(
-          `Unknown draft mod component: ${modComponentFormState.uuid}`,
-        );
-      }
-
-      state.modComponentFormStates[index] =
-        modComponentFormState as Draft<ModComponentFormState>;
-      state.dirty[modComponentFormState.uuid] = true;
-
-      syncBrickConfigurationUIStates(state, modComponentFormState);
-    },
-
-    removeModComponentFormState(state, action: PayloadAction<UUID>) {
-      const modComponentId = action.payload;
-      removeModComponentFormState(state, modComponentId);
+    markModComponentFormStateAsDeleted(state, action: PayloadAction<UUID>) {
+      markModComponentFormStateAsDeleted(state, action.payload);
     },
 
     ///

--- a/src/pageEditor/store/editor/editorSliceHelpers.test.ts
+++ b/src/pageEditor/store/editor/editorSliceHelpers.test.ts
@@ -26,7 +26,7 @@ import { getPipelineMap } from "@/pageEditor/tabs/editTab/editHelpers";
 import {
   ensureBrickPipelineUIState,
   ensureBrickConfigurationUIState,
-  removeModComponentFormState,
+  markModComponentFormStateAsDeleted,
   removeModData,
   setActiveModId,
   setActiveNodeId,
@@ -286,7 +286,7 @@ describe("removeModComponentFormState", () => {
     };
 
     const newState = produce(state, (draft) => {
-      removeModComponentFormState(draft, formState.uuid);
+      markModComponentFormStateAsDeleted(draft, formState.uuid);
     });
     expect(selectActiveModComponentId({ editor: newState })).toBeNull();
     expect(selectModComponentFormStates({ editor: newState })).not.toContain(
@@ -334,7 +334,10 @@ describe("removeModComponentFormState", () => {
     };
 
     const newState = produce(state, (draft) => {
-      removeModComponentFormState(draft, unavailableModComponentFormState.uuid);
+      markModComponentFormStateAsDeleted(
+        draft,
+        unavailableModComponentFormState.uuid,
+      );
     });
     expect(selectActiveModComponentId({ editor: newState })).toEqual(
       availableModComponentFormState.uuid,
@@ -433,8 +436,8 @@ describe("removeModData", () => {
     };
 
     const newState = produce(state, (draft) => {
-      removeModComponentFormState(draft, modComponentFormState1.uuid);
-      removeModComponentFormState(draft, modComponentFormState2.uuid);
+      markModComponentFormStateAsDeleted(draft, modComponentFormState1.uuid);
+      markModComponentFormStateAsDeleted(draft, modComponentFormState2.uuid);
       removeModData(draft, modMetadata.id);
     });
     expect(selectActiveModId({ editor: newState })).toBeNull();

--- a/src/pageEditor/store/editor/editorSliceHelpers.ts
+++ b/src/pageEditor/store/editor/editorSliceHelpers.ts
@@ -125,7 +125,7 @@ export function setActiveNodeId(state: Draft<EditorState>, nodeId: UUID) {
  * @param state The redux state (slice)
  * @param formStateId The id for the mod component to remove
  */
-export function removeModComponentFormState(
+export function markModComponentFormStateAsDeleted(
   state: Draft<EditorState>,
   formStateId: UUID,
 ) {

--- a/src/pageEditor/tabs/editTab/dataPanel/DataTabJsonTree.test.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataTabJsonTree.test.tsx
@@ -42,9 +42,7 @@ const data = {
 const renderJsonTree = () =>
   render(<DataTabJsonTree data={data} tabKey={DataPanelTabKey.Input} />, {
     setupRedux(dispatch) {
-      dispatch(
-        actions.selectActivatedModComponentFormState(formStateFactory()),
-      );
+      dispatch(actions.addModComponentFormState(formStateFactory()));
     },
   });
 

--- a/src/pageEditor/tabs/effect/BrickConfiguration.tsx
+++ b/src/pageEditor/tabs/effect/BrickConfiguration.tsx
@@ -55,13 +55,18 @@ import { actions as editorActions } from "@/pageEditor/store/editor/editorSlice"
  * This originally happened during the extension -> modComponent form state migration.
  * See https://github.com/pixiebrix/pixiebrix-extension/issues/8781
  */
-function useResetBrickPipeline(name: string) {
+function useRecoverFormStateIntegrityError(name: string) {
   const context = useFormikContext<ModComponentFormState>();
   const [config] = useField<BrickConfig | undefined>(name);
   const dispatch = useDispatch();
 
   if (!config.value) {
-    dispatch(editorActions.resetActivatedModComponentFormState(context.values));
+    dispatch(
+      editorActions.setModComponentFormState({
+        modComponentFormState: context.values,
+        dirty: true,
+      }),
+    );
   }
 
   return { context, config };
@@ -73,7 +78,7 @@ const BrickConfiguration: React.FunctionComponent<{
 }> = ({ name, brickId }) => {
   const configName = partial(joinName, name);
 
-  const { context, config } = useResetBrickPipeline(name);
+  const { context, config } = useRecoverFormStateIntegrityError(name);
 
   const [_rootField, _rootFieldMeta, rootFieldHelpers] =
     useField<BrickConfig | null>(configName("root"));

--- a/src/store/checkActiveModComponentAvailability.test.ts
+++ b/src/store/checkActiveModComponentAvailability.test.ts
@@ -93,7 +93,7 @@ describe("checkActiveModComponentAvailability", () => {
       actions.addModComponentFormState(unavailableDraftModComponent),
     );
     store.dispatch(
-      actions.selectActivatedModComponentFormState(availableDraftModComponent),
+      actions.addModComponentFormState(availableDraftModComponent),
     );
 
     jest
@@ -120,7 +120,12 @@ describe("checkActiveModComponentAvailability", () => {
     const available = produce(availableDraftModComponent, (draft) => {
       draft.starterBrick.definition.isAvailable.matchPatterns = [testUrl];
     });
-    store.dispatch(actions.syncModComponentFormState(available));
+    store.dispatch(
+      actions.setModComponentFormState({
+        modComponentFormState: available,
+        dirty: true,
+      }),
+    );
 
     await store.dispatch(actions.checkActiveModComponentAvailability());
 

--- a/src/store/checkAvailableDraftModComponents.test.ts
+++ b/src/store/checkAvailableDraftModComponents.test.ts
@@ -93,7 +93,7 @@ describe("checkAvailableDraftModComponents", () => {
       actions.addModComponentFormState(unavailableDraftModComponent),
     );
     store.dispatch(
-      actions.selectActivatedModComponentFormState(availableDraftModComponent),
+      actions.addModComponentFormState(availableDraftModComponent),
     );
 
     jest

--- a/src/store/sessionChanges/sessionChangesListenerMiddleware.ts
+++ b/src/store/sessionChanges/sessionChangesListenerMiddleware.ts
@@ -24,23 +24,22 @@ import modComponentSlice from "@/store/modComponents/modComponentSlice";
 const sessionChangesListenerMiddleware = createListenerMiddleware();
 sessionChangesListenerMiddleware.startListening({
   matcher: isAnyOf(
-    actions.syncModComponentFormState,
+    actions.setModComponentFormState,
+    actions.markModComponentFormStateAsClean,
+    actions.markModComponentFormStateAsDeleted,
     actions.addNode,
     actions.moveNode,
     actions.removeNode,
-    actions.resetActivatedModComponentFormState,
-    actions.removeModComponentFormState,
     actions.editModMetadata,
     actions.editModOptionsDefinitions,
     actions.editModOptionsValues,
     actions.clearMetadataAndOptionsChangesForMod,
-    actions.addModComponentFormState,
     actions.removeModById,
 
     modComponentSlice.actions.activateMod,
     modComponentSlice.actions.removeModById,
   ),
-  effect(action, { dispatch, getState }) {
+  effect(_action, { dispatch, getState }) {
     const { sessionId } = (getState() as SessionRootState).session;
     dispatch(sessionChangesActions.setSessionChanges({ sessionId }));
   },


### PR DESCRIPTION
## What does this PR do?

- More pre-work for #9323
- Consolidates/renames the mod component form state reducer

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
