### PR TITLE
fix ExtensionsShortcutsPage page object

### DIFF
--- a/end-to-end-tests/pageObjects/extensionsShortcutsPage.ts
+++ b/end-to-end-tests/pageObjects/extensionsShortcutsPage.ts
@@ -46,18 +46,24 @@ async function getShortcut(page: Page): Promise<string> {
 }
 
 export class ExtensionsShortcutsPage extends BasePageObject {
-  private readonly pageUrl: string;
+  readonly pageUrl: string;
+
+  editToggleQuickBarShortcut = this.getByLabel("Edit shortcut Toggle Quick").or(
+    this.getByRole("button", { name: "Clear shortcut" }),
+  );
+
+  toggleQuickBarShortcutTextBox = this.getByRole("textbox", {
+    name: "Shortcut Toggle Quick Bar for PixieBrix",
+  }).or(
+    this.getByLabel(/Type a shortcut that will Toggle Quick Bar for PixieBrix/),
+  );
 
   constructor(
     page: Page,
-    private readonly chromiumChannel: SupportedChannel,
+    readonly chromiumChannel: SupportedChannel,
   ) {
     super(page);
     this.pageUrl = getExtensionShortcutsUrl(this.chromiumChannel);
-  }
-
-  getPageUrl() {
-    return this.pageUrl;
   }
 
   async goto() {
@@ -76,71 +82,30 @@ export class ExtensionsShortcutsPage extends BasePageObject {
     await this.page.bringToFront();
 
     const shortcut = await getShortcut(this.page);
+    // Verify the shortcut is initially set
+    await expect(this.toggleQuickBarShortcutTextBox).toHaveValue(shortcut);
 
-    if (isChrome(this.chromiumChannel)) {
-      await expect(this.page.getByPlaceholder(/shortcut set: /i)).toHaveValue(
-        shortcut,
-      );
+    // Clear the shortcut
+    await this.editToggleQuickBarShortcut.click();
 
-      // Clear the shortcut
-      await this.getByLabel("Edit shortcut Toggle Quick").click();
-      await this.locator("extensions-keyboard-shortcuts #container").click();
-
-      await expect(
-        this.getByRole("textbox", {
-          name: "Shortcut Toggle Quick Bar for PixieBrix",
-        }),
-      ).toBeEmpty();
-    } else {
-      await expect(
-        this.getByLabel(
-          /Type a shortcut that will Toggle Quick Bar for PixieBrix/,
-        ),
-      ).toHaveValue(shortcut);
-
-      await this.getByRole("button", { name: "Clear shortcut" }).click();
-
-      await expect(
-        this.getByLabel(
-          /Type a shortcut that will Toggle Quick Bar for PixieBrix/,
-        ),
-      ).toBeEmpty();
-    }
+    await expect(this.toggleQuickBarShortcutTextBox).toBeEmpty();
   }
 
   async setQuickbarShortcut() {
     await this.page.bringToFront();
 
     const modifierKey = await getModifierKey(this.page);
-    const shortcut = await getShortcut(this.page);
+    // Verify the shortcut is initially cleared
+    await expect(this.toggleQuickBarShortcutTextBox).toBeEmpty();
 
-    if (isChrome(this.chromiumChannel)) {
-      await expect(
-        this.getByRole("textbox", {
-          name: "Shortcut Toggle Quick Bar for PixieBrix",
-        }),
-      ).toBeEmpty();
-
-      await this.getByLabel("Edit shortcut Toggle Quick").click();
-      await this.getByPlaceholder("Type a shortcut").press(`${modifierKey}+m`);
-
-      await this.locator("extensions-keyboard-shortcuts #container").click();
-
-      await expect(this.getByPlaceholder(/shortcut set: /i)).toHaveValue(
-        shortcut,
-      );
-    } else {
-      const shortcutLabel = /type a shortcut that will toggle quick bar/i;
-      const input = this.getByLabel(shortcutLabel);
-
-      await expect(input).toBeEmpty();
-
-      await input.click();
-      await input.press(`${modifierKey}+m`);
-
-      await this.getByText("Keyboard ShortcutsPixieBrix").click();
-
-      await expect(input).toHaveValue(shortcut);
+    // Old versions of Edge only show a clear button when a shortcut is set
+    if (await this.editToggleQuickBarShortcut.isVisible()) {
+      await this.editToggleQuickBarShortcut.click();
     }
+
+    await this.toggleQuickBarShortcutTextBox.press(`${modifierKey}+m`);
+
+    // Newest version of chrome replaces ⌘ with "Command" in the displayed shortcut
+    await expect(this.toggleQuickBarShortcutTextBox).toHaveValue(/M$/);
   }
 }

--- a/end-to-end-tests/tests/extensionConsole/activation.spec.ts
+++ b/end-to-end-tests/tests/extensionConsole/activation.spec.ts
@@ -219,7 +219,7 @@ test("activating a mod when the quickbar shortcut is not configured", async ({
       context,
     );
 
-    await expect(configureShortcutPage).toHaveURL(shortcutsPage.getPageUrl());
+    await expect(configureShortcutPage).toHaveURL(shortcutsPage.pageUrl);
     await configureShortcutPage.close();
   });
 


### PR DESCRIPTION
Using updated locators based on the newest Chrome and Edge `<browser>://extensions/shortcuts` UI

## What does this PR do?

- Fixes failing prerelease browsers e2e test job https://github.com/pixiebrix/pixiebrix-extension/actions/runs/11512151847/job/32079803969
- Tested by running locally against chrome, msedge, chrome-beta and msedge-beta

## Checklist

- [x] Added jest or playwright tests and/or storybook stories

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
