### PR TITLE
refactor pageEditor fixture for msedge bug

### DIFF
--- a/end-to-end-tests/tests/modLifecycle.spec.ts
+++ b/end-to-end-tests/tests/modLifecycle.spec.ts
@@ -32,7 +32,7 @@ test("create, run, package, and update mod", async ({
   context,
 }) => {
   await page.goto("/create-react-app/table");
-  const pageEditorPage = await newPageEditorPage(page.url());
+  const pageEditorPage = await newPageEditorPage(page);
 
   await pageEditorPage.modListingPanel.addNewMod({
     starterBrickName: "Button",

--- a/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts
@@ -19,16 +19,15 @@ import { test, expect } from "../../fixtures/testBase";
 
 // @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
 import { type Page, test as base } from "@playwright/test";
-import { getSidebarPage, isMsEdge } from "../../utils";
+import { getSidebarPage } from "../../utils";
 
 test("Add new mod with different starter brick components", async ({
   page,
   newPageEditorPage,
   extensionId,
-  chromiumChannel,
 }) => {
   await page.goto("/");
-  const pageEditorPage = await newPageEditorPage(page.url());
+  const pageEditorPage = await newPageEditorPage(page);
   const brickPipeline = pageEditorPage.brickActionsPanel.bricks;
 
   await test.step("Add new Button starter brick", async () => {
@@ -91,11 +90,6 @@ test("Add new mod with different starter brick components", async ({
   });
 
   await test.step("Add new Sidebar Panel starter brick", async () => {
-    // eslint-disable-next-line playwright/no-conditional-in-test -- MSedge won't open the sidebar unless the target page is focused
-    if (isMsEdge(chromiumChannel)) {
-      await page.bringToFront();
-    }
-
     const { modComponentNameMatcher } =
       await pageEditorPage.modListingPanel.addNewMod({
         starterBrickName: "Sidebar Panel",
@@ -160,7 +154,7 @@ test("Add starter brick to mod", async ({
   );
 
   await page.goto("/");
-  const pageEditorPage = await newPageEditorPage(page.url());
+  const pageEditorPage = await newPageEditorPage(page);
   const brickPipeline = pageEditorPage.brickActionsPanel.bricks;
 
   // Create arbitrary mod to which to add starter bricks
@@ -247,11 +241,6 @@ test("Add starter brick to mod", async ({
   });
 
   await test.step("Add Sidebar Panel starter brick to mod", async () => {
-    // eslint-disable-next-line playwright/no-conditional-in-test -- MSedge won't open the sidebar unless the target page is focused
-    if (isMsEdge(chromiumChannel)) {
-      await page.bringToFront();
-    }
-
     const modActionMenu = await modListItem.openModActionMenu();
     await modActionMenu.addStarterBrick("Sidebar Panel");
 

--- a/end-to-end-tests/tests/pageEditor/brickActions.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/brickActions.spec.ts
@@ -52,7 +52,7 @@ test("brick actions panel behavior", async ({
     await modActivationPage.clickActivateAndWaitForModsPageRedirect();
 
     await page.goto("/");
-    pageEditorPage = await newPageEditorPage(page.url());
+    pageEditorPage = await newPageEditorPage(page);
   });
 
   const { brickActionsPanel } = pageEditorPage!;

--- a/end-to-end-tests/tests/pageEditor/brickConfiguration.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/brickConfiguration.spec.ts
@@ -43,7 +43,7 @@ test("brick configuration", async ({
     await modActivationPage.clickActivateAndWaitForModsPageRedirect();
 
     await page.goto("/");
-    pageEditorPage = await newPageEditorPage(page.url());
+    pageEditorPage = await newPageEditorPage(page);
 
     brickConfigurationPanel = pageEditorPage.brickConfigurationPanel;
 

--- a/end-to-end-tests/tests/pageEditor/clearChanges.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/clearChanges.spec.ts
@@ -43,7 +43,7 @@ test("clear mod component changes", async ({
     await modActivationPage.clickActivateAndWaitForModsPageRedirect();
 
     await page.goto("/");
-    pageEditorPage = await newPageEditorPage(page.url());
+    pageEditorPage = await newPageEditorPage(page);
 
     brickConfigurationPanel = pageEditorPage.brickConfigurationPanel;
 

--- a/end-to-end-tests/tests/pageEditor/copyMod.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/copyMod.spec.ts
@@ -55,7 +55,7 @@ test("copying a mod that uses the PixieBrix API is copied correctly", async ({
 
   await test.step("Copy the mod", async () => {
     await page.goto("/");
-    const pageEditorPage = await newPageEditorPage(page.url());
+    const pageEditorPage = await newPageEditorPage(page);
     await pageEditorPage.copyMod(sourceModName, modUuid);
 
     await expect(
@@ -128,7 +128,7 @@ test("run a copied mod with a built-in integration", async ({
   });
 
   await page.goto("/");
-  const pageEditorPage = await newPageEditorPage(page.url());
+  const pageEditorPage = await newPageEditorPage(page);
   await test.step("Copy the mod", async () => {
     await pageEditorPage.copyMod(sourceModName, modUuid);
 

--- a/end-to-end-tests/tests/pageEditor/liveEditing.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/liveEditing.spec.ts
@@ -19,13 +19,12 @@ import { expect, test } from "../../fixtures/testBase";
 // @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
 import { test as base } from "@playwright/test";
 import { ActivateModPage } from "../../pageObjects/extensionConsole/modsPage";
-import { getSidebarPage, isMsEdge, isSidebarOpen } from "../../utils";
+import { getSidebarPage, isSidebarOpen } from "../../utils";
 
 test("live editing behavior", async ({
   page,
   extensionId,
   newPageEditorPage,
-  chromiumChannel,
 }) => {
   await test.step("Activate test mod and navigate to testing site", async () => {
     const modId = "@e2e-testing/page-editor-live-editing-test";
@@ -36,7 +35,7 @@ test("live editing behavior", async ({
     await page.goto("/");
   });
 
-  const pageEditor = await newPageEditorPage(page.url());
+  const pageEditor = await newPageEditorPage(page);
 
   const modListItem =
     pageEditor.modListingPanel.getModListItemByName("Live Editing Test");
@@ -73,14 +72,6 @@ test("live editing behavior", async ({
     await expect(pageEditor.editorPane.renderPanelButton).toBeVisible();
 
     expect(isSidebarOpen(page, extensionId)).toBe(false);
-
-    /* eslint-disable-next-line playwright/no-conditional-in-test -- MS Edge has a bug where the page editor
-     * cannot open the sidebar, unless the target page is already focused.
-     * https://www.loom.com/share/fbad85e901794161960b737b27a13677
-     */
-    if (isMsEdge(chromiumChannel)) {
-      await page.bringToFront();
-    }
 
     await pageEditor.editorPane.renderPanelButton.click();
     const sidebar = await getSidebarPage(page, extensionId);

--- a/end-to-end-tests/tests/pageEditor/logsPane.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/logsPane.spec.ts
@@ -33,7 +33,7 @@ test("can view error logs", async ({
 
   await page.goto("/");
 
-  const pageEditorPage = await newPageEditorPage(page.url());
+  const pageEditorPage = await newPageEditorPage(page);
   await pageEditorPage.modListingPanel.getModListItemByName(modName).click();
   await pageEditorPage.modEditorPane.logsTab.click();
   const logsTabPane = await pageEditorPage.modEditorPane.getLogsTabPanel();

--- a/end-to-end-tests/tests/pageEditor/modEditorPane.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/modEditorPane.spec.ts
@@ -40,7 +40,7 @@ test("mod editor pane behavior", async ({
     await modActivationPage.clickActivateAndWaitForModsPageRedirect();
 
     await page.goto("/");
-    pageEditorPage = await newPageEditorPage(page.url());
+    pageEditorPage = await newPageEditorPage(page);
   });
 
   const { modEditorPane } = pageEditorPage!;

--- a/end-to-end-tests/tests/pageEditor/moveOrCopyModComponent.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/moveOrCopyModComponent.spec.ts
@@ -28,7 +28,7 @@ test("Create new mod by moving mod component", async ({
   newPageEditorPage,
 }) => {
   await page.goto("/");
-  const pageEditorPage = await newPageEditorPage(page.url());
+  const pageEditorPage = await newPageEditorPage(page);
 
   await test.step("Add new starter bricks", async () => {
     // Add 2x mod components because the last mod component in a mod can't be moved
@@ -75,7 +75,7 @@ test("Create new mod by copying a mod component", async ({
   newPageEditorPage,
 }) => {
   await page.goto("/");
-  const pageEditorPage = await newPageEditorPage(page.url());
+  const pageEditorPage = await newPageEditorPage(page);
 
   await test.step("Add new Trigger starter brick", async () => {
     const { modComponentNameMatcher } =

--- a/end-to-end-tests/tests/pageEditor/optionsArgs.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/optionsArgs.spec.ts
@@ -20,13 +20,12 @@ import { expect, test } from "../../fixtures/testBase";
 import { test as base } from "@playwright/test";
 import { ActivateModPage } from "../../pageObjects/extensionConsole/modsPage";
 import { type PageEditorPage } from "end-to-end-tests/pageObjects/pageEditor/pageEditorPage";
-import { getSidebarPage, isMsEdge } from "../../utils";
+import { getSidebarPage } from "../../utils";
 
 test("mod editor pane behavior", async ({
   page,
   extensionId,
   newPageEditorPage,
-  chromiumChannel,
 }) => {
   const modId = "@e2e-testing/options-args";
   let pageEditorPage: PageEditorPage;
@@ -37,7 +36,7 @@ test("mod editor pane behavior", async ({
     await modActivationPage.clickActivateAndWaitForModsPageRedirect();
 
     await page.goto("/");
-    pageEditorPage = await newPageEditorPage(page.url());
+    pageEditorPage = await newPageEditorPage(page);
   });
 
   const { modEditorPane } = pageEditorPage!;
@@ -48,14 +47,6 @@ test("mod editor pane behavior", async ({
   });
 
   await test.step("Open Sidebar and assert default value", async () => {
-    /* eslint-disable-next-line playwright/no-conditional-in-test -- MS Edge has a bug where the page editor
-     * cannot open the sidebar unless it is already focused.
-     * https://www.loom.com/share/fbad85e901794161960b737b27a13677
-     */
-    if (isMsEdge(chromiumChannel)) {
-      await page.bringToFront();
-    }
-
     await pageEditorPage.modListingPanel
       .getModListItemByName("Sidebar Panel")
       .select();

--- a/end-to-end-tests/tests/pageEditor/saveMod.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/saveMod.spec.ts
@@ -29,7 +29,7 @@ test("can save a new trigger mod", async ({
   newPageEditorPage,
 }) => {
   await page.goto("/");
-  const pageEditorPage = await newPageEditorPage(page.url());
+  const pageEditorPage = await newPageEditorPage(page);
   await pageEditorPage.modListingPanel.addNewMod({
     starterBrickName: "Trigger",
   });
@@ -56,7 +56,7 @@ test("#9349: can save new mod with multiple components", async ({
   newPageEditorPage,
 }) => {
   await page.goto("/");
-  const pageEditorPage = await newPageEditorPage(page.url());
+  const pageEditorPage = await newPageEditorPage(page);
   await pageEditorPage.modListingPanel.addNewMod({
     starterBrickName: "Trigger",
   });
@@ -107,7 +107,7 @@ test("shows error notification when updating a public mod without incrementing t
   await modActivationPage.goto();
   await modActivationPage.clickActivateAndWaitForModsPageRedirect();
   await page.goto("/");
-  const pageEditorPage = await newPageEditorPage(page.url());
+  const pageEditorPage = await newPageEditorPage(page);
   const modListItem =
     pageEditorPage.modListingPanel.getModListItemByName(modName);
   await modListItem.select();

--- a/end-to-end-tests/tests/pageEditor/specialPages.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/specialPages.spec.ts
@@ -28,7 +28,7 @@ test("Restricted browser page", async ({
   extensionId,
 }) => {
   await page.goto("/");
-  const pageEditorPage = await newPageEditorPage(page.url());
+  const pageEditorPage = await newPageEditorPage(page);
   await page.goto(getBaseExtensionConsoleUrl(extensionId));
 
   await expect(
@@ -43,7 +43,7 @@ test("Unavailable mod", async ({ page, extensionId, newPageEditorPage }) => {
   await modActivationPage.clickActivateAndWaitForModsPageRedirect();
 
   await page.goto("/");
-  const pageEditorPage = await newPageEditorPage(page.url());
+  const pageEditorPage = await newPageEditorPage(page);
   await pageEditorPage.modListingPanel
     .getModListItemByName("Google.com trigger")
     .select();
@@ -59,11 +59,11 @@ test("Unavailable mod", async ({ page, extensionId, newPageEditorPage }) => {
 
 test("Page Editor reload", async ({ page, newPageEditorPage, extensionId }) => {
   await page.goto("/");
-  const firstPageEditorPage = await newPageEditorPage(page.url());
+  const firstPageEditorPage = await newPageEditorPage(page);
 
   const newPage = await page.context().newPage();
   await newPage.goto("/bootstrap-5");
-  const secondPageEditorPage = await newPageEditorPage(page.url());
+  const secondPageEditorPage = await newPageEditorPage(page);
 
   await secondPageEditorPage.modListingPanel.addNewMod({
     starterBrickName: "Trigger",

--- a/end-to-end-tests/tests/regressions/doNotCloseSidebarOnPageEditorSave.spec.ts
+++ b/end-to-end-tests/tests/regressions/doNotCloseSidebarOnPageEditorSave.spec.ts
@@ -18,24 +18,15 @@
 import { test, expect } from "../../fixtures/testBase";
 // @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
 import { type Page, test as base } from "@playwright/test";
-import { getSidebarPage, isMsEdge } from "../../utils";
+import { getSidebarPage } from "../../utils";
 
 test("#8104: Do not automatically close the sidebar when saving in the Page Editor", async ({
   page,
   newPageEditorPage,
   extensionId,
-  chromiumChannel,
 }) => {
   await page.goto("/");
-  const pageEditorPage = await newPageEditorPage(page.url());
-
-  /* eslint-disable-next-line playwright/no-conditional-in-test -- MS Edge has a bug where the page editor
-   * cannot open the sidebar unless it is already focused.
-   * https://www.loom.com/share/fbad85e901794161960b737b27a13677
-   */
-  if (isMsEdge(chromiumChannel)) {
-    await page.bringToFront();
-  }
+  const pageEditorPage = await newPageEditorPage(page);
 
   await pageEditorPage.modListingPanel.addNewMod({
     starterBrickName: "Sidebar Panel",

--- a/end-to-end-tests/tests/regressions/hideModalsOnPageEditorRefresh.spec.ts
+++ b/end-to-end-tests/tests/regressions/hideModalsOnPageEditorRefresh.spec.ts
@@ -34,7 +34,7 @@ test("should hide add brick modal when Page Editor refreshes", async ({
     await modActivationPage.goto();
     await modActivationPage.clickActivateAndWaitForModsPageRedirect();
     await page.goto("/");
-    pageEditorPage = await newPageEditorPage(page.url());
+    pageEditorPage = await newPageEditorPage(page);
   });
 
   const addBrickModalTitle = pageEditorPage!.getByText("Add Brick", {

--- a/end-to-end-tests/tests/regressions/sandboxBrickErrors.spec.ts
+++ b/end-to-end-tests/tests/regressions/sandboxBrickErrors.spec.ts
@@ -32,7 +32,7 @@ test("#8821: ensure Javascript script errors are thrown during brick runtime", a
   await modActivationPage.clickActivateAndWaitForModsPageRedirect();
 
   await page.goto("/bootstrap-5");
-  const pageEditorPage = await newPageEditorPage(page.url());
+  const pageEditorPage = await newPageEditorPage(page);
   await pageEditorPage.modListingPanel
     .getModListItemByName("8821 Repro")
     .click();

--- a/end-to-end-tests/tests/smoke/pageEditor.spec.ts
+++ b/end-to-end-tests/tests/smoke/pageEditor.spec.ts
@@ -26,7 +26,7 @@ test.describe("page editor smoke test", () => {
   }) => {
     await page.goto("/bootstrap-5");
 
-    const pageEditorPage = await newPageEditorPage(page.url());
+    const pageEditorPage = await newPageEditorPage(page);
     await expect(pageEditorPage.templateGalleryButton).toBeVisible();
   });
 });


### PR DESCRIPTION
## What does this PR do?

Moves msedge bug handling for bringing the connected page to the front to avoid issues opening the sidebar from the page editor.

Follow-up from this discussion:
https://github.com/pixiebrix/pixiebrix-extension/pull/9383#discussion_r1822630690


## Checklist


- [X] Added jest or playwright tests and/or storybook stories

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
