### PR TITLE
Move mod variables definition out of mod component form state

### DIFF
--- a/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts-snapshots/Add-starter-brick-to-mod/add-button-starter-brick-to-mod.yaml
+++ b/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts-snapshots/Add-starter-brick-to-mod/add-button-starter-brick-to-mod.yaml
@@ -9,8 +9,8 @@ options:
 metadata:
   id: >-
     @extension-e2e-test-unaffiliated/new-mod-00000000-0000-0000-0000-000000000000
-  name: New Mod
   version: 1.0.0
+  name: New Mod
   description: Created by playwright test for adding starter bricks to a mod
 variables:
   schema:

--- a/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/brick-added.diff
+++ b/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/brick-added.diff
@@ -2,7 +2,7 @@ Index: brick-added
 ===================================================================
 --- brick-added
 +++ brick-added
-@@ -6,78 +6,84 @@
+@@ -6,78 +6,88 @@
        containerSelector: span:has(> span:contains('Review in codespace'))
        isAvailable:
          allFrames: true
@@ -87,3 +87,7 @@ Index: brick-added
    uiSchema:
      ui:order:
        - '*'
++variables:
++  schema:
++    properties: {}
++    type: object

--- a/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/brick-copied-to-another-mod.diff
+++ b/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/brick-copied-to-another-mod.diff
@@ -2,7 +2,7 @@ Index: brick-copied-to-another-mod
 ===================================================================
 --- brick-copied-to-another-mod
 +++ brick-copied-to-another-mod
-@@ -1,74 +1,82 @@
+@@ -1,74 +1,86 @@
  apiVersion: v3
  definitions:
    extensionPoint:
@@ -85,3 +85,7 @@ Index: brick-copied-to-another-mod
    uiSchema:
      ui:order:
        - '*'
++variables:
++  schema:
++    properties: {}
++    type: object

--- a/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/brick-copy-pasted.diff
+++ b/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/brick-copy-pasted.diff
@@ -2,7 +2,7 @@ Index: brick-copy-pasted
 ===================================================================
 --- brick-copy-pasted
 +++ brick-copy-pasted
-@@ -6,78 +6,86 @@
+@@ -6,80 +6,88 @@
        containerSelector: span:has(> span:contains('Review in codespace'))
        isAvailable:
          allFrames: true
@@ -89,3 +89,5 @@ Index: brick-copy-pasted
    uiSchema:
      ui:order:
        - '*'
+ variables:
+   schema:

--- a/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/brick-removed.diff
+++ b/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/brick-removed.diff
@@ -2,7 +2,7 @@ Index: brick-removed
 ===================================================================
 --- brick-removed
 +++ brick-removed
-@@ -6,84 +6,78 @@
+@@ -6,86 +6,80 @@
        containerSelector: span:has(> span:contains('Review in codespace'))
        isAvailable:
          allFrames: true
@@ -87,3 +87,5 @@ Index: brick-removed
    uiSchema:
      ui:order:
        - '*'
+ variables:
+   schema:

--- a/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/bricks-moved.diff
+++ b/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/bricks-moved.diff
@@ -2,7 +2,7 @@ Index: bricks-moved
 ===================================================================
 --- bricks-moved
 +++ bricks-moved
-@@ -1,91 +1,91 @@
+@@ -1,95 +1,95 @@
  apiVersion: v3
  definitions:
    extensionPoint:
@@ -109,3 +109,7 @@ Index: bricks-moved
    uiSchema:
      ui:order:
        - '*'
+ variables:
+   schema:
+     properties: {}
+     type: object

--- a/end-to-end-tests/tests/pageEditor/brickConfiguration.spec.ts-snapshots/brick-configuration/starter-brick-configuration-changes.diff
+++ b/end-to-end-tests/tests/pageEditor/brickConfiguration.spec.ts-snapshots/brick-configuration/starter-brick-configuration-changes.diff
@@ -2,7 +2,7 @@ Index: starter-brick-configuration-changes
 ===================================================================
 --- starter-brick-configuration-changes
 +++ starter-brick-configuration-changes
-@@ -1,71 +1,77 @@
+@@ -1,71 +1,81 @@
  apiVersion: v3
  definitions:
    extensionPoint:
@@ -85,3 +85,7 @@ Index: starter-brick-configuration-changes
    uiSchema:
      ui:order:
        - '*'
++variables:
++  schema:
++    properties: {}
++    type: object

--- a/end-to-end-tests/tests/pageEditor/copyMod.spec.ts-snapshots/copying-a-mod-that-uses-the-PixieBrix-API-is-copied-correctly/write-to-db-static-copy.diff
+++ b/end-to-end-tests/tests/pageEditor/copyMod.spec.ts-snapshots/copying-a-mod-that-uses-the-PixieBrix-API-is-copied-correctly/write-to-db-static-copy.diff
@@ -2,7 +2,7 @@ Index: write-to-db-static-copy
 ===================================================================
 --- write-to-db-static-copy
 +++ write-to-db-static-copy
-@@ -22,51 +22,52 @@
+@@ -22,51 +22,56 @@
      kind: extensionPoint
  extensionPoints:
    - config:
@@ -57,3 +57,7 @@ Index: write-to-db-static-copy
    uiSchema:
      ui:order:
        - '*'
++variables:
++  schema:
++    properties: {}
++    type: object

--- a/end-to-end-tests/tests/pageEditor/copyMod.spec.ts-snapshots/run-a-copied-mod-with-a-built-in-integration/giphy-search-copy.diff
+++ b/end-to-end-tests/tests/pageEditor/copyMod.spec.ts-snapshots/run-a-copied-mod-with-a-built-in-integration/giphy-search-copy.diff
@@ -2,7 +2,7 @@ Index: giphy-search-copy
 ===================================================================
 --- giphy-search-copy
 +++ giphy-search-copy
-@@ -83,51 +83,52 @@
+@@ -83,51 +83,56 @@
                                  element: !defer 
                                    children:
                                      - config:
@@ -57,3 +57,7 @@ Index: giphy-search-copy
    uiSchema:
      ui:order:
        - '*'
++variables:
++  schema:
++    properties: {}
++    type: object

--- a/end-to-end-tests/tests/pageEditor/modEditorPane.spec.ts-snapshots/mod-editor-pane-behavior/updated-inputs.diff
+++ b/end-to-end-tests/tests/pageEditor/modEditorPane.spec.ts-snapshots/mod-editor-pane-behavior/updated-inputs.diff
@@ -2,7 +2,7 @@ Index: updated-inputs
 ===================================================================
 --- updated-inputs
 +++ updated-inputs
-@@ -30,45 +30,56 @@
+@@ -30,49 +30,60 @@
                                heading: h1
                                title: !nunjucks Simple Sidebar Panel
                              type: header
@@ -60,3 +60,7 @@ Index: updated-inputs
      ui:order:
 +      - testField
        - '*'
+ variables:
+   schema:
+     properties: {}
+     type: object

--- a/end-to-end-tests/tests/pageEditor/modEditorPane.spec.ts-snapshots/mod-editor-pane-behavior/updated-metadata.diff
+++ b/end-to-end-tests/tests/pageEditor/modEditorPane.spec.ts-snapshots/mod-editor-pane-behavior/updated-metadata.diff
@@ -2,7 +2,7 @@ Index: updated-metadata
 ===================================================================
 --- updated-metadata
 +++ updated-metadata
-@@ -23,52 +23,52 @@
+@@ -23,52 +23,56 @@
        body:
          - config:
              body:
@@ -58,3 +58,7 @@ Index: updated-metadata
    uiSchema:
      ui:order:
        - '*'
++variables:
++  schema:
++    properties: {}
++    type: object

--- a/src/analysis/ReduxAnalysisManager.ts
+++ b/src/analysis/ReduxAnalysisManager.ts
@@ -17,13 +17,13 @@
 
 import {
   selectActiveModComponentFormState,
-  selectGetOptionsArgsForModId,
+  selectGetModDraftStateForModId,
 } from "@/pageEditor/store/editor/editorSelectors";
 import {
   type AnyAction,
+  createListenerMiddleware,
   type ListenerEffect,
   type ThunkDispatch,
-  createListenerMiddleware,
 } from "@reduxjs/toolkit";
 import analysisSlice from "./analysisSlice";
 import {
@@ -105,7 +105,7 @@ class ReduxAnalysisManager {
           return;
         }
 
-        const getOptionsArgsForModId = selectGetOptionsArgsForModId(state);
+        const getModDraftStateForModId = selectGetModDraftStateForModId(state);
 
         const analysis = await analysisFactory(action, state);
         if (!analysis) {
@@ -122,11 +122,12 @@ class ReduxAnalysisManager {
         );
 
         try {
-          await analysis.run(activeModComponentFormState, {
-            optionsArgs: getOptionsArgsForModId(
+          await analysis.run(
+            activeModComponentFormState,
+            getModDraftStateForModId(
               activeModComponentFormState.modMetadata.id,
             ),
-          });
+          );
         } catch (error) {
           listenerApi.dispatch(
             analysisSlice.actions.failAnalysis({

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -17,8 +17,8 @@
 
 import VarAnalysis, {
   INVALID_VARIABLE_GENERIC_MESSAGE,
-  VARIABLE_SHOULD_START_WITH_AT_MESSAGE,
   NO_VARIABLE_PROVIDED_MESSAGE,
+  VARIABLE_SHOULD_START_WITH_AT_MESSAGE,
 } from "./varAnalysis";
 import { validateRegistryId } from "@/types/helpers";
 import { BrickTypes, validateOutputKey } from "@/runtime/runtimeTypes";
@@ -42,6 +42,7 @@ import { type Schema } from "@/types/schemaTypes";
 import { integrationConfigLocator } from "@/background/messenger/api";
 import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 import {
+  draftModStateFactory,
   formStateFactory,
   triggerFormStateFactory,
 } from "@/testUtils/factories/pageEditorFactories";
@@ -153,9 +154,12 @@ describe("Collecting available vars", () => {
         brickPipeline: [brickConfigFactory()],
       });
 
-      await analysis.run(formState, {
-        optionsArgs: { foo: "bar" },
-      });
+      await analysis.run(
+        formState,
+        draftModStateFactory({
+          optionsArgs: { foo: "bar" },
+        }),
+      );
 
       const knownVars = analysis.getKnownVars();
       expect(knownVars.size).toBe(1);
@@ -189,7 +193,7 @@ describe("Collecting available vars", () => {
         ],
       });
 
-      await analysis.run(formState, { optionsArgs: {} });
+      await analysis.run(formState, draftModStateFactory());
 
       const block0Vars = analysis
         .getKnownVars()
@@ -218,7 +222,7 @@ describe("Collecting available vars", () => {
         ],
       });
 
-      await analysis.run(formState, { optionsArgs: {} });
+      await analysis.run(formState, draftModStateFactory());
 
       const block0Vars = analysis
         .getKnownVars()
@@ -245,7 +249,7 @@ describe("Collecting available vars", () => {
         brickPipeline: [brickConfigFactory()],
       });
 
-      await analysis.run(formState, { optionsArgs: {} });
+      await analysis.run(formState, draftModStateFactory());
 
       const foundationKnownVars = analysis
         .getKnownVars()
@@ -267,7 +271,7 @@ describe("Collecting available vars", () => {
         brickPipeline: [brickConfigFactory()],
       });
 
-      await analysis.run(formState, { optionsArgs: {} });
+      await analysis.run(formState, draftModStateFactory());
 
       const foundationKnownVars = analysis
         .getKnownVars()
@@ -297,7 +301,7 @@ describe("Collecting available vars", () => {
         brickPipeline: [brickConfigFactory()],
       });
 
-      await analysis.run(formState, { optionsArgs: {} });
+      await analysis.run(formState, draftModStateFactory());
 
       const foundationKnownVars = analysis
         .getKnownVars()
@@ -326,7 +330,7 @@ describe("Collecting available vars", () => {
         brickPipeline: [brickConfigFactory()],
       });
 
-      await analysis.run(formState, { optionsArgs: {} });
+      await analysis.run(formState, draftModStateFactory());
 
       const foundationKnownVars = analysis
         .getKnownVars()
@@ -356,12 +360,15 @@ describe("Collecting available vars", () => {
         brickPipeline: [brickConfigFactory()],
       });
 
-      await analysis.run(formState, {
-        optionsArgs: {
-          bar: "qux",
-          baz: "quux",
-        },
-      });
+      await analysis.run(
+        formState,
+        draftModStateFactory({
+          optionsArgs: {
+            bar: "qux",
+            baz: "quux",
+          },
+        }),
+      );
 
       const foundationKnownVars = analysis
         .getKnownVars()
@@ -397,7 +404,7 @@ describe("Collecting available vars", () => {
         brickPipeline: [brickConfigFactory()],
       });
 
-      await analysis.run(formState, { optionsArgs: {} });
+      await analysis.run(formState, draftModStateFactory());
 
       const knownVars = analysis.getKnownVars();
 
@@ -427,11 +434,14 @@ describe("Collecting available vars", () => {
         brickPipeline: [brickConfigFactory()],
       });
 
-      await analysis.run(formState, {
-        optionsArgs: {
-          foo: "bar",
-        },
-      });
+      await analysis.run(
+        formState,
+        draftModStateFactory({
+          optionsArgs: {
+            foo: "bar",
+          },
+        }),
+      );
 
       const knownVars = analysis.getKnownVars();
 
@@ -469,7 +479,7 @@ describe("Collecting available vars", () => {
         ]) as any,
       );
 
-      await analysis.run(formState, { optionsArgs: {} });
+      await analysis.run(formState, draftModStateFactory());
 
       return analysis.getKnownVars().get("modComponent.brickPipeline.1");
     }
@@ -753,7 +763,7 @@ describe("Collecting available vars", () => {
         brickPipeline: [ifElseBlock, brickConfigFactory()],
       });
 
-      await analysis.run(formState, { optionsArgs: {} });
+      await analysis.run(formState, draftModStateFactory());
     });
 
     test("adds if-else output after the brick", async () => {
@@ -820,7 +830,7 @@ describe("Collecting available vars", () => {
       });
 
       analysis = new VarAnalysis();
-      await analysis.run(formState, { optionsArgs: {} });
+      await analysis.run(formState, draftModStateFactory());
 
       const knownVars = analysis.getKnownVars();
       const varMap = knownVars.get("modComponent.brickPipeline.1")!;
@@ -866,7 +876,7 @@ describe("Collecting available vars", () => {
       });
 
       analysis = new VarAnalysis();
-      await analysis.run(formState, { optionsArgs: {} });
+      await analysis.run(formState, draftModStateFactory());
     });
 
     test("adds the list element key list body", () => {
@@ -936,7 +946,7 @@ describe("Collecting available vars", () => {
       });
 
       analysis = new VarAnalysis();
-      await analysis.run(formState, { optionsArgs: {} });
+      await analysis.run(formState, draftModStateFactory());
     });
 
     test("adds the list element key list body", () => {
@@ -985,7 +995,7 @@ describe("Collecting available vars", () => {
       });
 
       analysis = new VarAnalysis();
-      await analysis.run(formState, { optionsArgs: {} });
+      await analysis.run(formState, draftModStateFactory());
     });
 
     test("adds the error key to the except branch", () => {
@@ -1024,7 +1034,7 @@ describe("Collecting available vars", () => {
       });
 
       analysis = new VarAnalysis();
-      await analysis.run(formState, { optionsArgs: {} });
+      await analysis.run(formState, draftModStateFactory());
     });
 
     test("adds the element key to the sub pipeline", () => {
@@ -1059,7 +1069,7 @@ describe("Collecting available vars", () => {
       });
 
       analysis = new VarAnalysis();
-      await analysis.run(formState, { optionsArgs: {} });
+      await analysis.run(formState, draftModStateFactory());
     });
 
     test("adds for-each output after the brick", () => {
@@ -1161,7 +1171,7 @@ describe("Collecting available vars", () => {
       );
 
       analysis = new VarAnalysis();
-      await analysis.run(formState, { optionsArgs: {} });
+      await analysis.run(formState, draftModStateFactory());
     });
 
     test("adds the `values` to the onsubmit handler", () => {
@@ -1216,11 +1226,11 @@ describe("Invalid template", () => {
   });
 
   test("analysis doesn't throw", async () => {
-    await expect(analysis.run(formState, { optionsArgs: {} })).toResolve();
+    await expect(analysis.run(formState, draftModStateFactory())).toResolve();
   });
 
   test("analysis doesn't annotate invalid template", async () => {
-    await analysis.run(formState, { optionsArgs: {} });
+    await analysis.run(formState, draftModStateFactory());
     const annotations = analysis.getAnnotations();
 
     // Only the second (index = 1) block should be annotated
@@ -1248,7 +1258,7 @@ describe("var expression annotations", () => {
     });
 
     const analysis = new VarAnalysis();
-    await analysis.run(formState, { optionsArgs: {} });
+    await analysis.run(formState, draftModStateFactory());
 
     expect(analysis.getAnnotations()).toHaveLength(0);
   });
@@ -1266,7 +1276,7 @@ describe("var expression annotations", () => {
     });
 
     const analysis = new VarAnalysis();
-    await analysis.run(formState, { optionsArgs: {} });
+    await analysis.run(formState, draftModStateFactory());
 
     expect(analysis.getAnnotations()).toHaveLength(0);
   });
@@ -1284,7 +1294,7 @@ describe("var expression annotations", () => {
     });
 
     const analysis = new VarAnalysis();
-    await analysis.run(formState, { optionsArgs: {} });
+    await analysis.run(formState, draftModStateFactory());
 
     const annotations = analysis.getAnnotations();
     expect(annotations).toHaveLength(1);
@@ -1306,7 +1316,7 @@ describe("var expression annotations", () => {
     });
 
     const analysis = new VarAnalysis();
-    await analysis.run(formState, { optionsArgs: {} });
+    await analysis.run(formState, draftModStateFactory());
 
     const annotations = analysis.getAnnotations();
     expect(annotations).toHaveLength(1);
@@ -1326,7 +1336,7 @@ describe("var expression annotations", () => {
     });
 
     const analysis = new VarAnalysis();
-    await analysis.run(formState, { optionsArgs: {} });
+    await analysis.run(formState, draftModStateFactory());
 
     const annotations = analysis.getAnnotations();
     expect(annotations).toHaveLength(1);
@@ -1351,7 +1361,7 @@ describe("var analysis integration tests", () => {
     formState.starterBrick.definition.trigger = "keypress";
 
     const analysis = new VarAnalysis();
-    await analysis.run(formState, { optionsArgs: {} });
+    await analysis.run(formState, draftModStateFactory());
 
     const annotations = analysis.getAnnotations();
     expect(annotations).toHaveLength(0);
@@ -1373,7 +1383,7 @@ describe("var analysis integration tests", () => {
     formState.starterBrick.definition.trigger = "custom";
 
     const analysis = new VarAnalysis();
-    await analysis.run(formState, { optionsArgs: {} });
+    await analysis.run(formState, draftModStateFactory());
 
     const annotations = analysis.getAnnotations();
     expect(annotations).toHaveLength(0);
@@ -1396,7 +1406,7 @@ describe("var analysis integration tests", () => {
     formState.starterBrick.definition.trigger = "selectionchange";
 
     const analysis = new VarAnalysis();
-    await analysis.run(formState, { optionsArgs: {} });
+    await analysis.run(formState, draftModStateFactory());
 
     const annotations = analysis.getAnnotations();
     expect(annotations).toHaveLength(1);

--- a/src/components/fields/schemaFields/integrations/integrationDependencyFieldUtils.test.ts
+++ b/src/components/fields/schemaFields/integrations/integrationDependencyFieldUtils.test.ts
@@ -31,10 +31,7 @@ import { validateOutputKey } from "@/runtime/runtimeTypes";
 import { toExpression } from "@/utils/expressionUtils";
 import { normalizeAvailability } from "@/bricks/available";
 import { StarterBrickTypes } from "@/types/starterBrickTypes";
-import {
-  createNewUnsavedModMetadata,
-  emptyModVariablesDefinitionFactory,
-} from "@/utils/modUtils";
+import { createNewUnsavedModMetadata } from "@/utils/modUtils";
 
 describe("selectVariables", () => {
   test("selects nothing when no services used", () => {
@@ -225,7 +222,6 @@ describe("selectVariables", () => {
         }),
       ],
       permissions: emptyPermissionsFactory(),
-      variablesDefinition: emptyModVariablesDefinitionFactory(),
       modMetadata: createNewUnsavedModMetadata({ modName: "Document Mod" }),
       modComponent: {
         brickPipeline: [

--- a/src/components/fields/schemaFields/widgets/varPopup/VarMenu.test.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarMenu.test.tsx
@@ -18,7 +18,10 @@
 import { render, screen } from "@/pageEditor/testHelpers";
 import React, { type MutableRefObject } from "react";
 import VarMenu from "@/components/fields/schemaFields/widgets/varPopup/VarMenu";
-import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
+import {
+  draftModStateFactory,
+  formStateFactory,
+} from "@/testUtils/factories/pageEditorFactories";
 import { actions as editorActions } from "@/pageEditor/store/editor/editorSlice";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import registerBuiltinBricks from "@/bricks/registerBuiltinBricks";
@@ -116,7 +119,7 @@ describe("VarMenu", () => {
 
           // Run analysis directly
           const analysis = new VarAnalysis();
-          await analysis.run(formState, { optionsArgs: {} });
+          await analysis.run(formState, draftModStateFactory());
 
           dispatch(
             analysisSlice.actions.setKnownVars({
@@ -161,7 +164,7 @@ describe("VarMenu", () => {
 
           // Run analysis directly
           const analysis = new VarAnalysis();
-          await analysis.run(formState, { optionsArgs: {} });
+          await analysis.run(formState, draftModStateFactory());
 
           dispatch(
             analysisSlice.actions.setKnownVars({

--- a/src/components/fields/schemaFields/widgets/varPopup/getMenuOptions.test.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/getMenuOptions.test.ts
@@ -26,7 +26,10 @@ import VarMap, {
 } from "@/analysis/analysisVisitors/varAnalysis/varMap";
 import getMenuOptions from "./getMenuOptions";
 import { type JsonObject } from "type-fest";
-import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
+import {
+  draftModStateFactory,
+  formStateFactory,
+} from "@/testUtils/factories/pageEditorFactories";
 import { brickConfigFactory } from "@/testUtils/factories/brickFactories";
 import registerBuiltinBricks from "@/bricks/registerBuiltinBricks";
 
@@ -182,7 +185,7 @@ describe("mod variables", () => {
     const formState = formStateFactory({
       brickPipeline: [brickConfigFactory()],
     });
-    await analysis.run(formState, { optionsArgs: {} });
+    await analysis.run(formState, draftModStateFactory());
 
     const knownVars = analysis
       .getKnownVars()

--- a/src/pageEditor/editorPermissionsHelpers.ts
+++ b/src/pageEditor/editorPermissionsHelpers.ts
@@ -26,6 +26,7 @@ import notify from "@/utils/notify";
 import { type Permissions } from "webextension-polyfill";
 import { castArray } from "lodash";
 import { adapterForComponent } from "@/pageEditor/starterBricks/adapter";
+import { emptyModVariablesDefinitionFactory } from "@/utils/modUtils";
 
 export async function calculatePermissionsForModComponentFormState(
   modComponentFormState: ModComponentFormState,
@@ -34,8 +35,11 @@ export async function calculatePermissionsForModComponentFormState(
 
   const { modComponent, starterBrickDefinition } = asDraftModComponent(
     modComponentFormState,
-    // Safe to pass empty `optionsArgs` because they don't affect permissions calculations
-    { optionsArgs: {} },
+    // Safe to pass empty `optionsArgs` and `variablesDefinition` because they don't affect permissions calculations
+    {
+      optionsArgs: {},
+      variablesDefinition: emptyModVariablesDefinitionFactory(),
+    },
   );
 
   const starterBrick = starterBrickFactory(starterBrickDefinition);

--- a/src/pageEditor/hooks/useAddNewModComponent.ts
+++ b/src/pageEditor/hooks/useAddNewModComponent.ts
@@ -41,7 +41,7 @@ import { useInsertPane } from "@/pageEditor/panes/insert/InsertPane";
 import { type ModMetadata } from "@/types/modComponentTypes";
 import { createNewUnsavedModMetadata } from "@/utils/modUtils";
 import {
-  selectGetOptionsArgsForModId,
+  selectGetModDraftStateForModId,
   selectModMetadatas,
 } from "@/pageEditor/store/editor/editorSelectors";
 import { RunReason } from "@/types/runtimeTypes";
@@ -80,7 +80,7 @@ function useAddNewModComponent(modMetadata?: ModMetadata): AddNewModComponent {
 
   const generateFreshModName = useFreshModNameGenerator();
 
-  const getOptionsArgsForModId = useSelector(selectGetOptionsArgsForModId);
+  const getModDraftStateForModId = useSelector(selectGetModDraftStateForModId);
 
   const getInitialModComponentFormState = useCallback(
     async ({
@@ -136,11 +136,10 @@ function useAddNewModComponent(modMetadata?: ModMetadata): AddNewModComponent {
 
         updateDraftModComponent(
           allFramesInInspectedTab,
-          adapter.asDraftModComponent(initialFormState, {
-            optionsArgs: getOptionsArgsForModId(
-              initialFormState.modMetadata.id,
-            ),
-          }),
+          adapter.asDraftModComponent(
+            initialFormState,
+            getModDraftStateForModId(initialFormState.modMetadata.id),
+          ),
           {
             isSelectedInEditor: true,
             runReason: RunReason.PAGE_EDITOR_REGISTER,
@@ -178,7 +177,7 @@ function useAddNewModComponent(modMetadata?: ModMetadata): AddNewModComponent {
       dispatch,
       flagOff,
       getInitialModComponentFormState,
-      getOptionsArgsForModId,
+      getModDraftStateForModId,
       modMetadata,
     ],
   );

--- a/src/pageEditor/hooks/useBuildAndValidateMod.ts
+++ b/src/pageEditor/hooks/useBuildAndValidateMod.ts
@@ -54,6 +54,7 @@ function useBuildAndValidateMod(): UseBuildAndValidateModReturn {
       draftModComponents,
       dirtyModOptionsDefinition,
       dirtyModMetadata,
+      dirtyModVariablesDefinition,
     }: ModParts) => {
       if (draftModComponents.length === 0) {
         throw new Error("Expected mod components to save");
@@ -64,6 +65,7 @@ function useBuildAndValidateMod(): UseBuildAndValidateModReturn {
         draftModComponents,
         dirtyModOptionsDefinition,
         dirtyModMetadata,
+        dirtyModVariablesDefinition,
       });
 
       if (sourceModDefinition) {

--- a/src/pageEditor/hooks/useClearModChanges.ts
+++ b/src/pageEditor/hooks/useClearModChanges.ts
@@ -21,7 +21,7 @@ import { actions as editorActions } from "@/pageEditor/store/editor/editorSlice"
 import { useModals } from "@/components/ConfirmationModal";
 import { useDispatch, useSelector } from "react-redux";
 import useClearModComponentChanges from "@/pageEditor/hooks/useClearModComponentChanges";
-import { selectGetModComponentFormStatesByModId } from "@/pageEditor/store/editor/editorSelectors";
+import { selectGetModComponentFormStatesForMod } from "@/pageEditor/store/editor/editorSelectors";
 
 /**
  * Hook that returns a callback to clear unsaved mod changes for a given mod id.
@@ -32,7 +32,7 @@ function useClearModChanges(): (modId: RegistryId) => Promise<void> {
   const dispatch = useDispatch();
   const clearModComponentChanges = useClearModComponentChanges();
   const getModComponentFormStatesByModId = useSelector(
-    selectGetModComponentFormStatesByModId,
+    selectGetModComponentFormStatesForMod,
   );
 
   return useCallback(

--- a/src/pageEditor/hooks/useRegisterDraftModInstanceOnAllFrames.ts
+++ b/src/pageEditor/hooks/useRegisterDraftModInstanceOnAllFrames.ts
@@ -18,7 +18,7 @@
 import { useEffect } from "react";
 import {
   formStateToDraftModComponent,
-  modComponentToFormState,
+  selectGetDraftFormStatesPromiseForModId,
   selectType,
 } from "@/pageEditor/starterBricks/adapter";
 import {
@@ -33,7 +33,6 @@ import {
   selectActiveModComponentId,
   selectCurrentModId,
   selectEditorUpdateKey,
-  selectGetCleanComponentsAndDirtyFormStatesForMod,
   selectGetModDraftStateForModId,
 } from "@/pageEditor/store/editor/editorSelectors";
 import { StarterBrickTypes } from "@/types/starterBrickTypes";
@@ -124,21 +123,9 @@ function updateDraftModInstance() {
     // NOTE: logic accounts for activated mod components that have been deleted. But it does not account for
     // unsaved draft mod component that have been deleted since the last injection. The draft mod component
     // deletion code is currently responsible for removing those from the tab
-    const getModDraftStateForModId = useSelector(
-      selectGetModDraftStateForModId,
-    );
-    const getEditorInstance =
-      selectGetCleanComponentsAndDirtyFormStatesForMod(state);
-    const editorInstance = getEditorInstance(modId);
-
-    const { cleanModComponents, dirtyModComponentFormStates } = editorInstance;
-
-    const draftFormStates = [
-      ...(await Promise.all(
-        cleanModComponents.map(async (x) => modComponentToFormState(x)),
-      )),
-      ...dirtyModComponentFormStates,
-    ];
+    const getModDraftStateForModId = selectGetModDraftStateForModId(state);
+    const draftFormStates =
+      await selectGetDraftFormStatesPromiseForModId(state)(modId);
 
     for (const draftFormState of draftFormStates) {
       const isSelectedInEditor = activeModComponentId === draftFormState.uuid;

--- a/src/pageEditor/hooks/useRegisterDraftModInstanceOnAllFrames.ts
+++ b/src/pageEditor/hooks/useRegisterDraftModInstanceOnAllFrames.ts
@@ -34,7 +34,7 @@ import {
   selectCurrentModId,
   selectEditorUpdateKey,
   selectGetCleanComponentsAndDirtyFormStatesForMod,
-  selectGetOptionsArgsForModId,
+  selectGetModDraftStateForModId,
 } from "@/pageEditor/store/editor/editorSelectors";
 import { StarterBrickTypes } from "@/types/starterBrickTypes";
 import { selectModInstanceMap } from "@/store/modComponents/modInstanceSelectors";
@@ -124,7 +124,9 @@ function updateDraftModInstance() {
     // NOTE: logic accounts for activated mod components that have been deleted. But it does not account for
     // unsaved draft mod component that have been deleted since the last injection. The draft mod component
     // deletion code is currently responsible for removing those from the tab
-    const getOptionsArgsForModId = selectGetOptionsArgsForModId(state);
+    const getModDraftStateForModId = useSelector(
+      selectGetModDraftStateForModId,
+    );
     const getEditorInstance =
       selectGetCleanComponentsAndDirtyFormStatesForMod(state);
     const editorInstance = getEditorInstance(modId);
@@ -143,9 +145,10 @@ function updateDraftModInstance() {
 
       // Skip is component is active -- ReloadToolbar handles running the selected draft mod component
       if (!isSelectedInEditor) {
-        const draftModComponent = formStateToDraftModComponent(draftFormState, {
-          optionsArgs: getOptionsArgsForModId(modId),
-        });
+        const draftModComponent = formStateToDraftModComponent(
+          draftFormState,
+          getModDraftStateForModId(modId),
+        );
 
         // PERFORMANCE: only re-register if the component's state has changed. It would technically be safe to
         // updateDraftModComponent on every change to the mod (even for different mod components), but computing the
@@ -193,7 +196,7 @@ function useRegisterDraftModInstanceOnAllFrames(): void {
   const modInstanceMap = useSelector(selectModInstanceMap);
   const activatedModInstance = modInstanceMap.get(modId);
 
-  const getOptionsArgsForModId = useSelector(selectGetOptionsArgsForModId);
+  const getModDraftStateForModId = useSelector(selectGetModDraftStateForModId);
 
   // Remove non-draft mod instance from the page. removeActivatedModInstanceFromTab is safe to call multiple times
   // per mod instance (it's a NOP if the mod instance is registered in a frame).
@@ -214,9 +217,11 @@ function useRegisterDraftModInstanceOnAllFrames(): void {
   // Register draft mod component on select. From there, ReloadToolbar will control re-running the mod component.
   // Currently, registering on select is to stop interval triggers from running when selected.
   useOnSelectModComponent(async (draftFormState) => {
-    const draftModComponent = formStateToDraftModComponent(draftFormState, {
-      optionsArgs: getOptionsArgsForModId(draftFormState.modMetadata.id),
-    });
+    const draftModComponent = formStateToDraftModComponent(
+      draftFormState,
+      getModDraftStateForModId(draftFormState.modMetadata.id),
+    );
+
     updateDraftModComponent(allFramesInInspectedTab, draftModComponent, {
       isSelectedInEditor: true,
       runReason: RunReason.PAGE_EDITOR_REGISTER,

--- a/src/pageEditor/hooks/useSaveMod.test.ts
+++ b/src/pageEditor/hooks/useSaveMod.test.ts
@@ -239,7 +239,7 @@ describe("useSaveMod", () => {
         );
         dispatch(editorSlice.actions.setActiveModId(modId));
         dispatch(
-          editorSlice.actions.editModOptionsDefinitions({
+          editorSlice.actions.editModOptionsDefinition({
             schema: {
               type: "object",
               properties: {

--- a/src/pageEditor/hooks/useSaveMod.test.ts
+++ b/src/pageEditor/hooks/useSaveMod.test.ts
@@ -93,13 +93,12 @@ describe("useSaveMod", () => {
 
     appApiMock.onGet(API_PATHS.BRICKS).reply(200, [editablePackage]);
 
-    const putMock = appApiMock
+    appApiMock
       .onPut(API_PATHS.BRICK(editablePackage.id))
       .reply(200, packageUpsertResponseFactory(editablePackage));
 
     return {
       modDefinition,
-      putMock,
     };
   }
 
@@ -130,7 +129,7 @@ describe("useSaveMod", () => {
   });
 
   it("preserves original options if no dirty options", async () => {
-    const { modDefinition, putMock } = setupModDefinitionMocks({
+    const { modDefinition } = setupModDefinitionMocks({
       options: {
         schema: {
           type: "object",
@@ -167,7 +166,7 @@ describe("useSaveMod", () => {
 
     const yamlConfig = (
       JSON.parse(
-        putMock.history.put[0]!.data,
+        appApiMock.history.put[0]!.data,
       ) as components["schemas"]["Package"]
     ).config;
 
@@ -184,7 +183,7 @@ describe("useSaveMod", () => {
   });
 
   it("saves dirty options", async () => {
-    const { modDefinition, putMock } = setupModDefinitionMocks();
+    const { modDefinition } = setupModDefinitionMocks();
 
     const { result, waitForEffect } = renderHook(() => useSaveMod(), {
       setupRedux(dispatch) {
@@ -223,7 +222,7 @@ describe("useSaveMod", () => {
 
     const yamlConfig = (
       JSON.parse(
-        putMock.history.put[0]!.data,
+        appApiMock.history.put[0]!.data,
       ) as components["schemas"]["Package"]
     ).config;
 
@@ -243,7 +242,7 @@ describe("useSaveMod", () => {
   });
 
   it("saves dirty mod variable definitions", async () => {
-    const { modDefinition, putMock } = setupModDefinitionMocks();
+    const { modDefinition } = setupModDefinitionMocks();
 
     const { result, waitForEffect } = renderHook(() => useSaveMod(), {
       setupRedux(dispatch) {
@@ -274,7 +273,7 @@ describe("useSaveMod", () => {
 
     const yamlConfig = (
       JSON.parse(
-        putMock.history.put[0]!.data,
+        appApiMock.history.put[0]!.data,
       ) as components["schemas"]["Package"]
     ).config;
 

--- a/src/pageEditor/modListingPanel/ModComponentActionMenu.stories.tsx
+++ b/src/pageEditor/modListingPanel/ModComponentActionMenu.stories.tsx
@@ -48,6 +48,7 @@ const Template: ComponentStory<StoryArgs> = (args: { isDirty?: boolean }) => {
     editor: {
       dirty: isDirty ? { [modComponentFormState.uuid]: true } : {},
       modComponentFormStates: [modComponentFormState],
+      deletedModComponentFormStatesByModId: {},
       brickPipelineUIStateById: {
         [modComponentFormState.uuid]: {
           pipelineMap: getPipelineMap(

--- a/src/pageEditor/modListingPanel/ModComponentActionMenu.stories.tsx
+++ b/src/pageEditor/modListingPanel/ModComponentActionMenu.stories.tsx
@@ -48,7 +48,7 @@ const Template: ComponentStory<StoryArgs> = (args: { isDirty?: boolean }) => {
     editor: {
       dirty: isDirty ? { [modComponentFormState.uuid]: true } : {},
       modComponentFormStates: [modComponentFormState],
-      deletedModComponentFormStatesByModId: {},
+      deletedModComponentFormStateIdsByModId: {},
       brickPipelineUIStateById: {
         [modComponentFormState.uuid]: {
           pipelineMap: getPipelineMap(

--- a/src/pageEditor/modals/addBrickModal/useAddBrick.ts
+++ b/src/pageEditor/modals/addBrickModal/useAddBrick.ts
@@ -26,7 +26,7 @@ import { useDispatch, useSelector } from "react-redux";
 import {
   getModalDataSelector,
   selectActiveModComponentFormState,
-  selectGetOptionsArgsForModId,
+  selectGetModDraftStateForModId,
   selectPipelineMap,
 } from "@/pageEditor/store/editor/editorSelectors";
 import { selectSessionId } from "@/pageEditor/store/session/sessionSelectors";
@@ -64,7 +64,7 @@ function useAddBrick(): AddBrick {
   const dispatch = useDispatch();
   const sessionId = useSelector(selectSessionId);
   const activeModComponent = useSelector(selectActiveModComponentFormState);
-  const getOptionsArgsForModId = useSelector(selectGetOptionsArgsForModId);
+  const getModDraftStateForModId = useSelector(selectGetModDraftStateForModId);
   const pipelineMap = useSelector(selectPipelineMap);
   const modalData = useSelector(getModalDataSelector(ModalKey.ADD_BRICK));
 
@@ -119,11 +119,10 @@ function useAddBrick(): AddBrick {
       const analyses = makeBrickLevelAnalyses();
       const annotationSets = await Promise.all(
         analyses.map(async (analysis) => {
-          await analysis.run(newModComponent, {
-            optionsArgs: getOptionsArgsForModId(
-              activeModComponent.modMetadata.id,
-            ),
-          });
+          await analysis.run(
+            newModComponent,
+            getModDraftStateForModId(activeModComponent.modMetadata.id),
+          );
           return analysis.getAnnotations();
         }),
       );

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -49,6 +49,7 @@ import {
 import { integrationDependencyFactory } from "@/testUtils/factories/integrationFactories";
 import { normalizeModDefinition } from "@/utils/modUtils";
 import { adapter } from "@/pageEditor/starterBricks/adapter";
+import { array } from "cooky-cutter";
 
 jest.mock("@/pageEditor/starterBricks/base", () => ({
   ...jest.requireActual("@/pageEditor/starterBricks/base"),
@@ -182,12 +183,7 @@ describe("buildNewMod", () => {
 
   test("Delete excess starter brick definitions", async () => {
     // Load the adapter for this mod component
-    const starterBricks = [
-      starterBrickInnerDefinitionFactory(),
-      starterBrickInnerDefinitionFactory(),
-      // Excess
-      starterBrickInnerDefinitionFactory(),
-    ];
+    const starterBricks = array(starterBrickInnerDefinitionFactory, 3)();
 
     const modComponents = starterBricks.slice(0, 2).map((starterBrick) => {
       const modComponent = modComponentFactory({

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -140,13 +140,15 @@ const emptyModDefinition: UnsavedModDefinition = {
 
 function mapModComponentFormStateToModComponentBase(
   modComponentFormState: ModComponentFormState,
-): Except<ModComponentBase, "variablesDefinition"> {
+): Except<ModComponentBase, "variablesDefinition" | "optionsArgs"> {
   const { selectModComponent, selectStarterBrickDefinition } =
     adapterForComponent(modComponentFormState);
 
   const unsavedModComponent = selectModComponent(modComponentFormState, {
-    // Activation-time optionsArgs are not relevant for mod component definitions
+    // Activation-time `optionsArgs` are not relevant for mod component definitions
     optionsArgs: {},
+    // Mod-level `variablesDefinition` are not relevant for mod component definitions
+    variablesDefinition: emptyModVariablesDefinitionFactory(),
   });
 
   if (isInnerDefinitionRegistryId(unsavedModComponent.extensionPointId)) {

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -219,7 +219,7 @@ export function buildNewMod({
     }
 
     if (dirtyModVariablesDefinition) {
-      draft.options = dirtyModVariablesDefinition;
+      draft.variables = dirtyModVariablesDefinition;
     }
 
     if (dirtyModMetadata) {

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -38,6 +38,7 @@ import {
   type ModComponentDefinition,
   type ModDefinition,
   type ModOptionsDefinition,
+  type ModVariablesDefinition,
   type UnsavedModDefinition,
 } from "@/types/modDefinitionTypes";
 import {
@@ -62,6 +63,7 @@ import {
   getDraftModComponentId,
   isModComponentFormState,
 } from "@/pageEditor/utils";
+import type { Except } from "type-fest";
 
 /**
  * Generate a new registry id from an existing registry id by adding/replacing the scope.
@@ -109,9 +111,13 @@ export type ModParts = {
    */
   sourceModDefinition?: ModDefinition;
   /**
-   * Dirty/new options to save. Undefined if there are no changes.
+   * Dirty/new option definition to save. Undefined if there are no changes.
    */
   dirtyModOptionsDefinition?: ModOptionsDefinition;
+  /**
+   * Dirty/new mod variables definition to save. Undefined if there are no changes.
+   */
+  dirtyModVariablesDefinition?: ModVariablesDefinition;
   /**
    * Dirty/new metadata to save. Undefined if there are no changes.
    */
@@ -134,7 +140,7 @@ const emptyModDefinition: UnsavedModDefinition = {
 
 function mapModComponentFormStateToModComponentBase(
   modComponentFormState: ModComponentFormState,
-): ModComponentBase {
+): Except<ModComponentBase, "variablesDefinition"> {
   const { selectModComponent, selectStarterBrickDefinition } =
     adapterForComponent(modComponentFormState);
 
@@ -167,12 +173,14 @@ function mapModComponentFormStateToModComponentBase(
  * @param sourceMod the original mod definition, or undefined for new mods
  * @param draftModComponents the activated mod components/form states to save. Must exclude deleted components
  * @param dirtyModOptionsDefinition the mod's option definition form state, or nullish if there are no dirty options
+ * @param dirtyModVariablesDefinition the mod's mod variables definition form state, or nullish if there are no dirty variables
  * @param dirtyModMetadata the mod's metadata form state, or nullish if there is no dirty mod metadata
  */
 export function buildNewMod({
   sourceModDefinition,
   draftModComponents,
   dirtyModOptionsDefinition,
+  dirtyModVariablesDefinition,
   dirtyModMetadata,
 }: ModParts): UnsavedModDefinition {
   // If there's no source mod, then we're creating a new one, so we
@@ -206,6 +214,10 @@ export function buildNewMod({
 
     if (dirtyModOptionsDefinition) {
       draft.options = normalizeModOptionsDefinition(dirtyModOptionsDefinition);
+    }
+
+    if (dirtyModVariablesDefinition) {
+      draft.options = dirtyModVariablesDefinition;
     }
 
     if (dirtyModMetadata) {

--- a/src/pageEditor/starterBricks/adapter.ts
+++ b/src/pageEditor/starterBricks/adapter.ts
@@ -36,7 +36,7 @@ import { assertNotNullish } from "@/utils/nullishUtils";
 import { compact, sortBy } from "lodash";
 import useAsyncState from "@/hooks/useAsyncState";
 import { flagOn } from "@/auth/featureFlagStorage";
-import { type OptionsArgs } from "@/types/runtimeTypes";
+import { type DraftModState } from "@/pageEditor/store/editor/pageEditorTypes";
 
 const ADAPTERS = new Map<StarterBrickType, ModComponentFormStateAdapter>([
   [StarterBrickTypes.TRIGGER, triggerModComponent],
@@ -131,7 +131,7 @@ export async function modComponentToFormState(
 
 export function formStateToDraftModComponent(
   modComponentFormState: ModComponentFormState,
-  options: { optionsArgs: OptionsArgs },
+  modState: DraftModState,
 ): DraftModComponent {
   const starterBrickType = modComponentFormState.starterBrick.definition.type;
   const adapter = ADAPTERS.get(starterBrickType);
@@ -139,5 +139,5 @@ export function formStateToDraftModComponent(
     adapter,
     `No adapter found for starter brick type: ${starterBrickType}`,
   );
-  return adapter.asDraftModComponent(modComponentFormState, options);
+  return adapter.asDraftModComponent(modComponentFormState, modState);
 }

--- a/src/pageEditor/starterBricks/adapter.ts
+++ b/src/pageEditor/starterBricks/adapter.ts
@@ -36,7 +36,13 @@ import { assertNotNullish } from "@/utils/nullishUtils";
 import { compact, sortBy } from "lodash";
 import useAsyncState from "@/hooks/useAsyncState";
 import { flagOn } from "@/auth/featureFlagStorage";
-import { type DraftModState } from "@/pageEditor/store/editor/pageEditorTypes";
+import {
+  type DraftModState,
+  type RootState,
+} from "@/pageEditor/store/editor/pageEditorTypes";
+import { selectGetDraftModComponentsForMod } from "@/pageEditor/store/editor/editorSelectors";
+import { type RegistryId } from "@/types/registryTypes";
+import { isModComponentBase } from "@/pageEditor/utils";
 
 const ADAPTERS = new Map<StarterBrickType, ModComponentFormStateAdapter>([
   [StarterBrickTypes.TRIGGER, triggerModComponent],
@@ -140,4 +146,17 @@ export function formStateToDraftModComponent(
     `No adapter found for starter brick type: ${starterBrickType}`,
   );
   return adapter.asDraftModComponent(modComponentFormState, modState);
+}
+
+export function selectGetDraftFormStatesPromiseForModId(state: RootState) {
+  return async (modId: RegistryId) => {
+    const getDraftModComponentsForMod =
+      selectGetDraftModComponentsForMod(state);
+
+    return Promise.all(
+      getDraftModComponentsForMod(modId).map(async (x) =>
+        isModComponentBase(x) ? modComponentToFormState(x) : x,
+      ),
+    );
+  };
 }

--- a/src/pageEditor/starterBricks/base.ts
+++ b/src/pageEditor/starterBricks/base.ts
@@ -56,7 +56,6 @@ import {
   type BaseModComponentState,
   type SingleLayerReaderConfig,
 } from "@/pageEditor/store/editor/baseFormStateTypes";
-import { emptyModVariablesDefinitionFactory } from "@/utils/modUtils";
 import {
   type Availability,
   type NormalizedAvailability,
@@ -122,7 +121,6 @@ export function baseFromModComponent<T extends StarterBrickType>(
   | "label"
   | "integrationDependencies"
   | "permissions"
-  | "variablesDefinition"
   | "modMetadata"
 > & { type: T } {
   return {
@@ -133,8 +131,6 @@ export function baseFromModComponent<T extends StarterBrickType>(
     // Normalize here because the fields aren't optional/nullable on the BaseFormState destination type.
     integrationDependencies: config.integrationDependencies ?? [],
     permissions: config.permissions ?? {},
-    variablesDefinition:
-      config.variablesDefinition ?? emptyModVariablesDefinitionFactory(),
     type,
     modMetadata: config.modMetadata,
   };
@@ -145,7 +141,6 @@ export function baseSelectModComponent(
     apiVersion,
     uuid,
     label,
-    variablesDefinition,
     integrationDependencies,
     permissions,
     starterBrick,
@@ -172,7 +167,6 @@ export function baseSelectModComponent(
     label,
     integrationDependencies,
     permissions,
-    variablesDefinition,
     optionsArgs: modState.optionsArgs,
   };
 }
@@ -190,7 +184,6 @@ export function makeInitialBaseState({
     modMetadata,
     integrationDependencies: [],
     permissions: emptyPermissionsFactory(),
-    variablesDefinition: emptyModVariablesDefinitionFactory(),
     modComponent: {
       brickPipeline: [],
     },

--- a/src/pageEditor/starterBricks/contextMenu.test.ts
+++ b/src/pageEditor/starterBricks/contextMenu.test.ts
@@ -18,6 +18,7 @@
 import config from "@/pageEditor/starterBricks/contextMenu";
 import { internalStarterBrickMetaFactory } from "@/pageEditor/starterBricks/base";
 import { createNewUnsavedModMetadata } from "@/utils/modUtils";
+import { draftModStateFactory } from "@/testUtils/factories/pageEditorFactories";
 
 describe("contextMenu", () => {
   it("smoke test", () => {
@@ -28,7 +29,9 @@ describe("contextMenu", () => {
       element: null,
     });
 
-    expect(config.selectModComponent(formState, { optionsArgs: {} })).toEqual(
+    expect(
+      config.selectModComponent(formState, draftModStateFactory()),
+    ).toEqual(
       expect.objectContaining({
         config: {
           action: [],

--- a/src/pageEditor/starterBricks/modComponentFormStateAdapter.ts
+++ b/src/pageEditor/starterBricks/modComponentFormStateAdapter.ts
@@ -29,8 +29,6 @@ import { type Target } from "@/types/messengerTypes";
 import { type BaseFormState } from "@/pageEditor/store/editor/baseFormStateTypes";
 import { type Nullishable } from "@/utils/nullishUtils";
 import { type FeatureFlag } from "@/auth/featureFlags";
-import { type OptionsArgs } from "@/types/runtimeTypes";
-
 import { type DraftModState } from "@/pageEditor/store/editor/pageEditorTypes";
 
 /**
@@ -107,8 +105,8 @@ export interface ModComponentFormStateAdapter<
    * Returns a draft mod component definition that the content script can render on the page
    */
   readonly asDraftModComponent: (
-    state: TState,
-    options: { optionsArgs: OptionsArgs },
+    modComponentFormState: TState,
+    modState: DraftModState,
   ) => DraftModComponent;
 
   /**

--- a/src/pageEditor/store/editor/baseFormStateTypes.ts
+++ b/src/pageEditor/store/editor/baseFormStateTypes.ts
@@ -256,7 +256,7 @@ export type BaseFormStateV7<
 /**
  * Base form state version that eliminates variablesDefinition because dirty variable definition should be tracked at
  * the mod-level instead of on the mod components.
- * @since 2.1.6
+ * @since 2.1.7
  */
 export type BaseFormStateV8<
   TModComponent extends BaseModComponentState = BaseModComponentState,

--- a/src/pageEditor/store/editor/baseFormStateTypes.ts
+++ b/src/pageEditor/store/editor/baseFormStateTypes.ts
@@ -253,12 +253,25 @@ export type BaseFormStateV7<
   TStarterBrick extends BaseStarterBrickState = BaseStarterBrickState,
 > = Except<BaseFormStateV6<TModComponent, TStarterBrick>, "optionsArgs">;
 
+/**
+ * Base form state version that eliminates variablesDefinition because dirty variable definition should be tracked at
+ * the mod-level instead of on the mod components.
+ * @since 2.1.6
+ */
+export type BaseFormStateV8<
+  TModComponent extends BaseModComponentState = BaseModComponentState,
+  TStarterBrick extends BaseStarterBrickState = BaseStarterBrickState,
+> = Except<
+  BaseFormStateV7<TModComponent, TStarterBrick>,
+  "variablesDefinition"
+>;
+
 export type BaseFormState<
   TModComponent extends BaseModComponentState = BaseModComponentState,
   TStarterBrick extends BaseStarterBrickState = BaseStarterBrickState,
 > = Except<
   // On migration, re-point this type to the most recent BaseFormStateV<N> type name
-  BaseFormStateV7<TModComponent, TStarterBrick>,
+  BaseFormStateV8<TModComponent, TStarterBrick>,
   // NOTE: overriding integrationDependencies is not changing the type shape/structure. It's just cleaning up the
   // type name/reference which makes types easier to work with for testing migrations.
   "integrationDependencies"

--- a/src/pageEditor/store/editor/editorSelectors/editorModComponentSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorModComponentSelectors.ts
@@ -16,7 +16,6 @@
  */
 
 import { createSelector } from "@reduxjs/toolkit";
-import { flatten } from "lodash";
 import type {
   EditorRootState,
   EditorState,
@@ -75,7 +74,7 @@ export const selectActiveModComponentRef = createSelector(
 ///
 
 export const selectAllDeletedModComponentIds = ({ editor }: EditorRootState) =>
-  new Set(flatten(Object.values(editor.deletedModComponentFormStatesByModId)));
+  new Set(Object.values(editor.deletedModComponentFormStateIdsByModId).flat());
 
 export const selectNotDeletedActivatedModComponents: ({
   options,

--- a/src/pageEditor/store/editor/editorSelectors/editorModComponentSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorModComponentSelectors.ts
@@ -16,7 +16,7 @@
  */
 
 import { createSelector } from "@reduxjs/toolkit";
-import { flatMap } from "lodash";
+import { flatten } from "lodash";
 import type {
   EditorRootState,
   EditorState,
@@ -75,11 +75,7 @@ export const selectActiveModComponentRef = createSelector(
 ///
 
 export const selectAllDeletedModComponentIds = ({ editor }: EditorRootState) =>
-  new Set(
-    flatMap(editor.deletedModComponentFormStatesByModId).map(
-      (formState) => formState.uuid,
-    ),
-  );
+  new Set(flatten(Object.values(editor.deletedModComponentFormStatesByModId)));
 
 export const selectNotDeletedActivatedModComponents: ({
   options,

--- a/src/pageEditor/store/editor/editorSelectors/editorModSelectors.test.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorModSelectors.test.ts
@@ -242,7 +242,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
               ...extraNewFormStates,
             ].map((formState) => [formState.uuid, true]),
           ),
-          deletedModComponentFormStatesByModId: {
+          deletedModComponentFormStateIdsByModId: {
             [primaryModMetadata.id]: deletedDirtyFormStates.map((x) => x.uuid),
           },
         },

--- a/src/pageEditor/store/editor/editorSelectors/editorModSelectors.test.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorModSelectors.test.ts
@@ -243,7 +243,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
             ].map((formState) => [formState.uuid, true]),
           ),
           deletedModComponentFormStatesByModId: {
-            [primaryModMetadata.id]: deletedDirtyFormStates,
+            [primaryModMetadata.id]: deletedDirtyFormStates.map((x) => x.uuid),
           },
         },
         options: {

--- a/src/pageEditor/store/editor/editorSelectors/editorModSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorModSelectors.ts
@@ -284,6 +284,7 @@ const selectGetModIsDirtySelector = createSelector(
   selectDirtyModMetadata,
   selectIsModComponentDirtyById,
   selectGetDirtyOptionsDefinitionForModId,
+  selectDirtyModVariablesDefinitionForModId,
   selectDirtyOptionsArgsForModId,
   selectGetModComponentFormStatesByModId,
   selectDeletedComponentFormStatesByModId,
@@ -291,6 +292,7 @@ const selectGetModIsDirtySelector = createSelector(
     dirtyModMetadata,
     isModComponentDirtyById,
     getDirtyOptionsDefinitionsForModId,
+    dirtyModVariablesDefinitionForModId,
     dirtyModOptionsArgsForModId,
     getModComponentFormStatesByModId,
     getDeletedModComponentFormStatesByModId,
@@ -307,6 +309,8 @@ const selectGetModIsDirtySelector = createSelector(
         // eslint-disable-next-line security/detect-object-injection -- registry id
         Boolean(dirtyModMetadata[modId]) ||
         Boolean(getDirtyOptionsDefinitionsForModId(modId)) ||
+        // eslint-disable-next-line security/detect-object-injection -- registry id
+        Boolean(dirtyModVariablesDefinitionForModId[modId]) ||
         // Mod Options Args aren't on the mod definition. But this selector is used to determine if the mod definition
         // or its configuration is dirty.
         // eslint-disable-next-line security/detect-object-injection -- registry id
@@ -330,6 +334,7 @@ export const selectGetModDraftStateForModId = createSelector(
   selectGetOptionsArgsForModId,
   selectGetModVariablesDefinitionForModId,
   (getOptionsArgsForModId, getModVariablesDefinitionForModId) =>
+    // Memoize because it constructs a new object
     memoize((modId: RegistryId) => ({
       optionsArgs: getOptionsArgsForModId(modId),
       variablesDefinition: getModVariablesDefinitionForModId(modId),

--- a/src/pageEditor/store/editor/editorSelectors/editorModSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorModSelectors.ts
@@ -55,11 +55,11 @@ export const selectCurrentModId = createSelector(
 /// MOD METADATA
 ///
 
-export const selectDirtyModMetadata = ({ editor }: EditorRootState) =>
+const selectDirtyModMetadataById = ({ editor }: EditorRootState) =>
   editor.dirtyModMetadataById;
 
 const dirtyMetadataForModIdSelector = createSelector(
-  selectDirtyModMetadata,
+  selectDirtyModMetadataById,
   (_state: EditorRootState, modId: RegistryId) => modId,
   (dirtyModMetadataById, modId) =>
     // eslint-disable-next-line security/detect-object-injection -- modId is a controlled string
@@ -73,7 +73,7 @@ export const selectDirtyMetadataForModId =
 export const selectModMetadatas = createSelector(
   selectModComponentFormStates,
   selectModInstances,
-  selectDirtyModMetadata,
+  selectDirtyModMetadataById,
   (formStates, modInstances, dirtyModMetadataById) => {
     const formStateModMetadatas = formStates.map(
       (formState) => formState.modMetadata,
@@ -109,11 +109,10 @@ export const selectModMetadataMap = createSelector(
 /// MOD OPTION DEFINITIONS
 ///
 
-export const selectDirtyModOptionsDefinitionById = ({
-  editor,
-}: EditorRootState) => editor.dirtyModOptionsDefinitionById;
+const selectDirtyModOptionsDefinitionById = ({ editor }: EditorRootState) =>
+  editor.dirtyModOptionsDefinitionById;
 
-export const selectGetDirtyModOptionsDefinitionForModId = createSelector(
+const selectGetDirtyModOptionsDefinitionForModId = createSelector(
   selectDirtyModOptionsDefinitionById,
   (dirtyOptionsDefinitionsByModId) =>
     // Memoize because normalizeModOptionsDefinition returns a fresh object reference
@@ -283,7 +282,7 @@ export const selectDeletedComponentFormStatesByModId = ({
  * are dirty.
  */
 const selectGetModIsDirtySelector = createSelector(
-  selectDirtyModMetadata,
+  selectDirtyModMetadataById,
   selectIsModComponentDirtyById,
   selectGetDirtyModOptionsDefinitionForModId,
   selectDirtyModVariablesDefinitionByModId,

--- a/src/pageEditor/store/editor/editorSelectors/editorModSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorModSelectors.ts
@@ -251,7 +251,7 @@ const selectDirtyModVariablesDefinitionForModId = (state: EditorRootState) =>
 /**
  * Returns the draft mod options args for the given mod id.
  */
-export const selectGetModVariablesDefinitionForModId = createSelector(
+const selectGetModVariablesDefinitionForModId = createSelector(
   selectDirtyModVariablesDefinitionForModId,
   selectGetDraftModComponentsForMod,
   (dirtyModVariablesDefinitionForModId, getDraftModComponentsForMod) =>

--- a/src/pageEditor/store/editor/editorSelectors/editorModSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorModSelectors.ts
@@ -273,9 +273,9 @@ const selectGetModVariablesDefinitionForModId = createSelector(
 ///
 
 /** @internal */
-export const selectDeletedComponentFormStatesByModId = ({
+export const selectDeletedComponentFormStateIdsByModId = ({
   editor,
-}: EditorRootState) => editor.deletedModComponentFormStatesByModId;
+}: EditorRootState) => editor.deletedModComponentFormStateIdsByModId;
 
 /**
  * Returns a function that returns if the mod definition or instance (i.e., options args, integration configurations)
@@ -288,7 +288,7 @@ const selectGetModIsDirtySelector = createSelector(
   selectDirtyModVariablesDefinitionByModId,
   selectDirtyOptionsArgsByModId,
   selectGetModComponentFormStatesForMod,
-  selectDeletedComponentFormStatesByModId,
+  selectDeletedComponentFormStateIdsByModId,
   (
     dirtyModMetadata,
     isModComponentDirtyById,
@@ -296,7 +296,7 @@ const selectGetModIsDirtySelector = createSelector(
     dirtyModVariablesDefinitionForModId,
     dirtyModOptionsArgsForModId,
     getModComponentFormStatesByModId,
-    getDeletedModComponentFormStatesByModId,
+    getDeletedModComponentFormStateIdsByModId,
     // eslint-disable-next-line max-params -- required because createSelector takes array of selector args
   ) =>
     // Memoize for consistency. It's not necessary because the return value is primitive
@@ -318,7 +318,7 @@ const selectGetModIsDirtySelector = createSelector(
         Boolean(dirtyModOptionsArgsForModId[modId]) ||
         hasDirtyFormState ||
         // eslint-disable-next-line security/detect-object-injection -- registry id
-        !isEmpty(getDeletedModComponentFormStatesByModId[modId])
+        !isEmpty(getDeletedModComponentFormStateIdsByModId[modId])
       );
     }),
 );

--- a/src/pageEditor/store/editor/editorSlice.test.ts
+++ b/src/pageEditor/store/editor/editorSlice.test.ts
@@ -48,6 +48,7 @@ import {
   selectExpandedModId,
   selectModIsDirty,
 } from "@/pageEditor/store/editor/editorSelectors";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 function getTabState(
   state: EditorState,
@@ -339,6 +340,57 @@ describe("Mod Options editing", () => {
 
     expect(stateAfterEdit.dirtyModOptionsArgsById[modId]).toStrictEqual(
       updatedOptionsArgs,
+    );
+
+    expect(selectModIsDirty(modId)({ editor: stateAfterEdit })).toBeTrue();
+  });
+});
+
+describe("Mod Variables Definition editing", () => {
+  let initialState: EditorState;
+  const modId = validateRegistryId("test/mod");
+  const modMetadata = modMetadataFactory({ id: modId });
+
+  const existingComponentId = autoUUIDSequence();
+
+  const existingComponent = formStateFactory({
+    formStateConfig: {
+      uuid: existingComponentId,
+      modMetadata,
+    },
+  });
+
+  beforeEach(() => {
+    initialState = {
+      ...editorSlice.getInitialState(),
+      modComponentFormStates: [existingComponent],
+    };
+    // Make the mod active
+    initialState = editorSlice.reducer(
+      initialState,
+      actions.setActiveModId(modId),
+    );
+  });
+
+  test("mod variables definition are updated and marks mod as dirty", () => {
+    const updatedModOptionsDefinition = {
+      schema: propertiesToSchema({ foo: { type: "string" } }, []),
+    };
+
+    let stateAfterEdit = editorSlice.reducer(
+      initialState,
+      actions.markModAsCleanById(modId),
+    );
+
+    expect(selectModIsDirty(modId)({ editor: stateAfterEdit })).toBeFalse();
+
+    stateAfterEdit = editorSlice.reducer(
+      stateAfterEdit,
+      actions.editModVariablesDefinition(updatedModOptionsDefinition),
+    );
+
+    expect(stateAfterEdit.dirtyModVariablesDefinitionById[modId]).toStrictEqual(
+      updatedModOptionsDefinition,
     );
 
     expect(selectModIsDirty(modId)({ editor: stateAfterEdit })).toBeTrue();

--- a/src/pageEditor/store/editor/editorSlice.ts
+++ b/src/pageEditor/store/editor/editorSlice.ts
@@ -105,7 +105,7 @@ export const initialState: EditorState = {
   dirtyModVariablesDefinitionById: {},
   dirtyModOptionsArgsById: {},
   visibleModal: null,
-  deletedModComponentFormStatesByModId: {},
+  deletedModComponentFormStateIdsByModId: {},
   availableActivatedModComponentIds: [],
   isPendingAvailableActivatedModComponents: false,
   availableDraftModComponentIds: [],
@@ -537,7 +537,7 @@ export const editorSlice = createSlice({
         state.dirty[modComponentFormState.uuid] = false;
       }
 
-      delete state.deletedModComponentFormStatesByModId[modId];
+      delete state.deletedModComponentFormStateIdsByModId[modId];
       delete state.dirtyModMetadataById[modId];
       delete state.dirtyModOptionsDefinitionById[modId];
       delete state.dirtyModVariablesDefinitionById[modId];
@@ -571,7 +571,7 @@ export const editorSlice = createSlice({
       delete state.dirtyModVariablesDefinitionById[modId];
       delete state.dirtyModOptionsArgsById[modId];
       delete state.dirtyModMetadataById[modId];
-      delete state.deletedModComponentFormStatesByModId[modId];
+      delete state.deletedModComponentFormStateIdsByModId[modId];
     },
 
     ///

--- a/src/pageEditor/store/editor/editorSlice.ts
+++ b/src/pageEditor/store/editor/editorSlice.ts
@@ -98,7 +98,8 @@ export const initialState: EditorState = {
   isBetaUI: false,
   brickPipelineUIStateById: {},
   dirtyModMetadataById: {},
-  dirtyModOptionsDefinitionsById: {},
+  dirtyModOptionsDefinitionById: {},
+  dirtyModVariablesDefinitionById: {},
   dirtyModOptionsArgsById: {},
   visibleModal: null,
   deletedModComponentFormStatesByModId: {},
@@ -477,7 +478,7 @@ export const editorSlice = createSlice({
     ) {
       const { activeModId } = state;
       assertNotNullish(activeModId, "Expected active mod");
-      state.dirtyModOptionsDefinitionsById[activeModId] =
+      state.dirtyModOptionsDefinitionById[activeModId] =
         action.payload as Draft<ModOptionsDefinition>;
     },
 
@@ -525,7 +526,8 @@ export const editorSlice = createSlice({
 
       delete state.deletedModComponentFormStatesByModId[modId];
       delete state.dirtyModMetadataById[modId];
-      delete state.dirtyModOptionsDefinitionsById[modId];
+      delete state.dirtyModOptionsDefinitionById[modId];
+      delete state.dirtyModVariablesDefinitionById[modId];
       delete state.dirtyModOptionsArgsById[modId];
     },
 
@@ -552,7 +554,8 @@ export const editorSlice = createSlice({
       }
 
       // Perform cleanup last because removeModComponentFormState sets entries on deletedModComponentFormStatesByModId
-      delete state.dirtyModOptionsDefinitionsById[modId];
+      delete state.dirtyModOptionsDefinitionById[modId];
+      delete state.dirtyModVariablesDefinitionById[modId];
       delete state.dirtyModOptionsArgsById[modId];
       delete state.dirtyModMetadataById[modId];
       delete state.deletedModComponentFormStatesByModId[modId];

--- a/src/pageEditor/store/editor/editorSlice.ts
+++ b/src/pageEditor/store/editor/editorSlice.ts
@@ -1070,7 +1070,7 @@ export const persistEditorConfig = {
   // Change the type of localStorage to our overridden version so that it can be exported
   // See: @/store/StorageInterface.ts
   storage: localStorage as StorageInterface,
-  version: 10,
+  version: 11,
   migrate: createMigrate(migrations, { debug: Boolean(process.env.DEBUG) }),
   blacklist: ["inserting", "isVarPopoverVisible", "visibleModal"],
 };

--- a/src/pageEditor/store/editor/editorSlice.ts
+++ b/src/pageEditor/store/editor/editorSlice.ts
@@ -70,7 +70,10 @@ import { localStorage } from "redux-persist-webextension-storage";
 import { removeUnusedDependencies } from "@/components/fields/schemaFields/integrations/integrationDependencyFieldUtils";
 import { type UUID } from "@/types/stringTypes";
 import { type RegistryId } from "@/types/registryTypes";
-import { type ModOptionsDefinition } from "@/types/modDefinitionTypes";
+import {
+  type ModOptionsDefinition,
+  type ModVariablesDefinition,
+} from "@/types/modDefinitionTypes";
 import {
   type ModComponentBase,
   type ModMetadata,
@@ -472,7 +475,7 @@ export const editorSlice = createSlice({
       state.dirtyModMetadataById[activeModId] = action.payload;
     },
 
-    editModOptionsDefinitions(
+    editModOptionsDefinition(
       state,
       action: PayloadAction<ModOptionsDefinition>,
     ) {
@@ -491,6 +494,16 @@ export const editorSlice = createSlice({
 
       // Bump sequence number because arguments impact mod functionality
       state.selectionSeq++;
+    },
+
+    editModVariablesDefinition(
+      state,
+      action: PayloadAction<ModVariablesDefinition>,
+    ) {
+      const { activeModId } = state;
+      assertNotNullish(activeModId, "Expected active mod");
+      state.dirtyModVariablesDefinitionById[activeModId] =
+        action.payload as Draft<ModVariablesDefinition>;
     },
 
     updateModMetadataOnModComponentFormStates(

--- a/src/pageEditor/store/editor/editorSliceHelpers.test.ts
+++ b/src/pageEditor/store/editor/editorSliceHelpers.test.ts
@@ -45,7 +45,7 @@ import {
   selectActiveModId,
   selectDeletedComponentFormStatesByModId,
   selectDirtyMetadataForModId,
-  selectDirtyOptionsDefinitionForModId,
+  selectDirtyModOptionsDefinitionForModId,
   selectModComponentFormStates,
   selectExpandedModId,
 } from "@/pageEditor/store/editor/editorSelectors";
@@ -449,7 +449,7 @@ describe("removeModData", () => {
     expect(selectActiveModId({ editor: newState })).toBeNull();
     expect(selectExpandedModId({ editor: newState })).toBeNull();
     expect(
-      selectDirtyOptionsDefinitionForModId(modMetadata.id)({
+      selectDirtyModOptionsDefinitionForModId(modMetadata.id)({
         editor: newState,
       }),
     ).toBeUndefined();

--- a/src/pageEditor/store/editor/editorSliceHelpers.test.ts
+++ b/src/pageEditor/store/editor/editorSliceHelpers.test.ts
@@ -43,7 +43,7 @@ import {
   selectActiveModComponentId,
   selectActiveNodeId,
   selectActiveModId,
-  selectDeletedComponentFormStatesByModId,
+  selectDeletedComponentFormStateIdsByModId,
   selectDirtyMetadataForModId,
   selectDirtyModOptionsDefinitionForModId,
   selectModComponentFormStates,
@@ -431,7 +431,7 @@ describe("removeModData", () => {
           description: "new description",
         },
       },
-      deletedModComponentFormStatesByModId: {
+      deletedModComponentFormStateIdsByModId: {
         [modMetadata.id]: [modComponentFormState2.uuid],
       },
     };
@@ -457,7 +457,7 @@ describe("removeModData", () => {
       selectDirtyMetadataForModId(modMetadata.id)({ editor: newState }),
     ).toBeUndefined();
     expect(
-      selectDeletedComponentFormStatesByModId({ editor: newState })[
+      selectDeletedComponentFormStateIdsByModId({ editor: newState })[
         modMetadata.id
       ],
     ).toBeUndefined();

--- a/src/pageEditor/store/editor/editorSliceHelpers.test.ts
+++ b/src/pageEditor/store/editor/editorSliceHelpers.test.ts
@@ -432,7 +432,7 @@ describe("removeModData", () => {
         },
       },
       deletedModComponentFormStatesByModId: {
-        [modMetadata.id]: [modComponentFormState2],
+        [modMetadata.id]: [modComponentFormState2.uuid],
       },
     };
 

--- a/src/pageEditor/store/editor/editorSliceHelpers.test.ts
+++ b/src/pageEditor/store/editor/editorSliceHelpers.test.ts
@@ -413,7 +413,7 @@ describe("removeModData", () => {
         modComponentFormState1.uuid,
         orphanModComponentFormState.uuid,
       ],
-      dirtyModOptionsDefinitionsById: {
+      dirtyModOptionsDefinitionById: {
         [modMetadata.id]: {
           schema: {
             type: "object",

--- a/src/pageEditor/store/editor/editorSliceHelpers.ts
+++ b/src/pageEditor/store/editor/editorSliceHelpers.ts
@@ -155,7 +155,7 @@ export function markModComponentFormStateAsDeleted(
   // See discussion at: https://github.com/pixiebrix/pixiebrix-extension/pull/9320
   (state.deletedModComponentFormStatesByModId[
     removedFormState.modMetadata.id
-  ] ??= []).push(removedFormState);
+  ] ??= []).push(formStateId);
 
   // Make sure we're not keeping any private data around from Page Editor sessions
   void clearModComponentTraces(formStateId);

--- a/src/pageEditor/store/editor/editorSliceHelpers.ts
+++ b/src/pageEditor/store/editor/editorSliceHelpers.ts
@@ -153,7 +153,7 @@ export function markModComponentFormStateAsDeleted(
   // The effect of adding the draft to deletedModComponentFormStatesByModId is benign - the mod will show as dirty
   // even if the only change is that you added/removed a draft mod component.
   // See discussion at: https://github.com/pixiebrix/pixiebrix-extension/pull/9320
-  (state.deletedModComponentFormStatesByModId[
+  (state.deletedModComponentFormStateIdsByModId[
     removedFormState.modMetadata.id
   ] ??= []).push(formStateId);
 

--- a/src/pageEditor/store/editor/pageEditorTypes.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes.ts
@@ -436,7 +436,7 @@ export type EditorStateV10 = Except<
  * Version bump to move mod variables definition tracking from the form states.
  *
  * @deprecated - Do not use versioned state types directly, exported for testing
- * @since 2.1.6
+ * @since 2.1.7
  */
 export type EditorStateV11 = Except<
   EditorStateV10,
@@ -445,7 +445,7 @@ export type EditorStateV11 = Except<
   | "dirtyModOptionsDefinitionsById"
 > & {
   modComponentFormStates: BaseFormStateV8[];
-  deletedModComponentFormStatesByModId: Record<RegistryId, UUID[]>;
+  deletedModComponentFormStateIdsByModId: Record<RegistryId, UUID[]>;
   dirtyModOptionsDefinitionById: Record<RegistryId, ModOptionsDefinition>;
   dirtyModVariablesDefinitionById: Record<RegistryId, ModVariablesDefinition>;
 };

--- a/src/pageEditor/store/editor/pageEditorTypes.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes.ts
@@ -459,7 +459,7 @@ export type EditorState = Except<
   "modComponentFormStates" | "deletedModComponentFormStatesByModId"
 > & {
   modComponentFormStates: ModComponentFormState[];
-  deletedModComponentFormStatesByModId: Record<string, ModComponentFormState[]>;
+  deletedModComponentFormStatesByModId: Record<string, UUID[]>;
 };
 
 export type EditorRootState = {

--- a/src/pageEditor/store/editor/pageEditorTypes.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes.ts
@@ -447,7 +447,7 @@ export type EditorStateV11 = Except<
   modComponentFormStates: BaseFormStateV8[];
   deletedModComponentFormStatesByModId: Record<RegistryId, UUID[]>;
   dirtyModOptionsDefinitionById: Record<RegistryId, ModOptionsDefinition>;
-  dirtyModVariablesDefinitionById: Record<RegistryId, ModOptionsDefinition>;
+  dirtyModVariablesDefinitionById: Record<RegistryId, ModVariablesDefinition>;
 };
 
 export type EditorState = Except<

--- a/src/pageEditor/store/editor/pageEditorTypes.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes.ts
@@ -45,6 +45,7 @@ import {
   type BaseFormStateV5,
   type BaseFormStateV6,
   type BaseFormStateV7,
+  type BaseFormStateV8,
 } from "@/pageEditor/store/editor/baseFormStateTypes";
 import { type OptionsArgs } from "@/types/runtimeTypes";
 
@@ -427,7 +428,7 @@ export type EditorStateV10 = Except<
 > & {
   modComponentFormStates: BaseFormStateV7[];
   deletedModComponentFormStatesByModId: Record<RegistryId, BaseFormStateV7[]>;
-  dirtyModOptionsDefinitionById: Record<RegistryId, ModOptionsDefinition>;
+  dirtyModOptionsDefinitionsById: Record<RegistryId, ModOptionsDefinition>;
   dirtyModOptionsArgsById: Record<RegistryId, OptionsArgs>;
 };
 
@@ -441,9 +442,9 @@ export type EditorStateV11 = Except<
   EditorStateV10,
   | "modComponentFormStates"
   | "deletedModComponentFormStatesByModId"
-  | "dirtyModOptionsDefinitionById"
+  | "dirtyModOptionsDefinitionsById"
 > & {
-  modComponentFormStates: BaseFormStateV7[];
+  modComponentFormStates: BaseFormStateV8[];
   deletedModComponentFormStatesByModId: Record<RegistryId, UUID[]>;
   dirtyModOptionsDefinitionById: Record<RegistryId, ModOptionsDefinition>;
   dirtyModVariablesDefinitionById: Record<RegistryId, ModOptionsDefinition>;

--- a/src/pageEditor/store/editor/pageEditorTypes.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes.ts
@@ -32,7 +32,10 @@ import { type ModDefinitionsRootState } from "@/modDefinitions/modDefinitionsTyp
 import { type SimpleErrorObject } from "@/errors/errorHelpers";
 import { type SessionChangesRootState } from "@/store/sessionChanges/sessionChangesTypes";
 import { type SessionRootState } from "@/pageEditor/store/session/sessionSliceTypes";
-import { type ModOptionsDefinition } from "@/types/modDefinitionTypes";
+import {
+  type ModOptionsDefinition,
+  type ModVariablesDefinition,
+} from "@/types/modDefinitionTypes";
 import { type EmptyObject, type Except } from "type-fest";
 import {
   type BaseFormStateV1,
@@ -54,6 +57,10 @@ export type DraftModState = {
    * The current option args for the draft mod
    */
   optionsArgs: OptionsArgs;
+  /**
+   * The current mod variables definition for the draft mod.
+   */
+  variablesDefinition: ModVariablesDefinition;
 };
 
 export type AddBrickLocation = {
@@ -407,7 +414,7 @@ export type EditorStateV9 = Except<
 /**
  * Version bump to move mod options args tracking from the form states.
  *
- * Renames dirtyModOptionsById to dirtyModOptionsDefinitionsById for clarity.
+ * Renames dirtyModOptionsById to dirtyModOptionsDefinitionById for clarity.
  *
  * @deprecated - Do not use versioned state types directly, exported for testing
  * @since 2.1.6
@@ -420,13 +427,31 @@ export type EditorStateV10 = Except<
 > & {
   modComponentFormStates: BaseFormStateV7[];
   deletedModComponentFormStatesByModId: Record<RegistryId, BaseFormStateV7[]>;
-  dirtyModOptionsDefinitionsById: Record<RegistryId, ModOptionsDefinition>;
+  dirtyModOptionsDefinitionById: Record<RegistryId, ModOptionsDefinition>;
   dirtyModOptionsArgsById: Record<RegistryId, OptionsArgs>;
+};
+
+/**
+ * Version bump to move mod variables definition tracking from the form states.
+ *
+ * @deprecated - Do not use versioned state types directly, exported for testing
+ * @since 2.1.6
+ */
+export type EditorStateV11 = Except<
+  EditorStateV10,
+  | "modComponentFormStates"
+  | "deletedModComponentFormStatesByModId"
+  | "dirtyModOptionsDefinitionById"
+> & {
+  modComponentFormStates: BaseFormStateV7[];
+  deletedModComponentFormStatesByModId: Record<RegistryId, UUID[]>;
+  dirtyModOptionsDefinitionById: Record<RegistryId, ModOptionsDefinition>;
+  dirtyModVariablesDefinitionById: Record<RegistryId, ModOptionsDefinition>;
 };
 
 export type EditorState = Except<
   // On migration, re-point this type to the most recent EditorStateV<N> type name
-  EditorStateV10,
+  EditorStateV11,
   // Swap out any properties with versioned types for type references to the latest version.
   // NOTE: overriding these properties is not changing the type shape/structure. It's just cleaning up the type
   // name/reference which makes types easier to work with for testing migrations.

--- a/src/pageEditor/store/editor/pageEditorTypes.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes.ts
@@ -456,10 +456,9 @@ export type EditorState = Except<
   // Swap out any properties with versioned types for type references to the latest version.
   // NOTE: overriding these properties is not changing the type shape/structure. It's just cleaning up the type
   // name/reference which makes types easier to work with for testing migrations.
-  "modComponentFormStates" | "deletedModComponentFormStatesByModId"
+  "modComponentFormStates"
 > & {
   modComponentFormStates: ModComponentFormState[];
-  deletedModComponentFormStatesByModId: Record<string, UUID[]>;
 };
 
 export type EditorRootState = {

--- a/src/pageEditor/tabs/effect/StarterBrickPreview.tsx
+++ b/src/pageEditor/tabs/effect/StarterBrickPreview.tsx
@@ -34,7 +34,7 @@ import { StarterBrickTypes } from "@/types/starterBrickTypes";
 import { useSelector } from "react-redux";
 import {
   selectActiveModComponentFormState,
-  selectGetOptionsArgsForModId,
+  selectGetModDraftStateForModId,
 } from "@/pageEditor/store/editor/editorSelectors";
 import { useAsyncEffect } from "use-async-effect";
 
@@ -85,7 +85,7 @@ const StarterBrickPreview: React.FC = () => {
   );
   const { starterBrick } = activeModComponentFormState;
 
-  const getOptionsArgsForModId = useSelector(selectGetOptionsArgsForModId);
+  const getModDraftStateForModId = useSelector(selectGetModDraftStateForModId);
 
   const run = useCallback(async () => {
     dispatch(previewSlice.actions.startRun());
@@ -106,18 +106,17 @@ const StarterBrickPreview: React.FC = () => {
 
       const data = await runStarterBrickReaderPreview(
         inspectedTab,
-        asDraftModComponent(activeModComponentFormState, {
-          optionsArgs: getOptionsArgsForModId(
-            activeModComponentFormState.modMetadata.id,
-          ),
-        }),
+        asDraftModComponent(
+          activeModComponentFormState,
+          getModDraftStateForModId(activeModComponentFormState.modMetadata.id),
+        ),
         rootSelector,
       );
       dispatch(previewSlice.actions.runSuccess({ "@input": data }));
     } catch (error) {
       dispatch(previewSlice.actions.runError(error));
     }
-  }, [activeModComponentFormState, getOptionsArgsForModId, starterBrick]);
+  }, [activeModComponentFormState, getModDraftStateForModId, starterBrick]);
 
   const debouncedRun = useDebouncedCallback(run, 250, {
     trailing: true,

--- a/src/pageEditor/tabs/modOptionsArgs/ModOptionsArgsEditor.tsx
+++ b/src/pageEditor/tabs/modOptionsArgs/ModOptionsArgsEditor.tsx
@@ -15,35 +15,42 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, {useCallback, useMemo} from "react";
-import {useDispatch, useSelector} from "react-redux";
+import React, { useCallback, useMemo } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import {
   selectActiveModId,
-  selectDirtyOptionsDefinitionForModId,
+  selectDirtyModOptionsDefinitionForModId,
   selectGetDraftModComponentsForMod,
   selectGetOptionsArgsForModId,
 } from "@/pageEditor/store/editor/editorSelectors";
-import {useOptionalModDefinition} from "@/modDefinitions/modDefinitionHooks";
-import genericOptionsFactory, {type BrickOptionProps,} from "@/components/fields/schemaFields/genericOptionsFactory";
-import FieldRuntimeContext, {type RuntimeContext,} from "@/components/fields/schemaFields/FieldRuntimeContext";
-import {Card, Container} from "react-bootstrap";
+import { useOptionalModDefinition } from "@/modDefinitions/modDefinitionHooks";
+import genericOptionsFactory, {
+  type BrickOptionProps,
+} from "@/components/fields/schemaFields/genericOptionsFactory";
+import FieldRuntimeContext, {
+  type RuntimeContext,
+} from "@/components/fields/schemaFields/FieldRuntimeContext";
+import { Card, Container } from "react-bootstrap";
 import Form from "@/components/form/Form";
 import ErrorBoundary from "@/components/ErrorBoundary";
-import {getOptionsValidationSchema} from "@/hooks/useAsyncModOptionsValidationSchema";
+import { getOptionsValidationSchema } from "@/hooks/useAsyncModOptionsValidationSchema";
 import Effect from "@/components/Effect";
-import {actions} from "@/pageEditor/store/editor/editorSlice";
-import {type OptionsArgs} from "@/types/runtimeTypes";
-import {DEFAULT_RUNTIME_API_VERSION} from "@/runtime/apiVersionOptions";
+import { actions } from "@/pageEditor/store/editor/editorSlice";
+import { type OptionsArgs } from "@/types/runtimeTypes";
+import { DEFAULT_RUNTIME_API_VERSION } from "@/runtime/apiVersionOptions";
 import ModIntegrationsContext from "@/mods/ModIntegrationsContext";
-import {emptyModOptionsDefinitionFactory} from "@/utils/modUtils";
-import {uniqBy} from "lodash";
-import {assertNotNullish} from "@/utils/nullishUtils";
-import type {RegistryId} from "@/types/registryTypes";
+import { emptyModOptionsDefinitionFactory } from "@/utils/modUtils";
+import { uniqBy } from "lodash";
+import { assertNotNullish } from "@/utils/nullishUtils";
+import type { RegistryId } from "@/types/registryTypes";
 import useDeriveAsyncState from "@/hooks/useDeriveAsyncState";
-import {mergeAsyncState, valueToAsyncState} from "@/utils/asyncStateUtils";
-import type {ModDefinition, ModOptionsDefinition,} from "@/types/modDefinitionTypes";
+import { mergeAsyncState, valueToAsyncState } from "@/utils/asyncStateUtils";
+import type {
+  ModDefinition,
+  ModOptionsDefinition,
+} from "@/types/modDefinitionTypes";
 import AsyncStateGate from "@/components/AsyncStateGate";
-import type {FormikValues} from "formik";
+import type { FormikValues } from "formik";
 
 const OPTIONS_FIELD_RUNTIME_CONTEXT: RuntimeContext = {
   apiVersion: DEFAULT_RUNTIME_API_VERSION,
@@ -58,7 +65,7 @@ function useOptionsFieldGroupQuery(modId: RegistryId) {
   const modDefinitionQuery = useOptionalModDefinition(modId);
 
   const dirtyModOptionsDefinition = useSelector(
-    selectDirtyOptionsDefinitionForModId(modId),
+    selectDirtyModOptionsDefinitionForModId(modId),
   );
 
   return useDeriveAsyncState(

--- a/src/pageEditor/tabs/modOptionsDefinitions/ModOptionsDefinitionEditor.tsx
+++ b/src/pageEditor/tabs/modOptionsDefinitions/ModOptionsDefinitionEditor.tsx
@@ -149,7 +149,7 @@ const ModOptionsDefinitionEditor: React.VFC = () => {
   const dispatch = useDispatch();
   const updateRedux = useCallback(
     (options: ModOptionsDefinition) => {
-      dispatch(actions.editModOptionsDefinitions(options));
+      dispatch(actions.editModOptionsDefinition(options));
     },
     [dispatch],
   );

--- a/src/pageEditor/tabs/modOptionsDefinitions/ModOptionsDefinitionEditor.tsx
+++ b/src/pageEditor/tabs/modOptionsDefinitions/ModOptionsDefinitionEditor.tsx
@@ -32,7 +32,7 @@ import FORM_FIELD_TYPE_OPTIONS from "@/pageEditor/fields/formFieldTypeOptions";
 import { useDispatch, useSelector } from "react-redux";
 import {
   selectActiveModId,
-  selectDirtyOptionsDefinitionForModId,
+  selectDirtyModOptionsDefinitionForModId,
 } from "@/pageEditor/store/editor/editorSelectors";
 import { PAGE_EDITOR_DEFAULT_BRICK_API_VERSION } from "@/pageEditor/starterBricks/base";
 // eslint-disable-next-line no-restricted-imports -- TODO: Fix over time
@@ -119,7 +119,7 @@ function useInitialValuesQuery(
   modId: RegistryId,
 ): AsyncState<{ optionsDefinition: ModOptionsDefinition }> {
   const dirtyOptionsDefinition = useSelector(
-    selectDirtyOptionsDefinitionForModId(modId),
+    selectDirtyModOptionsDefinitionForModId(modId),
   );
 
   const modDefinitionQuery = useOptionalModDefinition(modId);

--- a/src/pageEditor/toolbar/ReloadToolbar.tsx
+++ b/src/pageEditor/toolbar/ReloadToolbar.tsx
@@ -30,7 +30,7 @@ import useKeyboardShortcut from "@/hooks/useKeyboardShortcut";
 import { allFramesInInspectedTab } from "@/pageEditor/context/connection";
 import { StarterBrickTypes } from "@/types/starterBrickTypes";
 import { RunReason } from "@/types/runtimeTypes";
-import { selectGetOptionsArgsForModId } from "@/pageEditor/store/editor/editorSelectors";
+import { selectGetModDraftStateForModId } from "@/pageEditor/store/editor/editorSelectors";
 
 const DEFAULT_RELOAD_MILLIS = 350;
 
@@ -105,17 +105,16 @@ const ReloadToolbar: React.FunctionComponent<{
   refreshMillis?: number;
 }> = ({ modComponentFormState, refreshMillis = DEFAULT_RELOAD_MILLIS }) => {
   const sessionId = useSelector(selectSessionId);
-  const getOptionsArgsForModId = useSelector(selectGetOptionsArgsForModId);
+  const getModDraftStateForModId = useSelector(selectGetModDraftStateForModId);
   const { asDraftModComponent } = adapterForComponent(modComponentFormState);
 
   const run = useCallback(async () => {
     updateDraftModComponent(
       allFramesInInspectedTab,
-      asDraftModComponent(modComponentFormState, {
-        optionsArgs: getOptionsArgsForModId(
-          modComponentFormState.modMetadata.id,
-        ),
-      }),
+      asDraftModComponent(
+        modComponentFormState,
+        getModDraftStateForModId(modComponentFormState.modMetadata.id),
+      ),
       { isSelectedInEditor: true, runReason: RunReason.PAGE_EDITOR_RUN },
     );
   }, [asDraftModComponent, modComponentFormState]);

--- a/src/store/editorMigrations.test.ts
+++ b/src/store/editorMigrations.test.ts
@@ -305,7 +305,7 @@ const initialStateV11: EditorStateV11 & PersistedState = {
   ),
   dirtyModOptionsDefinitionById: {},
   dirtyModVariablesDefinitionById: {},
-  deletedModComponentFormStatesByModId: {},
+  deletedModComponentFormStateIdsByModId: {},
 };
 
 function unmigrateServices(
@@ -571,10 +571,10 @@ function unmigrateEditorStateV11toV10(
         unmigrateFormState(formState),
       ),
       deletedModComponentFormStatesByModId: mapValues(
-        state.deletedModComponentFormStatesByModId,
+        state.deletedModComponentFormStateIdsByModId,
         (modComponentIds, modId) =>
           // Create fake form states for the deleted ones
-          // FIXME: assign mod metadata to the fake form states
+          // XXX: ideally would assign mod metadata to the fake form states, but it doesn't matter for the tests
           modComponentIds.map((modComponentId) => ({
             ...formStateFactory({ formStateConfig: { uuid: modComponentId } }),
             variablesDefinition:

--- a/src/store/editorMigrations.test.ts
+++ b/src/store/editorMigrations.test.ts
@@ -26,9 +26,11 @@ import {
   type EditorStateV8,
   type EditorStateV9,
   type EditorStateV10,
+  type DraftModState,
 } from "@/pageEditor/store/editor/pageEditorTypes";
 import { cloneDeep, mapValues, omit } from "lodash";
 import {
+  draftModStateFactory,
   formStateFactory,
   type InternalFormStateOverride,
 } from "@/testUtils/factories/pageEditorFactories";
@@ -287,7 +289,7 @@ const initialStateV9: EditorStateV9 & PersistedState = {
 
 const initialStateV10: EditorStateV10 & PersistedState = {
   ...omit(cloneDeep(initialStateV9), "dirtyModOptionsById"),
-  dirtyModOptionsDefinitionsById: {},
+  dirtyModOptionsDefinitionById: {},
   dirtyModOptionsArgsById: {},
 };
 
@@ -430,7 +432,7 @@ function unmigrateFormStateV6toV5(formState: BaseFormStateV6): BaseFormStateV5 {
 
 function unmigrateFormStateV7toV6(
   formState: BaseFormStateV7,
-  modState: { optionsArgs: OptionsArgs },
+  modState: DraftModState,
 ): BaseFormStateV6 {
   return {
     ...formState,
@@ -506,7 +508,7 @@ function unmigrateEditorStateV10toV9(
   return omit(
     {
       ...state,
-      dirtyModOptionsById: state.dirtyModOptionsDefinitionsById,
+      dirtyModOptionsById: state.dirtyModOptionsDefinitionById,
       modComponentFormStates: state.modComponentFormStates.map((formState) =>
         unmigrateFormStateV7toV6(formState, {
           optionsArgs:
@@ -536,7 +538,7 @@ const formStateFactoryV7: SimpleFactory<BaseFormStateV7> = (override) =>
   });
 
 const formStateFactoryV6: SimpleFactory<BaseFormStateV6> = () =>
-  unmigrateFormStateV7toV6(formStateFactoryV7(), { optionsArgs: {} });
+  unmigrateFormStateV7toV6(formStateFactoryV7(), draftModStateFactory());
 
 const formStateFactoryV5: SimpleFactory<BaseFormStateV5> = () =>
   unmigrateFormStateV6toV5(formStateFactoryV6());

--- a/src/store/editorMigrations.ts
+++ b/src/store/editorMigrations.ts
@@ -320,7 +320,11 @@ export function migrateEditorStateV10(
     (draft) => {
       // Alias the old draft type for deleting old properties
       const oldDraft = draft as unknown as Draft<
-        SetOptional<EditorStateV10, "dirtyModOptionsDefinitionsById">
+        SetOptional<
+          EditorStateV10,
+          | "dirtyModOptionsDefinitionsById"
+          | "deletedModComponentFormStatesByModId"
+        >
       >;
 
       // Rename dirtyModOptionsDefinitionsById to dirtyModOptionsDefinitionById
@@ -328,6 +332,13 @@ export function migrateEditorStateV10(
         oldDraft.dirtyModOptionsDefinitionsById ??
         emptyModOptionsDefinitionFactory();
       delete oldDraft.dirtyModOptionsDefinitionsById;
+
+      // Rename dirtyModOptionsDefinitionsById to deletedModComponentFormStateIdsByModId
+      draft.deletedModComponentFormStateIdsByModId = mapValues(
+        oldDraft.deletedModComponentFormStatesByModId,
+        (formStates) => formStates.map((x) => x.uuid),
+      );
+      delete oldDraft.deletedModComponentFormStatesByModId;
 
       // Populate dirtyModOptionsArgsById and drop optionsArgs from modComponentFormStates
       draft.dirtyModVariablesDefinitionById = {};

--- a/src/store/editorMigrations.ts
+++ b/src/store/editorMigrations.ts
@@ -286,8 +286,8 @@ export function migrateEditorStateV9(
         SetOptional<EditorStateV9, "dirtyModOptionsById">
       >;
 
-      // Rename dirtyModOptionsById to dirtyModOptionsDefinitionsById
-      draft.dirtyModOptionsDefinitionsById = oldDraft.dirtyModOptionsById ?? {};
+      // Rename dirtyModOptionsById to dirtyModOptionsDefinitionById
+      draft.dirtyModOptionsDefinitionById = oldDraft.dirtyModOptionsById ?? {};
       delete oldDraft.dirtyModOptionsById;
 
       // Populate dirtyModOptionsArgsById and drop optionsArgs from modComponentFormStates

--- a/src/store/modComponents/modComponentUtils.ts
+++ b/src/store/modComponents/modComponentUtils.ts
@@ -26,8 +26,12 @@ import {
   INTEGRATIONS_BASE_SCHEMA_URL,
   PIXIEBRIX_INTEGRATION_ID,
 } from "@/integrations/constants";
-import type { ModComponentDefinition } from "@/types/modDefinitionTypes";
+import type {
+  ModComponentDefinition,
+  ModVariablesDefinition,
+} from "@/types/modDefinitionTypes";
 import type { Schema } from "@/types/schemaTypes";
+import { emptyModVariablesDefinitionFactory } from "@/utils/modUtils";
 
 /**
  * Infer options from existing mod-component-like instances for reactivating a mod
@@ -40,6 +44,20 @@ export function collectModOptionsArgs(
   // activation process (even if they don't use the options), so we can take
   // the optionsArgs for any of the extensions
   return modComponents[0]?.optionsArgs ?? {};
+}
+
+/**
+ * Infer options from existing mod-component-like instances for reactivating a mod
+ * @see activateMod
+ */
+export function collectModVariablesDefinition(
+  modComponents: Array<Pick<ModComponentBase, "variablesDefinition">>,
+): ModVariablesDefinition {
+  // `variablesDefinition` is defined at the mod-level, so will be the same on each mod component
+  return (
+    modComponents[0]?.variablesDefinition ??
+    emptyModVariablesDefinitionFactory()
+  );
 }
 
 /**

--- a/src/store/sessionChanges/sessionChangesListenerMiddleware.ts
+++ b/src/store/sessionChanges/sessionChangesListenerMiddleware.ts
@@ -26,7 +26,8 @@ sessionChangesListenerMiddleware.startListening({
   matcher: isAnyOf(
     // Page Editor mod actions
     editorActions.editModMetadata,
-    editorActions.editModOptionsDefinitions,
+    editorActions.editModOptionsDefinition,
+    editorActions.editModVariablesDefinition,
     editorActions.editModOptionsArgs,
     editorActions.markModAsCleanById,
     editorActions.removeModById,

--- a/src/testUtils/factories/pageEditorFactories.ts
+++ b/src/testUtils/factories/pageEditorFactories.ts
@@ -50,13 +50,16 @@ import {
 } from "@/testUtils/factories/brickFactories";
 import { type BaseModComponentState } from "@/pageEditor/store/editor/baseFormStateTypes";
 import { assertNotNullish } from "@/utils/nullishUtils";
-import { type Permissions } from "webextension-polyfill";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
 import {
   createNewUnsavedModMetadata,
   emptyModVariablesDefinitionFactory,
 } from "@/utils/modUtils";
-import { type AddBrickLocation } from "@/pageEditor/store/editor/pageEditorTypes";
+import {
+  type AddBrickLocation,
+  type DraftModState,
+} from "@/pageEditor/store/editor/pageEditorTypes";
+import { emptyPermissionsFactory } from "@/permissions/permissionsUtils";
 
 const baseModComponentStateFactory = define<BaseModComponentState>({
   brickPipeline: () => pipelineFactory(),
@@ -75,18 +78,12 @@ const internalFormStateFactory = define<InternalFormStateOverride>({
   apiVersion: "v3" as ApiVersion,
   uuid: uuidSequence,
   installed: true,
-  variablesDefinition: () => emptyModVariablesDefinitionFactory(),
   integrationDependencies(): IntegrationDependency[] {
     return [];
   },
   modMetadata: (n: number) =>
     createNewUnsavedModMetadata({ modName: `Unsaved Mod ${n}` }),
-  permissions(): Permissions.Permissions {
-    return {
-      permissions: [],
-      origins: [],
-    };
-  },
+  permissions: emptyPermissionsFactory,
   label: (i: number) => `Element ${i}`,
   modComponent: baseModComponentStateFactory,
   starterBrick: starterBrickDefinitionFactory,
@@ -311,4 +308,11 @@ export const addBrickLocationFactory = define<AddBrickLocation>({
   path: "body",
   flavor: PipelineFlavor.AllBricks,
   index: 0,
+});
+
+export const draftModStateFactory = define<DraftModState>({
+  optionsArgs() {
+    return {};
+  },
+  variablesDefinition: emptyModVariablesDefinitionFactory,
 });


### PR DESCRIPTION
## What does this PR do?

- Move mod variables definition out of mod component form state. They're duplicated across the form states
- 🐛 Fixes bug where mod variable definitions weren't being pushed down to draft mod components when editing in the Page Editor
- Pre-work for surfacing mod variable definitions and sync policies in the Page Editor
- Other improvements
  - `deletedModComponentFormStatesByModId` was renamed to `deletedModComponentFormStateIdsByModId` and now just stores mod component UUIDs instead of form states. (The deleted form states weren't used anywhere. Clearing changes for a mod component resets to the activated mod component)
  - Rename `dirtyModOptionsDefinitionsById` (with `s`) to `dirtyModOptionsDefinitionById` to match type name `ModOptionsDefinition`

## Remaining Work

- [x] Fix calls to the save helpers to include mod variables definition
- [x] Update/write jest tests for save helpers
- [x] Update Playwright snapshots that now include variable definition section

## Future Work

- Consider tracking `modMetadata` at the mod-level. The information is duplicated aside from the `modId`. It's more complicated due to the number of references, and the mod-level dirty state  is currently only tracks the `Metadata` without the sharing/update timestamp information
- Consider refactoring to make ModOptionsDefinition available via selector. See note: https://github.com/pixiebrix/pixiebrix-extension/blob/ea442104630461e269a5562cd460d5454a3fe431/src/pageEditor/store/editor/editorSelectors/editorModSelectors.ts#L338-L338. This will be possible if/when modComponentSlice is modified to store ModInstances

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
