### PR TITLE
#9376: fix options args focus/active subtab resetting

### DIFF
--- a/src/components/tabLayout/EditorTabLayout.tsx
+++ b/src/components/tabLayout/EditorTabLayout.tsx
@@ -28,7 +28,6 @@ export interface TabItem {
   badgeCount?: number;
   badgeVariant?: Variant;
   TabContent: React.VoidFunctionComponent;
-  mountWhenActive?: boolean;
 }
 
 export interface ActionButton {
@@ -64,7 +63,7 @@ const EditorTabLayout: React.FC<{
           className={styles.nav}
         >
           {tabs.map(({ name, badgeCount, badgeVariant }) => (
-            <Nav.Item key={`nav-tab-${name}`} className={styles.navItem}>
+            <Nav.Item key={name} className={styles.navItem}>
               <Nav.Link eventKey={name} className={styles.navLink}>
                 {name}
                 {badgeCount && badgeVariant && (
@@ -82,10 +81,7 @@ const EditorTabLayout: React.FC<{
               <div className="flex-grow-1" />
               <ButtonGroup>
                 {actionButtons.map(
-                  (
-                    { variant, onClick, caption, disabled = false, icon },
-                    index,
-                  ) => (
+                  ({ variant, onClick, caption, disabled = false, icon }) => (
                     <Button
                       key={caption}
                       size="sm"
@@ -109,14 +105,15 @@ const EditorTabLayout: React.FC<{
         </Nav>
 
         <Tab.Content className={styles.content}>
-          {tabs.map(({ name, TabContent, mountWhenActive }) => (
+          {tabs.map(({ name, TabContent }) => (
             <Tab.Pane
               key={name}
               eventKey={name}
-              mountOnEnter={mountWhenActive}
-              unmountOnExit={mountWhenActive}
+              // Simplify form state handling by only mounting when active
+              mountOnEnter
+              unmountOnExit
             >
-              <TabContent key={name} />
+              <TabContent />
             </Tab.Pane>
           ))}
         </Tab.Content>

--- a/src/components/tabLayout/__snapshots__/EditorTabLayout.test.tsx.snap
+++ b/src/components/tabLayout/__snapshots__/EditorTabLayout.test.tsx.snap
@@ -143,34 +143,6 @@ exports[`EditorTabLayout renders 1`] = `
           </p>
         </div>
       </div>
-      <div
-        aria-hidden="true"
-        class="fade tab-pane"
-        role="tabpanel"
-      >
-        <div>
-          <h1>
-            Sample $Options Tab
-          </h1>
-          <p>
-            This is a sample tab with some text content
-          </p>
-        </div>
-      </div>
-      <div
-        aria-hidden="true"
-        class="fade tab-pane"
-        role="tabpanel"
-      >
-        <div>
-          <h1>
-            Sample $Logs Tab
-          </h1>
-          <p>
-            This is a sample tab with some text content
-          </p>
-        </div>
-      </div>
     </div>
   </div>
 </DocumentFragment>

--- a/src/pageEditor/store/editor/editorSelectors/editorModSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorModSelectors.ts
@@ -107,26 +107,27 @@ export const selectDirtyMetadataForModId =
 export const selectDirtyModOptionsDefinitions = ({ editor }: EditorRootState) =>
   editor.dirtyModOptionsById;
 
-const dirtyOptionsDefinitionsForModIdSelector = createSelector(
+const selectGetDirtyOptionsDefinitionsForModId = createSelector(
   selectDirtyModOptionsDefinitions,
-  (_state: EditorRootState, modId: RegistryId) => modId,
-  (dirtyOptionsDefinitionsByModId, modId) => {
-    // eslint-disable-next-line security/detect-object-injection -- RegistryId for mod
-    const options = dirtyOptionsDefinitionsByModId[modId];
+  (dirtyOptionsDefinitionsByModId) =>
+    // Memoize because normalizeModOptionsDefinition returns a fresh object reference
+    memoize((modId: RegistryId) => {
+      // eslint-disable-next-line security/detect-object-injection -- RegistryId for mod
+      const options = dirtyOptionsDefinitionsByModId[modId];
 
-    if (options) {
-      // Provide a consistent shape of the options
-      return normalizeModOptionsDefinition(options);
-    }
+      if (options) {
+        // Provide a consistent shape of the options
+        return normalizeModOptionsDefinition(options);
+      }
 
-    // Return undefined if the options aren't dirty. Returning nullish instead of a default empty options allows the
-    // caller to distinguish no dirty options vs. options that have been reverted to the default.
-  },
+      // Return undefined if the options aren't dirty. Returning nullish instead of a default empty options allows the
+      // caller to distinguish no dirty options vs. options that have been reverted to the default.
+    }),
 );
 
 export const selectDirtyOptionsDefinitionsForModId =
   (modId: RegistryId) => (state: EditorRootState) =>
-    dirtyOptionsDefinitionsForModIdSelector(state, modId);
+    selectGetDirtyOptionsDefinitionsForModId(state)(modId);
 
 ///
 /// MOD COMPONENTS
@@ -233,38 +234,38 @@ export const selectDeletedComponentFormStatesByModId = ({
   editor,
 }: EditorRootState) => editor.deletedModComponentFormStatesByModId;
 
-const modIsDirtySelector = createSelector(
+const selectGetModIsDirtySelector = createSelector(
+  selectDirtyModMetadata,
   selectIsModComponentDirtyById,
-  dirtyOptionsDefinitionsForModIdSelector,
-  dirtyMetadataForModIdSelector,
-  (state: EditorRootState, modId: RegistryId) =>
-    // eslint-disable-next-line security/detect-object-injection -- RegistryId is a controlled string
-    selectDeletedComponentFormStatesByModId(state)[modId],
-  ({ editor }: EditorRootState, modId: RegistryId) =>
-    editor.modComponentFormStates
-      .filter((formState) => formState.modMetadata.id === modId)
-      .map((formState) => formState.uuid),
+  selectGetDirtyOptionsDefinitionsForModId,
+  selectGetModComponentFormStatesByModId,
+  selectDeletedComponentFormStatesByModId,
   (
-    isModComponentDirtyById,
-    dirtyModOptions,
     dirtyModMetadata,
-    deletedModComponentFormStates,
-    modComponentFormStateIds,
-    // eslint-disable-next-line max-params -- all are needed
-  ) => {
-    const hasSomeDirtyComponentFormState = modComponentFormStateIds.some(
-      // eslint-disable-next-line security/detect-object-injection -- UUID
-      (modComponentId) => isModComponentDirtyById[modComponentId],
-    );
-    return (
-      hasSomeDirtyComponentFormState ||
-      Boolean(dirtyModOptions) ||
-      Boolean(dirtyModMetadata) ||
-      !isEmpty(deletedModComponentFormStates)
-    );
-  },
+    isModComponentDirtyById,
+    getDirtyOptionsDefinitionsForModId,
+    getModComponentFormStatesByModId,
+    getDeletedModComponentFormStatesByModId,
+    // eslint-disable-next-line max-params -- required because createSelector takes array of selector args
+  ) =>
+    // Memoize for consistency. It's not necessary because the return value is primitive
+    memoize((modId: RegistryId) => {
+      const hasDirtyFormState = getModComponentFormStatesByModId(modId).some(
+        // eslint-disable-next-line security/detect-object-injection -- UUID
+        ({ uuid }) => isModComponentDirtyById[uuid],
+      );
+
+      return (
+        // eslint-disable-next-line security/detect-object-injection -- registry id
+        Boolean(dirtyModMetadata[modId]) ||
+        Boolean(getDirtyOptionsDefinitionsForModId(modId)) ||
+        hasDirtyFormState ||
+        // eslint-disable-next-line security/detect-object-injection -- registry id
+        !isEmpty(getDeletedModComponentFormStatesByModId[modId])
+      );
+    }),
 );
 
 export const selectModIsDirty =
   (modId: RegistryId) => (state: EditorRootState) =>
-    Boolean(modId && modIsDirtySelector(state, modId));
+    modId != null && selectGetModIsDirtySelector(state)(modId);

--- a/src/pageEditor/store/editor/editorSelectors/editorModSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorModSelectors.ts
@@ -107,7 +107,7 @@ export const selectDirtyMetadataForModId =
 export const selectDirtyModOptionsDefinitions = ({ editor }: EditorRootState) =>
   editor.dirtyModOptionsById;
 
-const selectGetDirtyOptionsDefinitionsForModId = createSelector(
+const selectGetDirtyOptionsDefinitionForModId = createSelector(
   selectDirtyModOptionsDefinitions,
   (dirtyOptionsDefinitionsByModId) =>
     // Memoize because normalizeModOptionsDefinition returns a fresh object reference
@@ -125,9 +125,9 @@ const selectGetDirtyOptionsDefinitionsForModId = createSelector(
     }),
 );
 
-export const selectDirtyOptionsDefinitionsForModId =
+export const selectDirtyOptionsDefinitionForModId =
   (modId: RegistryId) => (state: EditorRootState) =>
-    selectGetDirtyOptionsDefinitionsForModId(state)(modId);
+    selectGetDirtyOptionsDefinitionForModId(state)(modId);
 
 ///
 /// MOD COMPONENTS
@@ -237,7 +237,7 @@ export const selectDeletedComponentFormStatesByModId = ({
 const selectGetModIsDirtySelector = createSelector(
   selectDirtyModMetadata,
   selectIsModComponentDirtyById,
-  selectGetDirtyOptionsDefinitionsForModId,
+  selectGetDirtyOptionsDefinitionForModId,
   selectGetModComponentFormStatesByModId,
   selectDeletedComponentFormStatesByModId,
   (

--- a/src/pageEditor/store/editor/editorSliceHelpers.test.ts
+++ b/src/pageEditor/store/editor/editorSliceHelpers.test.ts
@@ -45,7 +45,7 @@ import {
   selectActiveModId,
   selectDeletedComponentFormStatesByModId,
   selectDirtyMetadataForModId,
-  selectDirtyOptionsDefinitionsForModId,
+  selectDirtyOptionsDefinitionForModId,
   selectModComponentFormStates,
   selectExpandedModId,
 } from "@/pageEditor/store/editor/editorSelectors";
@@ -449,7 +449,7 @@ describe("removeModData", () => {
     expect(selectActiveModId({ editor: newState })).toBeNull();
     expect(selectExpandedModId({ editor: newState })).toBeNull();
     expect(
-      selectDirtyOptionsDefinitionsForModId(modMetadata.id)({
+      selectDirtyOptionsDefinitionForModId(modMetadata.id)({
         editor: newState,
       }),
     ).toBeUndefined();

--- a/src/pageEditor/tabs/modOptionsArgs/ModOptionsArgsEditor.tsx
+++ b/src/pageEditor/tabs/modOptionsArgs/ModOptionsArgsEditor.tsx
@@ -70,7 +70,7 @@ function useOptionsFieldGroupQuery(modId: RegistryId) {
   );
 
   return useDeriveAsyncState(
-    // Map undefined to null because `useDeriveAsyncState` does't support undefined values in isSuccess state
+    // Map undefined to null because `useDeriveAsyncState` does not support undefined values in isSuccess state
     mergeAsyncState(
       modDefinitionQuery,
       (x: ModDefinition | undefined) => x ?? null,
@@ -78,10 +78,10 @@ function useOptionsFieldGroupQuery(modId: RegistryId) {
     valueToAsyncState(dirtyModOptionsDefinitions),
     async (
       modDefinition: ModDefinition,
-      dirtyModOptionsDefinitions: ModOptionsDefinition,
+      dirtyModOptionsDefinition: ModOptionsDefinition,
     ) => {
       const optionsDefinition =
-        dirtyModOptionsDefinitions ??
+        dirtyModOptionsDefinition ??
         modDefinition?.options ??
         emptyModOptionsDefinitionFactory();
 

--- a/src/pageEditor/tabs/modOptionsArgs/ModOptionsArgsEditor.tsx
+++ b/src/pageEditor/tabs/modOptionsArgs/ModOptionsArgsEditor.tsx
@@ -75,7 +75,7 @@ function useOptionsFieldGroupQuery(modId: RegistryId) {
       modDefinitionQuery,
       (x: ModDefinition | undefined) => x ?? null,
     ),
-    valueToAsyncState(dirtyModOptionsDefinitions),
+    valueToAsyncState(dirtyModOptionsDefinitions ?? null),
     async (
       modDefinition: ModDefinition,
       dirtyModOptionsDefinition: ModOptionsDefinition,

--- a/src/pageEditor/tabs/modOptionsArgs/ModOptionsArgsEditor.tsx
+++ b/src/pageEditor/tabs/modOptionsArgs/ModOptionsArgsEditor.tsx
@@ -90,8 +90,8 @@ function useOptionsFieldGroupQuery(modId: RegistryId) {
           optionsDefinition.schema,
         ),
         OptionsFieldGroup: genericOptionsFactory(
-          optionsDefinition?.schema,
-          optionsDefinition?.uiSchema,
+          optionsDefinition.schema,
+          optionsDefinition.uiSchema,
           { NoOptionsComponent: NoModOptions },
         ),
       };

--- a/src/pageEditor/tabs/modOptionsArgs/ModOptionsArgsEditor.tsx
+++ b/src/pageEditor/tabs/modOptionsArgs/ModOptionsArgsEditor.tsx
@@ -134,9 +134,7 @@ const ModOptionsArgsContent: React.FC = () => {
     [dispatch],
   );
 
-  const optionsFieldBody = (
-    OptionsFieldGroup: React.FunctionComponent<BrickOptionProps>,
-  ) => {
+  const optionsFieldBody = (OptionsFieldGroup: React.FC<BrickOptionProps>) => {
     // Name local variable so React has a display name
     const renderBody = ({ values }: { values: FormikValues }) => (
       <ModIntegrationsContext.Provider value={{ integrationDependencies }}>

--- a/src/pageEditor/tabs/modOptionsArgs/ModOptionsArgsEditor.tsx
+++ b/src/pageEditor/tabs/modOptionsArgs/ModOptionsArgsEditor.tsx
@@ -20,7 +20,7 @@ import { useDispatch, useSelector } from "react-redux";
 import {
   selectActiveModId,
   selectDirtyOptionsArgsForModId,
-  selectDirtyOptionsDefinitionsForModId,
+  selectDirtyOptionsDefinitionForModId,
   selectGetDraftModComponentsForMod,
 } from "@/pageEditor/store/editor/editorSelectors";
 import { useOptionalModDefinition } from "@/modDefinitions/modDefinitionHooks";
@@ -65,8 +65,8 @@ const NoModOptions: React.FC = () => (
 function useOptionsFieldGroupQuery(modId: RegistryId) {
   const modDefinitionQuery = useOptionalModDefinition(modId);
 
-  const dirtyModOptionsDefinitions = useSelector(
-    selectDirtyOptionsDefinitionsForModId(modId),
+  const dirtyModOptionsDefinition = useSelector(
+    selectDirtyOptionsDefinitionForModId(modId),
   );
 
   return useDeriveAsyncState(
@@ -75,7 +75,7 @@ function useOptionsFieldGroupQuery(modId: RegistryId) {
       modDefinitionQuery,
       (x: ModDefinition | undefined) => x ?? null,
     ),
-    valueToAsyncState(dirtyModOptionsDefinitions ?? null),
+    valueToAsyncState(dirtyModOptionsDefinition ?? null),
     async (
       modDefinition: ModDefinition,
       dirtyModOptionsDefinition: ModOptionsDefinition,

--- a/src/pageEditor/tabs/modOptionsArgs/ModOptionsArgsEditor.tsx
+++ b/src/pageEditor/tabs/modOptionsArgs/ModOptionsArgsEditor.tsx
@@ -19,23 +19,22 @@ import React, { useCallback, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   selectActiveModId,
-  selectDirtyOptionsDefinitionsForModId,
   selectDirtyOptionsArgsForModId,
+  selectDirtyOptionsDefinitionsForModId,
   selectGetDraftModComponentsForMod,
 } from "@/pageEditor/store/editor/editorSelectors";
 import { useOptionalModDefinition } from "@/modDefinitions/modDefinitionHooks";
-import genericOptionsFactory from "@/components/fields/schemaFields/genericOptionsFactory";
+import genericOptionsFactory, {
+  type BrickOptionProps,
+} from "@/components/fields/schemaFields/genericOptionsFactory";
 import FieldRuntimeContext, {
   type RuntimeContext,
 } from "@/components/fields/schemaFields/FieldRuntimeContext";
 import { Card, Container } from "react-bootstrap";
-import Form, { type RenderBody } from "@/components/form/Form";
-import Loader from "@/components/Loader";
-import Alert from "@/components/Alert";
-import { getErrorMessage } from "@/errors/errorHelpers";
+import Form from "@/components/form/Form";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { collectModOptionsArgs } from "@/store/modComponents/modComponentUtils";
-import useAsyncModOptionsValidationSchema from "@/hooks/useAsyncModOptionsValidationSchema";
+import { getOptionsValidationSchema } from "@/hooks/useAsyncModOptionsValidationSchema";
 import Effect from "@/components/Effect";
 import { actions } from "@/pageEditor/store/editor/editorSlice";
 import { type OptionsArgs } from "@/types/runtimeTypes";
@@ -44,6 +43,15 @@ import ModIntegrationsContext from "@/mods/ModIntegrationsContext";
 import { emptyModOptionsDefinitionFactory } from "@/utils/modUtils";
 import { uniqBy } from "lodash";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import type { RegistryId } from "@/types/registryTypes";
+import useDeriveAsyncState from "@/hooks/useDeriveAsyncState";
+import { mergeAsyncState, valueToAsyncState } from "@/utils/asyncStateUtils";
+import type {
+  ModDefinition,
+  ModOptionsDefinition,
+} from "@/types/modDefinitionTypes";
+import AsyncStateGate from "@/components/AsyncStateGate";
+import type { FormikValues } from "formik";
 
 const OPTIONS_FIELD_RUNTIME_CONTEXT: RuntimeContext = {
   apiVersion: DEFAULT_RUNTIME_API_VERSION,
@@ -54,55 +62,58 @@ const NoModOptions: React.FC = () => (
   <div>This mod does not require any configuration</div>
 );
 
+function useOptionsFieldGroupQuery(modId: RegistryId) {
+  const modDefinitionQuery = useOptionalModDefinition(modId);
+
+  const dirtyModOptionsDefinitions = useSelector(
+    selectDirtyOptionsDefinitionsForModId(modId),
+  );
+
+  return useDeriveAsyncState(
+    // Map undefined to null because `useDeriveAsyncState` does't support undefined values in isSuccess state
+    mergeAsyncState(
+      modDefinitionQuery,
+      (x: ModDefinition | undefined) => x ?? null,
+    ),
+    valueToAsyncState(dirtyModOptionsDefinitions),
+    async (
+      modDefinition: ModDefinition,
+      dirtyModOptionsDefinitions: ModOptionsDefinition,
+    ) => {
+      const optionsDefinition =
+        dirtyModOptionsDefinitions ??
+        modDefinition?.options ??
+        emptyModOptionsDefinitionFactory();
+
+      return {
+        validationSchema: await getOptionsValidationSchema(
+          optionsDefinition.schema,
+        ),
+        OptionsFieldGroup: genericOptionsFactory(
+          optionsDefinition?.schema,
+          optionsDefinition?.uiSchema,
+          { NoOptionsComponent: NoModOptions },
+        ),
+      };
+    },
+  );
+}
+
 const ModOptionsArgsContent: React.FC = () => {
   const dispatch = useDispatch();
   const activeModId = useSelector(selectActiveModId);
 
   assertNotNullish(activeModId, "activeModId is required");
 
-  const {
-    data: mod,
-    isFetching: isFetchingMod,
-    error: modError,
-  } = useOptionalModDefinition(activeModId);
-  const dirtyModOptions = useSelector(
-    selectDirtyOptionsDefinitionsForModId(activeModId),
-  );
-  const modifiedOptionValues = useSelector(
-    selectDirtyOptionsArgsForModId(activeModId),
-  );
   const getDraftModComponentsForMod = useSelector(
     selectGetDraftModComponentsForMod,
   );
   const draftModComponents = getDraftModComponentsForMod(activeModId);
 
-  const optionsDefinition = useMemo(() => {
-    if (dirtyModOptions) {
-      return dirtyModOptions;
-    }
+  const fieldGroupQuery = useOptionsFieldGroupQuery(activeModId);
 
-    return mod?.options ?? emptyModOptionsDefinitionFactory();
-  }, [dirtyModOptions, mod?.options]);
-
-  const {
-    data: validationSchema,
-    isLoading: isLoadingSchema,
-    error: schemaError,
-  } = useAsyncModOptionsValidationSchema(optionsDefinition?.schema);
-
-  const OptionsFieldGroup = useMemo(
-    () =>
-      genericOptionsFactory(
-        optionsDefinition?.schema,
-        optionsDefinition?.uiSchema,
-        { NoOptionsComponent: NoModOptions },
-      ),
-    [optionsDefinition],
-  );
-
-  const initialValues = useMemo(
-    () => modifiedOptionValues ?? collectModOptionsArgs(draftModComponents),
-    [draftModComponents, modifiedOptionValues],
+  const dirtyOptionsArgs = useSelector(
+    selectDirtyOptionsArgsForModId(activeModId),
   );
 
   const integrationDependencies = useMemo(
@@ -123,51 +134,53 @@ const ModOptionsArgsContent: React.FC = () => {
     [dispatch],
   );
 
-  if (isLoadingSchema || isFetchingMod) {
-    return <Loader />;
-  }
+  const optionsFieldBody = (
+    OptionsFieldGroup: React.FunctionComponent<BrickOptionProps>,
+  ) => {
+    // Name local variable so React has a display name
+    const renderBody = ({ values }: { values: FormikValues }) => (
+      <ModIntegrationsContext.Provider value={{ integrationDependencies }}>
+        <Effect values={values} onChange={updateRedux} delayMillis={300} />
+        <Card>
+          <Card.Header>Mod Input Options</Card.Header>
+          <Card.Body>
+            <FieldRuntimeContext.Provider value={OPTIONS_FIELD_RUNTIME_CONTEXT}>
+              <OptionsFieldGroup name="" />
+            </FieldRuntimeContext.Provider>
+          </Card.Body>
+        </Card>
+      </ModIntegrationsContext.Provider>
+    );
 
-  const error = modError ?? schemaError;
-  if (error) {
-    console.error(error);
-    return <Alert variant="danger">{getErrorMessage(error)}</Alert>;
-  }
-
-  const renderBody: RenderBody = ({ values }) => (
-    <ModIntegrationsContext.Provider value={{ integrationDependencies }}>
-      <Effect values={values} onChange={updateRedux} delayMillis={300} />
-      <Card>
-        <Card.Header>Mod Input Options</Card.Header>
-        <Card.Body>
-          <FieldRuntimeContext.Provider value={OPTIONS_FIELD_RUNTIME_CONTEXT}>
-            <OptionsFieldGroup name="" />
-          </FieldRuntimeContext.Provider>
-        </Card.Body>
-      </Card>
-    </ModIntegrationsContext.Provider>
-  );
+    return renderBody;
+  };
 
   return (
-    <ErrorBoundary>
-      <Form
-        validationSchema={validationSchema}
-        initialValues={initialValues}
-        enableReinitialize
-        renderBody={renderBody}
-        onSubmit={() => {
-          console.error(
-            "The form's submit should not be called to save mod option values, they are automatically synced with redux",
-          );
-        }}
-        renderSubmit={() => null}
-      />
-    </ErrorBoundary>
+    <AsyncStateGate state={fieldGroupQuery}>
+      {({ data: { validationSchema, OptionsFieldGroup } }) => (
+        <Form
+          validationSchema={validationSchema}
+          initialValues={
+            dirtyOptionsArgs ?? collectModOptionsArgs(draftModComponents)
+          }
+          renderBody={optionsFieldBody(OptionsFieldGroup)}
+          onSubmit={() => {
+            console.error(
+              "The form's submit should not be called to save mod option args, they are automatically synced with redux",
+            );
+          }}
+          renderSubmit={() => null}
+        />
+      )}
+    </AsyncStateGate>
   );
 };
 
 const ModOptionsArgsEditor: React.FC = () => (
   <Container fluid className="pt-3">
-    <ModOptionsArgsContent />
+    <ErrorBoundary>
+      <ModOptionsArgsContent />
+    </ErrorBoundary>
   </Container>
 );
 

--- a/src/pageEditor/tabs/modOptionsDefinitions/ModOptionsDefinitionEditor.tsx
+++ b/src/pageEditor/tabs/modOptionsDefinitions/ModOptionsDefinitionEditor.tsx
@@ -33,7 +33,7 @@ import FORM_FIELD_TYPE_OPTIONS from "@/pageEditor/fields/formFieldTypeOptions";
 import { useDispatch, useSelector } from "react-redux";
 import {
   selectActiveModId,
-  selectDirtyOptionsDefinitionsForModId,
+  selectDirtyOptionsDefinitionForModId,
 } from "@/pageEditor/store/editor/editorSelectors";
 import { PAGE_EDITOR_DEFAULT_BRICK_API_VERSION } from "@/pageEditor/starterBricks/base";
 // eslint-disable-next-line no-restricted-imports -- TODO: Fix over time
@@ -121,9 +121,7 @@ const ModOptionsDefinitionEditor: React.VFC = () => {
   } = useOptionalModDefinition(modId);
 
   const savedOptions = modDefinition?.options;
-  const dirtyOptions = useSelector(
-    selectDirtyOptionsDefinitionsForModId(modId),
-  );
+  const dirtyOptions = useSelector(selectDirtyOptionsDefinitionForModId(modId));
 
   const optionsDefinition =
     dirtyOptions ?? savedOptions ?? emptyModOptionsDefinitionFactory();


### PR DESCRIPTION
## What does this PR do?

- Closes #9376: the root cause was the mod editor pane including the form sequence number in its key
- Closes #7148: the root cause was the editorSlice selector returning a fresh options definition object

## Remaining Work

- [x] Add Playwright test covering the regression and the fix for keeping field focus

## Future Work

- :bug: Mod Options Args are buggy: https://github.com/pixiebrix/pixiebrix-extension/issues/9378
- Finish making selector naming and calling conventions consistent

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
