### PR TITLE
#7462: Bump react-redux from 7 to 8 and memoize remaining selectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,7 @@
         "react-image-crop": "^11.0.7",
         "react-json-tree": "^0.19.0",
         "react-outside-click-handler": "^1.3.0",
-        "react-redux": "^7.2.4",
+        "react-redux": "^8.1.3",
         "react-router": "5.3.4",
         "react-router-dom": "^5.3.4",
         "react-select": "^5.8.2",
@@ -24933,6 +24933,35 @@
       "version": "5.2.1",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
+    "node_modules/react-beautiful-dnd-next/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-beautiful-dnd-next/node_modules/react-redux": {
+      "version": "7.2.9",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
+      "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-bootstrap": {
       "version": "1.6.5",
       "integrity": "sha512-l2rm5LtDI7JMtdGrzaxNl4OJwH0fMIJDlvwQ2TMvs9h9d0E4ELLpG3J45Pox6xUkpuFfXdWUiGazZXyIuv/OKA==",
@@ -25182,31 +25211,52 @@
       }
     },
     "node_modules/react-redux": {
-      "version": "7.2.8",
-      "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
       "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "@types/react-redux": "^7.1.20",
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
         "hoist-non-react-statics": "^3.3.2",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2"
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
       },
       "peerDependencies": {
-        "react": "^16.8.3 || ^17 || ^18"
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
         "react-dom": {
           "optional": true
         },
         "react-native": {
           "optional": true
+        },
+        "redux": {
+          "optional": true
         }
       }
     },
+    "node_modules/react-redux/node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
+    },
     "node_modules/react-redux/node_modules/react-is": {
-      "version": "17.0.2",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "react-image-crop": "^11.0.7",
     "react-json-tree": "^0.19.0",
     "react-outside-click-handler": "^1.3.0",
-    "react-redux": "^7.2.4",
+    "react-redux": "^8.1.3",
     "react-router": "5.3.4",
     "react-router-dom": "^5.3.4",
     "react-select": "^5.8.2",

--- a/src/components/logViewer/LogCard.tsx
+++ b/src/components/logViewer/LogCard.tsx
@@ -26,6 +26,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { selectLogs } from "./logSelectors";
 import { logActions } from "./logSlice";
 import { ErrorDisplay } from "@/layout/ErrorDisplay";
+import { type AppDispatch } from "@/extensionConsole/store";
 
 type OwnProps = {
   initialLevel?: MessageLevel;
@@ -40,9 +41,11 @@ const LogCard: React.FunctionComponent<OwnProps> = ({
   const [page, setPage] = useState(0);
 
   const { isLoading, isError, error } = useSelector(selectLogs);
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<AppDispatch>();
   const refreshEntries = () => dispatch(logActions.refreshEntries());
-  const clearAvailableEntries = () => dispatch(logActions.clear());
+  const clearAvailableEntries = async () => {
+    await dispatch(logActions.clear());
+  };
 
   const logs = useLogEntriesView({ level, page, perPage });
 

--- a/src/components/logViewer/logSlice.ts
+++ b/src/components/logViewer/logSlice.ts
@@ -49,7 +49,7 @@ export const initialLogState: LogState = {
  */
 const clear = createAsyncThunk<void, void, { state: LogRootState }>(
   "logs/clearStatus",
-  async (arg, thunkAPI) => {
+  async (_arg, thunkAPI) => {
     const activeContext = selectActiveContext(thunkAPI.getState());
     if (activeContext != null) {
       await clearLog(activeContext);
@@ -70,6 +70,7 @@ const pollLogs = createAsyncThunk<
   if (intervalTimeout) {
     // Clear previous polling call (if any)
     clearTimeout(intervalTimeout);
+    intervalTimeout = null;
   }
 
   const activeContext = selectActiveContext(thunkAPI.getState());
@@ -79,6 +80,7 @@ const pollLogs = createAsyncThunk<
   }
 
   intervalTimeout = setTimeout(
+    // XXX: will this cause a stack overflow eventually? Or does it get a fresh stack since it's via createAsyncThunk?
     async () => thunkAPI.dispatch(pollLogs()),
     REFRESH_INTERVAL,
   );
@@ -89,6 +91,7 @@ const pollLogs = createAsyncThunk<
 export function stopPollLogs(): void {
   if (intervalTimeout) {
     clearTimeout(intervalTimeout);
+    intervalTimeout = null;
   }
 }
 

--- a/src/components/logViewer/logSlice.ts
+++ b/src/components/logViewer/logSlice.ts
@@ -19,9 +19,11 @@ import { clearLog, getLogEntries, type LogEntry } from "@/telemetry/logging";
 import { type MessageContext } from "@/types/loggerTypes";
 import {
   type ActionReducerMapBuilder,
+  type AnyAction,
   createAsyncThunk,
   createSlice,
   type PayloadAction,
+  type ThunkDispatch,
 } from "@reduxjs/toolkit";
 import { isEqual } from "lodash";
 import { selectActiveContext } from "./logSelectors";
@@ -29,6 +31,8 @@ import { type LogRootState, type LogState } from "./logViewerTypes";
 import { castDraft } from "immer";
 
 const REFRESH_INTERVAL = 750;
+
+let intervalTimeout: NodeJS.Timeout | null = null;
 
 /** @internal */
 export const initialLogState: LogState = {
@@ -40,7 +44,9 @@ export const initialLogState: LogState = {
   error: null,
 };
 
-// Clear the logs in storage for the given context
+/**
+ * Clear the logs in storage for the given context
+ */
 const clear = createAsyncThunk<void, void, { state: LogRootState }>(
   "logs/clearStatus",
   async (arg, thunkAPI) => {
@@ -51,24 +57,40 @@ const clear = createAsyncThunk<void, void, { state: LogRootState }>(
   },
 );
 
-// Init the logs polling. Should be dispatched once at the start of the app
+/**
+ * @see usePollModLogs
+ */
 const pollLogs = createAsyncThunk<
   LogEntry[],
   void,
   {
     state: LogRootState;
   }
->("logs/polling", async (arg, thunkAPI) => {
+>("logs/polling", async (_arg, thunkAPI) => {
+  if (intervalTimeout) {
+    // Clear previous polling call (if any)
+    clearTimeout(intervalTimeout);
+  }
+
   const activeContext = selectActiveContext(thunkAPI.getState());
   let availableEntries: LogEntry[] = [];
   if (activeContext != null) {
     availableEntries = await getLogEntries(activeContext);
   }
 
-  setTimeout(async () => thunkAPI.dispatch(pollLogs()), REFRESH_INTERVAL);
+  intervalTimeout = setTimeout(
+    async () => thunkAPI.dispatch(pollLogs()),
+    REFRESH_INTERVAL,
+  );
 
   return availableEntries;
 });
+
+export function stopPollLogs(): void {
+  if (intervalTimeout) {
+    clearTimeout(intervalTimeout);
+  }
+}
 
 // Extract extraReducers. Otherwise, TypeScript was failing with "Excessive stack depth comparing types" after
 // updating to TypeScript 4.7. Other people seeing issues with TypeScript upgrade:
@@ -131,3 +153,5 @@ export const logActions = {
   clear,
   pollLogs,
 };
+
+export type LogDispatch = ThunkDispatch<LogRootState, unknown, AnyAction>;

--- a/src/components/logViewer/usePollModLogs.ts
+++ b/src/components/logViewer/usePollModLogs.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect } from "react";
+import {
+  logActions,
+  type LogDispatch,
+  stopPollLogs,
+} from "@/components/logViewer/logSlice";
+import { useDispatch } from "react-redux";
+
+/**
+ * Polls the mod logs for new entries for the active mod context.
+ * Should be included once at the top of the App React tree.
+ */
+function usePollModLogs(): void {
+  const dispatch = useDispatch<LogDispatch>();
+
+  useEffect(() => {
+    // Start polling logs
+    void dispatch(logActions.pollLogs());
+
+    return () => {
+      stopPollLogs();
+    };
+  }, [dispatch]);
+}
+
+export default usePollModLogs;

--- a/src/extensionConsole/App.tsx
+++ b/src/extensionConsole/App.tsx
@@ -15,13 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect } from "react";
-import store, {
-  type AppDispatch,
-  hashHistory,
-  persistor,
-} from "@/extensionConsole/store";
-import { Provider, useDispatch } from "react-redux";
+import React from "react";
+import store, { hashHistory, persistor } from "@/extensionConsole/store";
+import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
 import { Container } from "react-bootstrap";
 import ErrorBoundary from "@/components/ErrorBoundary";
@@ -50,7 +46,6 @@ import useFlags from "@/hooks/useFlags";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
 import RequireAuth from "@/auth/RequireAuth";
 import useTheme from "@/hooks/useTheme";
-import { logActions } from "@/components/logViewer/logSlice";
 import ReduxPersistenceContext, {
   type ReduxPersistenceContextType,
 } from "@/store/ReduxPersistenceContext";
@@ -61,6 +56,7 @@ import ActivateModPage from "@/extensionConsole/pages/activateMod/ActivateModPag
 import { RestrictedFeatures } from "@/auth/featureFlags";
 import { useLocation } from "react-router";
 import TeamTrialBanner from "@/components/teamTrials/TeamTrialBanner";
+import usePollModLogs from "@/components/logViewer/usePollModLogs";
 
 // Register the built-in bricks
 registerEditors();
@@ -71,13 +67,8 @@ registerContribBricks();
 registerDefaultWidgets();
 
 const AuthenticatedContent: React.VFC = () => {
-  const dispatch = useDispatch<AppDispatch>();
   const { permit } = useFlags();
-
-  useEffect(() => {
-    // Start polling logs
-    void dispatch(logActions.pollLogs());
-  }, [dispatch]);
+  usePollModLogs();
 
   return (
     <DeploymentsProvider>

--- a/src/extensionConsole/App.tsx
+++ b/src/extensionConsole/App.tsx
@@ -16,7 +16,11 @@
  */
 
 import React, { useEffect } from "react";
-import store, { hashHistory, persistor } from "@/extensionConsole/store";
+import store, {
+  type AppDispatch,
+  hashHistory,
+  persistor,
+} from "@/extensionConsole/store";
 import { Provider, useDispatch } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
 import { Container } from "react-bootstrap";
@@ -67,12 +71,12 @@ registerContribBricks();
 registerDefaultWidgets();
 
 const AuthenticatedContent: React.VFC = () => {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<AppDispatch>();
   const { permit } = useFlags();
 
   useEffect(() => {
     // Start polling logs
-    dispatch(logActions.pollLogs());
+    void dispatch(logActions.pollLogs());
   }, [dispatch]);
 
   return (

--- a/src/extensionConsole/pages/deployments/useDeactivateUnassignedDeploymentsEffect.ts
+++ b/src/extensionConsole/pages/deployments/useDeactivateUnassignedDeploymentsEffect.ts
@@ -18,13 +18,12 @@
 import { deactivateUnassignedModComponents } from "@/extensionConsole/pages/deployments/activateDeployments";
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
-import type { Dispatch } from "@reduxjs/toolkit";
 import type { ModInstance } from "@/types/modInstanceTypes";
 
 function useDeactivateUnassignedDeploymentsEffect(
   unassignedModInstances: ModInstance[],
 ): void {
-  const dispatch = useDispatch<Dispatch>();
+  const dispatch = useDispatch();
   useEffect(() => {
     if (unassignedModInstances.length === 0) {
       return;

--- a/src/modDefinitions/modDefinitionHooks.ts
+++ b/src/modDefinitions/modDefinitionHooks.ts
@@ -32,6 +32,8 @@ import { loadingAsyncStateFactory } from "@/utils/asyncStateUtils";
 import useMergeAsyncState from "@/hooks/useMergeAsyncState";
 import pluralize from "@/utils/pluralize";
 import { type Nullishable } from "@/utils/nullishUtils";
+import type { AnyAction, ThunkDispatch } from "@reduxjs/toolkit";
+import type { ModDefinitionsRootState } from "@/modDefinitions/modDefinitionsTypes";
 
 /**
  * Lookup a mod definition from the registry by ID, or null if it doesn't exist.
@@ -144,16 +146,16 @@ export function useRequiredModDefinitions(
  * Safe to include multiple times in the React tree, because it's connected to the Redux store.
  */
 export function useAllModDefinitions(): UseCachedQueryResult<ModDefinition[]> {
-  const dispatch = useDispatch();
-  const refetch = useCallback(
-    () => dispatch(modDefinitionsActions.syncRemoteModDefinitions()),
-    [dispatch],
-  );
+  const dispatch =
+    useDispatch<ThunkDispatch<ModDefinitionsRootState, unknown, AnyAction>>();
+  const refetch = useCallback(async () => {
+    await dispatch(modDefinitionsActions.syncRemoteModDefinitions());
+  }, [dispatch]);
   const state = useSelector(selectModDefinitionsAsyncState);
 
   // First load from local database
   useEffect(() => {
-    dispatch(modDefinitionsActions.loadModDefinitionsFromCache());
+    void dispatch(modDefinitionsActions.loadModDefinitionsFromCache());
   }, [dispatch]);
 
   // Load from remote data source once the local data has been loaded
@@ -163,7 +165,7 @@ export function useAllModDefinitions(): UseCachedQueryResult<ModDefinition[]> {
       !state.isLoadingFromCache &&
       !state.isCacheUninitialized
     ) {
-      dispatch(modDefinitionsActions.syncRemoteModDefinitions());
+      void dispatch(modDefinitionsActions.syncRemoteModDefinitions());
     }
   }, [
     dispatch,

--- a/src/modDefinitions/modDefinitionsSlice.ts
+++ b/src/modDefinitions/modDefinitionsSlice.ts
@@ -15,7 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import {
+  type AnyAction,
+  createAsyncThunk,
+  createSlice,
+  type ThunkDispatch,
+} from "@reduxjs/toolkit";
 import {
   type ModDefinitionsRootState,
   type ModDefinitionsState,
@@ -164,3 +169,9 @@ export const modDefinitionsActions = {
   loadModDefinitionsFromCache,
   syncRemoteModDefinitions,
 };
+
+export type ModDefinitionsDispatch = ThunkDispatch<
+  ModDefinitionsRootState,
+  unknown,
+  AnyAction
+>;

--- a/src/pageEditor/hooks/useAddNewModComponent.ts
+++ b/src/pageEditor/hooks/useAddNewModComponent.ts
@@ -45,6 +45,7 @@ import {
   selectModMetadatas,
 } from "@/pageEditor/store/editor/editorSelectors";
 import { RunReason } from "@/types/runtimeTypes";
+import { type AppDispatch } from "@/pageEditor/store/store";
 
 export type AddNewModComponent = (
   adapter: ModComponentFormStateAdapter,
@@ -68,7 +69,7 @@ function useFreshModNameGenerator(): () => string {
 }
 
 function useAddNewModComponent(modMetadata?: ModMetadata): AddNewModComponent {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<AppDispatch>();
   const { setInsertingStarterBrickType } = useInsertPane();
   // XXX: useFlags is async. The flag query might not be initialized by the time the callback is called. Ensure
   // useFlags has already been used on the page, e.g., the AddStarterBrickButton, to ensure the flags have loaded by
@@ -131,8 +132,8 @@ function useAddNewModComponent(modMetadata?: ModMetadata): AddNewModComponent {
 
         dispatch(actions.addModComponentFormState(initialFormState));
         // Need to explicitly check availability of the new component form state
-        // TODO: refactor this to be an implicit side-effect in the reducer (add action above possibly needs to be a thunk?)
-        dispatch(actions.checkActiveModComponentAvailability());
+        // TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/9389
+        void dispatch(actions.checkActiveModComponentAvailability());
 
         updateDraftModComponent(
           allFramesInInspectedTab,

--- a/src/pageEditor/layout/PanelContent.tsx
+++ b/src/pageEditor/layout/PanelContent.tsx
@@ -18,7 +18,7 @@
 import React, { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { tabStateActions } from "@/pageEditor/store/tabState/tabStateSlice";
-import { persistor } from "@/pageEditor/store/store";
+import { type AppDispatch, persistor } from "@/pageEditor/store/store";
 import { ModalProvider } from "@/components/ConfirmationModal";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import TabConnectionErrorBanner from "@/pageEditor/components/TabConnectionErrorBanner";
@@ -44,15 +44,15 @@ import { navigationEvent } from "@/pageEditor/events";
  * @see navigationEvent
  */
 function useConnectToContentScript(): void {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<AppDispatch>();
 
   useEffect(() => {
-    const connect = () => {
-      dispatch(tabStateActions.connectToContentScript());
+    const connect = async () => {
+      await dispatch(tabStateActions.connectToContentScript());
     };
 
     // Automatically connect on mount
-    connect();
+    void connect();
 
     navigationEvent.add(connect);
     return () => {
@@ -62,14 +62,14 @@ function useConnectToContentScript(): void {
 }
 
 const PanelContent: React.FC = () => {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<AppDispatch>();
   const trialStatus = useTeamTrialStatus();
 
   useConnectToContentScript();
 
   useEffect(() => {
     // Start polling logs
-    dispatch(logActions.pollLogs());
+    void dispatch(logActions.pollLogs());
   }, [dispatch]);
 
   const authPersistenceContext: ReduxPersistenceContextType = {

--- a/src/pageEditor/layout/PanelContent.tsx
+++ b/src/pageEditor/layout/PanelContent.tsx
@@ -26,7 +26,6 @@ import RequireAuth from "@/auth/RequireAuth";
 import LoginCard from "@/pageEditor/components/LoginCard";
 import EditorLayout from "@/pageEditor/layout/EditorLayout";
 import { PersistGate } from "redux-persist/integration/react";
-import { logActions } from "@/components/logViewer/logSlice";
 import ReduxPersistenceContext, {
   type ReduxPersistenceContextType,
 } from "@/store/ReduxPersistenceContext";
@@ -38,6 +37,7 @@ import useTeamTrialStatus, {
   TeamTrialStatus,
 } from "@/components/teamTrials/useTeamTrialStatus";
 import { navigationEvent } from "@/pageEditor/events";
+import usePollModLogs from "@/components/logViewer/usePollModLogs";
 
 /**
  * Hook to connect to the content script on Page Editor mount and on navigation events.
@@ -62,15 +62,10 @@ function useConnectToContentScript(): void {
 }
 
 const PanelContent: React.FC = () => {
-  const dispatch = useDispatch<AppDispatch>();
   const trialStatus = useTeamTrialStatus();
 
   useConnectToContentScript();
-
-  useEffect(() => {
-    // Start polling logs
-    void dispatch(logActions.pollLogs());
-  }, [dispatch]);
+  usePollModLogs();
 
   const authPersistenceContext: ReduxPersistenceContextType = {
     async flush() {

--- a/src/pageEditor/modListingPanel/ActivatedModComponentListItem.tsx
+++ b/src/pageEditor/modListingPanel/ActivatedModComponentListItem.tsx
@@ -50,6 +50,7 @@ import { appApi } from "@/data/service/api";
 import useAsyncState from "@/hooks/useAsyncState";
 import { inspectedTab } from "@/pageEditor/context/connection";
 import { StarterBrickTypes } from "@/types/starterBrickTypes";
+import { type AppDispatch } from "@/pageEditor/store/store";
 
 /**
  * A sidebar menu entry corresponding to an untouched mod component
@@ -61,7 +62,7 @@ const ActivatedModComponentListItem: React.FunctionComponent<{
   isNested?: boolean;
 }> = ({ modComponent, isAvailable, isNested = false }) => {
   const sessionId = useSelector(selectSessionId);
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<AppDispatch>();
   const { data: type } = useAsyncState(
     async () => selectType(modComponent),
     [modComponent.extensionPointId],
@@ -95,7 +96,8 @@ const ActivatedModComponentListItem: React.FunctionComponent<{
           }),
         );
 
-        dispatch(actions.checkActiveModComponentAvailability());
+        // TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/9389
+        void dispatch(actions.checkActiveModComponentAvailability());
 
         if (type === StarterBrickTypes.SIDEBAR_PANEL) {
           // Switch the sidepanel over to the panel. However, don't refresh because the user might be switching

--- a/src/pageEditor/modListingPanel/ModComponentActionMenu.tsx
+++ b/src/pageEditor/modListingPanel/ModComponentActionMenu.tsx
@@ -36,12 +36,13 @@ import {
 } from "@/pageEditor/store/editor/editorSelectors";
 import useClearModComponentChanges from "@/pageEditor/hooks/useClearModComponentChanges";
 import { actions } from "@/pageEditor/store/editor/editorSlice";
+import { type AppDispatch } from "@/pageEditor/store/store";
 
 const ModComponentActionMenu: React.FC<{
   modComponentFormState: ModComponentFormState;
   labelRoot: string;
 }> = ({ modComponentFormState, labelRoot }) => {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<AppDispatch>();
 
   const deleteDraftModComponent = useDeleteDraftModComponent();
   const clearModComponentChanges = useClearModComponentChanges();
@@ -75,7 +76,7 @@ const ModComponentActionMenu: React.FC<{
       title: "Duplicate",
       icon: <FontAwesomeIcon icon={faClone} fixedWidth />,
       async action() {
-        dispatch(
+        await dispatch(
           // Duplicate the mod component within the current mod
           actions.duplicateActiveModComponent(),
         );

--- a/src/pageEditor/modListingPanel/modals/MoveOrCopyToModModal.tsx
+++ b/src/pageEditor/modListingPanel/modals/MoveOrCopyToModModal.tsx
@@ -36,6 +36,7 @@ import { object, string } from "yup";
 import { type RegistryId } from "@/types/registryTypes";
 import { assertNotNullish } from "@/utils/nullishUtils";
 import { ModalKey } from "@/pageEditor/store/editor/pageEditorTypes";
+import { type AppDispatch } from "@/pageEditor/store/store";
 
 type FormState = {
   modId: RegistryId | null;
@@ -56,6 +57,7 @@ const formStateSchema = object({
  * @see selectKeepLocalCopyOnCreateMod
  */
 const MoveOrCopyToModModal: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>();
   const { isMoveCopyToModVisible: show } = useSelector(
     selectEditorModalVisibilities,
   );
@@ -66,8 +68,6 @@ const MoveOrCopyToModModal: React.FC = () => {
   const activeModComponentFormState = useSelector(
     selectActiveModComponentFormState,
   );
-
-  const dispatch = useDispatch();
 
   const hideModal = useCallback(() => {
     dispatch(editorActions.hideModal());
@@ -96,7 +96,7 @@ const MoveOrCopyToModModal: React.FC = () => {
       "Invalid for state: mod id does not match activate mod metadata entry",
     );
 
-    dispatch(
+    await dispatch(
       editorActions.duplicateActiveModComponent({
         destinationModMetadata: modMetadata,
       }),

--- a/src/pageEditor/panes/ModComponentEditorPane.tsx
+++ b/src/pageEditor/panes/ModComponentEditorPane.tsx
@@ -37,6 +37,7 @@ import { assertNotNullish } from "@/utils/nullishUtils";
 import useRegisterDraftModInstanceOnAllFrames from "@/pageEditor/hooks/useRegisterDraftModInstanceOnAllFrames";
 import { usePreviousValue } from "@/hooks/usePreviousValue";
 import type { EditorRootState } from "@/pageEditor/store/editor/pageEditorTypes";
+import type { AppDispatch } from "@/pageEditor/store/store";
 
 // CHANGE_DETECT_DELAY_MILLIS should be low enough so that sidebar gets updated in a reasonable amount of time, but
 // high enough that there isn't an entry lag in the page editor
@@ -66,7 +67,7 @@ function useGetFormReinitializationKey(): () => string {
 const EditorPaneContent: React.VoidFunctionComponent<{
   modComponentFormState: ModComponentFormState;
 }> = ({ modComponentFormState }) => {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<AppDispatch>();
   const getFormReinitializationKey = useGetFormReinitializationKey();
   const previousKey = useRef<string | null>(getFormReinitializationKey());
 
@@ -91,7 +92,8 @@ const EditorPaneContent: React.VoidFunctionComponent<{
         }),
       );
 
-      dispatch(actions.checkActiveModComponentAvailability());
+      // TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/9389
+      void dispatch(actions.checkActiveModComponentAvailability());
 
       previousKey.current = currentKey;
     },

--- a/src/pageEditor/store/editor/editorSelectors/editorAnalysisSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorAnalysisSelectors.ts
@@ -101,11 +101,11 @@ export const selectKnownEventNamesForActiveModComponent = createSelector(
 // TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/7462
 //  Use https://reselect.js.org/api/createstructuredselector/ after upgrading to RTK 2
 export const selectModComponentAvailability = createSelector(
-  (state: EditorRootState) => state.editor.availableActivatedModComponentIds,
-  (state: EditorRootState) =>
-    state.editor.isPendingAvailableActivatedModComponents,
-  (state: EditorRootState) => state.editor.availableDraftModComponentIds,
-  (state: EditorRootState) => state.editor.isPendingDraftModComponents,
+  ({ editor }: EditorRootState) => editor.availableActivatedModComponentIds,
+  ({ editor }: EditorRootState) =>
+    editor.isPendingAvailableActivatedModComponents,
+  ({ editor }: EditorRootState) => editor.availableDraftModComponentIds,
+  ({ editor }: EditorRootState) => editor.isPendingDraftModComponents,
   (
     availableActivatedModComponentIds,
     isPendingAvailableActivatedModComponents,

--- a/src/pageEditor/store/editor/editorSelectors/editorAnalysisSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorAnalysisSelectors.ts
@@ -98,16 +98,23 @@ export const selectKnownEventNamesForActiveModComponent = createSelector(
 );
 
 // Not analysis of the analysis engine/linter sense, but tracks which components are available on the page
-export const selectModComponentAvailability = ({
-  editor: {
+// TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/7462
+//  Use https://reselect.js.org/api/createstructuredselector/ after upgrading to RTK 2
+export const selectModComponentAvailability = createSelector(
+  (state: EditorRootState) => state.editor.availableActivatedModComponentIds,
+  (state: EditorRootState) =>
+    state.editor.isPendingAvailableActivatedModComponents,
+  (state: EditorRootState) => state.editor.availableDraftModComponentIds,
+  (state: EditorRootState) => state.editor.isPendingDraftModComponents,
+  (
     availableActivatedModComponentIds,
     isPendingAvailableActivatedModComponents,
     availableDraftModComponentIds,
     isPendingDraftModComponents,
-  },
-}: EditorRootState) => ({
-  availableActivatedModComponentIds,
-  isPendingAvailableActivatedModComponents,
-  availableDraftModComponentIds,
-  isPendingDraftModComponents,
-});
+  ) => ({
+    availableActivatedModComponentIds,
+    isPendingAvailableActivatedModComponents,
+    availableDraftModComponentIds,
+    isPendingDraftModComponents,
+  }),
+);

--- a/src/pageEditor/store/editor/editorSelectors/editorErrorSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorErrorSelectors.ts
@@ -17,11 +17,16 @@
 
 import type { EditorRootState } from "@/pageEditor/store/editor/pageEditorTypes";
 import { deserializeError } from "serialize-error";
+import { createSelector } from "@reduxjs/toolkit";
 
-export const selectErrorState = ({ editor }: EditorRootState) => ({
-  isBetaError: editor.error && editor.beta,
-  editorError: editor.error ? deserializeError(editor.error) : null,
-});
+export const selectErrorState = createSelector(
+  (state: EditorRootState) => state.editor.error,
+  (state: EditorRootState) => state.editor.beta,
+  (error, beta) => ({
+    isBetaError: error && beta,
+    editorError: error ? deserializeError(error) : null,
+  }),
+);
 
 export const selectIsDimensionsWarningDismissed = (state: EditorRootState) =>
   state.editor.isDimensionsWarningDismissed;

--- a/src/pageEditor/store/editor/editorSelectors/editorModComponentSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorModComponentSelectors.ts
@@ -82,8 +82,12 @@ export const selectActiveModComponentRef = createSelector(
 /// DELETE STATE
 ///
 
-export const selectAllDeletedModComponentIds = ({ editor }: EditorRootState) =>
-  new Set(Object.values(editor.deletedModComponentFormStateIdsByModId).flat());
+export const selectAllDeletedModComponentIds = createSelector(
+  ({ editor }: EditorRootState) =>
+    editor.deletedModComponentFormStateIdsByModId,
+  (deletedModComponentFormStateIdsByModId) =>
+    new Set(Object.values(deletedModComponentFormStateIdsByModId).flat()),
+);
 
 export const selectNotDeletedActivatedModComponents: ({
   options,

--- a/src/pageEditor/store/editor/editorSelectors/editorModalSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorModalSelectors.ts
@@ -21,19 +21,23 @@ import {
   ModalKey,
 } from "@/pageEditor/store/editor/pageEditorTypes";
 import type { Selector } from "react-redux";
+import { createSelector } from "@reduxjs/toolkit";
 
-export const selectEditorModalVisibilities = ({ editor }: EditorRootState) => {
-  const { type } = editor.visibleModal ?? {};
+export const selectEditorModalVisibilities = createSelector(
+  ({ editor }: EditorRootState) => editor.visibleModal,
+  (visibleModal) => {
+    const { type } = visibleModal ?? {};
 
-  return {
-    isMoveCopyToModVisible: type === ModalKey.MOVE_COPY_TO_MOD,
-    isSaveAsNewModModalVisible: type === ModalKey.SAVE_AS_NEW_MOD,
-    isCreateModModalVisible: type === ModalKey.CREATE_MOD,
-    isAddBlockModalVisible: type === ModalKey.ADD_BRICK,
-    isSaveDataIntegrityErrorModalVisible:
-      type === ModalKey.SAVE_DATA_INTEGRITY_ERROR,
-  };
-};
+    return {
+      isMoveCopyToModVisible: type === ModalKey.MOVE_COPY_TO_MOD,
+      isSaveAsNewModModalVisible: type === ModalKey.SAVE_AS_NEW_MOD,
+      isCreateModModalVisible: type === ModalKey.CREATE_MOD,
+      isAddBlockModalVisible: type === ModalKey.ADD_BRICK,
+      isSaveDataIntegrityErrorModalVisible:
+        type === ModalKey.SAVE_DATA_INTEGRITY_ERROR,
+    };
+  },
+);
 
 // Typescript-Fu for getModalDataSelector
 type ModalDataMap = {

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/StarterBrickOutputTab.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/StarterBrickOutputTab.tsx
@@ -28,11 +28,11 @@ import ViewModeField, {
   type ViewModeOption,
 } from "@/pageEditor/tabs/editTab/dataPanel/tabs/ViewModeField";
 import type { ValueOf } from "type-fest";
-import { makeSelectBrickTrace } from "@/pageEditor/store/runtime/runtimeSelectors";
 import DataTabJsonTree from "@/pageEditor/tabs/editTab/dataPanel/DataTabJsonTree";
 import StarterBrickPreview from "@/pageEditor/tabs/effect/StarterBrickPreview";
 import { assertNotNullish } from "@/utils/nullishUtils";
 import { type TraceRecord } from "@/telemetry/trace";
+import { selectGetBrickTraceRecord } from "@/pageEditor/store/runtime/runtimeSelectors";
 
 const OutputViewModes = {
   Actual: "actual",
@@ -68,9 +68,11 @@ function useStarterBrickTraceRecord(): TraceRecord | undefined {
 
   const firstBrickInstanceId = brickPipeline[0]?.instanceId;
 
-  const { record } = useSelector(makeSelectBrickTrace(firstBrickInstanceId));
+  const getBrickTraceRecord = useSelector(selectGetBrickTraceRecord);
 
-  return record;
+  return firstBrickInstanceId
+    ? getBrickTraceRecord(firstBrickInstanceId)?.record
+    : undefined;
 }
 
 const OutputActualBody: React.FC = () => {

--- a/src/sidebar/sidebarSelectors.ts
+++ b/src/sidebar/sidebarSelectors.ts
@@ -53,14 +53,12 @@ export const selectSidebarModActivationPanel = ({
 }: SidebarRootState) => sidebar.modActivationPanel;
 
 export const selectSidebarEntries = createSelector(
-  [
-    ({ sidebar }: SidebarRootState) => sidebar.panels,
-    ({ sidebar }: SidebarRootState) => sidebar.forms,
-    ({ sidebar }: SidebarRootState) => sidebar.temporaryPanels,
-    ({ sidebar }: SidebarRootState) => sidebar.staticPanels,
-    ({ sidebar }: SidebarRootState) => sidebar.modActivationPanel,
-  ],
-  // eslint-disable-next-line max-params -- reselect uses parameters for memoization
+  selectSidebarPanels,
+  selectSidebarForms,
+  selectSidebarTemporaryPanels,
+  selectSidebarStaticPanels,
+  selectSidebarModActivationPanel,
+  // eslint-disable-next-line max-params -- reselect uses parameters/args for memoization
   (panels, forms, temporaryPanels, staticPanels, modActivationPanel) => [
     ...panels,
     ...forms,

--- a/src/sidebar/sidebarSelectors.ts
+++ b/src/sidebar/sidebarSelectors.ts
@@ -52,13 +52,23 @@ export const selectSidebarModActivationPanel = ({
   sidebar,
 }: SidebarRootState) => sidebar.modActivationPanel;
 
-export const selectSidebarEntries = ({ sidebar }: SidebarRootState) => [
-  ...sidebar.panels,
-  ...sidebar.forms,
-  ...sidebar.temporaryPanels,
-  ...sidebar.staticPanels,
-  sidebar.modActivationPanel,
-];
+export const selectSidebarEntries = createSelector(
+  [
+    ({ sidebar }: SidebarRootState) => sidebar.panels,
+    ({ sidebar }: SidebarRootState) => sidebar.forms,
+    ({ sidebar }: SidebarRootState) => sidebar.temporaryPanels,
+    ({ sidebar }: SidebarRootState) => sidebar.staticPanels,
+    ({ sidebar }: SidebarRootState) => sidebar.modActivationPanel,
+  ],
+  // eslint-disable-next-line max-params -- reselect uses parameters for memoization
+  (panels, forms, temporaryPanels, staticPanels, modActivationPanel) => [
+    ...panels,
+    ...forms,
+    ...temporaryPanels,
+    ...staticPanels,
+    modActivationPanel,
+  ],
+);
 
 const selectEventKeyEntryMap = createSelector(
   selectSidebarEntries,


### PR DESCRIPTION
## What does this PR do?

- Stepping stone to #7462
- Bump react-redux from 7 to 8
- Closes #9251 (react-redux 8 seems to be better about logging console warnings for unmemoized selectors). I opened the Page Editor/Extension Console/Sidebar and looked for console warnings

## Discussion

- `react-redux` 9 (and therefore RTK 2) depends on React 18 because it drops the `useSyncExternalStore` polyfill (and others). We might be able to keep using that shim and bypass the requirement. But IMO we should likely bump to React 18 first

## Remaining Work

- [x] Fix type errors
- [x] Wait for CI E2E tests to run and fix bugs uncovered by E2E tests: infinite re-render, etc.

## Future Work

- Brownbag lightening talk on memoizing selectors

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
