### PR TITLE
#9151 Add FAB events to lexicon

### DIFF
--- a/src/components/floatingActions/FloatingActions.tsx
+++ b/src/components/floatingActions/FloatingActions.tsx
@@ -39,7 +39,7 @@ function reportReposition() {
   // Check here to prevent reporting the event twice on the same page. We just want to know
   // whether users are repositioning on the page at all.
   if (!dragReported) {
-    reportEvent(Events.FLOATING_ACTION_BUTTON_REPOSITIONED);
+    reportEvent(Events.FLOATING_ACTION_BUTTON_REPOSITION);
     dragReported = true;
   }
 }

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -47,7 +47,6 @@ export const Events = {
   FLOATING_ACTION_BUTTON_CLICK: "FloatingQuickBarButtonClick",
   FLOATING_ACTION_BUTTON_REPOSITION: "FloatingQuickBarButtonRepositioned",
   FLOATING_ACTION_BUTTON_ON_SCREEN_HIDE: "FloatingQuickBarButtonOnScreenHide",
-  FLOATING_ACTION_BUTTON_TOGGLE_SETTING: "ToggleFloatingQuickBarButtonSetting",
 
   GOOGLE_FILE_PICKER_EVENT: "GoogleFilePickerEvent",
 

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -45,7 +45,7 @@ export const Events = {
   FACTORY_RESET: "FactoryReset",
 
   FLOATING_ACTION_BUTTON_CLICK: "FloatingQuickBarButtonClick",
-  FLOATING_ACTION_BUTTON_REPOSITIONED: "FloatingQuickBarButtonRepositioned",
+  FLOATING_ACTION_BUTTON_REPOSITION: "FloatingQuickBarButtonRepositioned",
   FLOATING_ACTION_BUTTON_ON_SCREEN_HIDE: "FloatingQuickBarButtonOnScreenHide",
   FLOATING_ACTION_BUTTON_TOGGLE_SETTING: "ToggleFloatingQuickBarButtonSetting",
 

--- a/src/telemetry/lexicon.ts
+++ b/src/telemetry/lexicon.ts
@@ -198,6 +198,11 @@ export const lexicon: LexiconMap = {
       "the Extension Console settings page. This event is triggered after the user confirms the factory reset action.",
     tags: [LexiconTags.EXTENSION_CONSOLE],
   },
+  FLOATING_ACTION_BUTTON_CLICK: {
+    description:
+      "Reported when a user clicks the floating action button on any web page for which it is shown.",
+    tags: [LexiconTags.MOD_RUNTIME],
+  },
 };
 
 /**

--- a/src/telemetry/lexicon.ts
+++ b/src/telemetry/lexicon.ts
@@ -209,6 +209,13 @@ export const lexicon: LexiconMap = {
       "the button to a new location. Only reported once per page load.",
     tags: [LexiconTags.MOD_RUNTIME],
   },
+  FLOATING_ACTION_BUTTON_ON_SCREEN_HIDE: {
+    description:
+      "Reported when the floating action button is hidden by clicking the 'Hide Button' button " +
+      "that appears when hovering over the floating action button. Sets the Floating Action Button setting to 'disabled' " +
+      "in the Extension Console settings.",
+    tags: [LexiconTags.MOD_RUNTIME],
+  },
 };
 
 /**

--- a/src/telemetry/lexicon.ts
+++ b/src/telemetry/lexicon.ts
@@ -192,6 +192,12 @@ export const lexicon: LexiconMap = {
       "DevTools in the Extension Console or on internal chrome pages).",
     tags: [LexiconTags.PAGE_EDITOR],
   },
+  FACTORY_RESET: {
+    description:
+      "Reported when a user performs a factory reset of the PixieBrix Extension, which is available via " +
+      "the Extension Console settings page. This event is triggered after the user confirms the factory reset action.",
+    tags: [LexiconTags.EXTENSION_CONSOLE],
+  },
 };
 
 /**

--- a/src/telemetry/lexicon.ts
+++ b/src/telemetry/lexicon.ts
@@ -203,6 +203,12 @@ export const lexicon: LexiconMap = {
       "Reported when a user clicks the floating action button on any web page for which it is shown.",
     tags: [LexiconTags.MOD_RUNTIME],
   },
+  FLOATING_ACTION_BUTTON_REPOSITION: {
+    description:
+      "Reported when the floating action button is repositioned on the page by clicking the drag handle and moving " +
+      "the button to a new location. Only reported once per page load.",
+    tags: [LexiconTags.MOD_RUNTIME],
+  },
 };
 
 /**


### PR DESCRIPTION
## What does this PR do?

- Part of #9151
- In addition to adding entries for FAB events and FactoryReset, deletes an apparently unused and never reported FAB event for toggling the setting on the settings page