### PR TITLE
8348: making telemetry e2e tests faster

### DIFF
--- a/end-to-end-tests/tests/telemetry/errors.spec.ts
+++ b/end-to-end-tests/tests/telemetry/errors.spec.ts
@@ -30,7 +30,7 @@ async function waitForBackgroundPageRequest(
 
   const request = offscreenPage?.waitForRequest(errorServiceEndpoint);
 
-  // Workaround to force datadog to flush metrics
+  // Workaround to force datadog to flush metrics immediately
   // See: https://github.com/DataDog/browser-sdk/issues/2327
   await offscreenPage?.evaluate(() => {
     document.dispatchEvent(new Event("freeze"));

--- a/end-to-end-tests/tests/telemetry/errors.spec.ts
+++ b/end-to-end-tests/tests/telemetry/errors.spec.ts
@@ -27,12 +27,16 @@ async function waitForBackgroundPageRequest(
 
     expect(offscreenPage?.url()).toBeDefined();
   }).toPass({ timeout: 5000 });
-  return offscreenPage?.waitForRequest(errorServiceEndpoint, {
-    // TODO: due to Datadog SDK implementation, it will take ~30 seconds for the
-    //  request to be sent. We should figure out a way to induce the request to be sent sooner.
-    //  See this datadog support request: https://help.datadoghq.com/hc/en-us/requests/1754158
-    timeout: 35_000,
+
+  const request = offscreenPage?.waitForRequest(errorServiceEndpoint);
+
+  // Workaround to force datadog to flush metrics
+  // See: https://github.com/DataDog/browser-sdk/issues/2327
+  await offscreenPage?.evaluate(() => {
+    document.dispatchEvent(new Event("freeze"));
   });
+
+  return request;
 }
 
 const ERROR_SERVICE_ENDPOINT = "https://browser-intake-datadoghq.com/api/v2/*";

--- a/src/telemetry/initErrorReporter.ts
+++ b/src/telemetry/initErrorReporter.ts
@@ -71,6 +71,10 @@ async function initErrorReporter(
     addAuthListener(updatePerson);
 
     datadogLogs.init({
+      // Allows us to programmatically flush datadog metrics using freeze events
+      // See: end-to-end-tests/tests/telemetry/errors.spec.ts
+      // See: https://github.com/DataDog/browser-sdk/issues/2327
+      allowUntrustedEvents: true,
       clientToken: CLIENT_TOKEN,
       service: "pixiebrix-browser-extension",
       env: ENVIRONMENT,


### PR DESCRIPTION
## What does this PR do?

- Closes #8348 
 
## Discussion

- Considered making datadog `allowUntrustedEvents` depend on a env variable to be set to true, but I don't think there's any real harm in just always setting it to true (and avoids having to fuss with CI/e2e specific env vars)

## Checklist

- [X] Added jest or playwright tests and/or storybook stories

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
