### PR TITLE
Fix Upload Mixpanel Lexicon workflow & set to run in CI

### DIFF
--- a/.github/workflows/upload-mixpanel-lexicon.yml
+++ b/.github/workflows/upload-mixpanel-lexicon.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Compile TypeScript
-        run: npx tsc scripts/uploadMixpanelLexicon.ts --esModuleInterop
+        run: npx tsc scripts/uploadMixpanelLexicon.ts --esModuleInterop --lib esnext
       - name: Upload Lexicon
         if: github.ref_name == 'main'
         run: node scripts/uploadMixpanelLexicon.js

--- a/.github/workflows/upload-mixpanel-lexicon.yml
+++ b/.github/workflows/upload-mixpanel-lexicon.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Compile TypeScript
-        run: npx tsc scripts/uploadMixpanelLexicon.ts --esModuleInterop --lib es2022
+        run: npx tsc scripts/uploadMixpanelLexicon.ts --esModuleInterop --lib
       - name: Upload Lexicon
         if: github.ref_name == 'main'
         run: node scripts/uploadMixpanelLexicon.js

--- a/.github/workflows/upload-mixpanel-lexicon.yml
+++ b/.github/workflows/upload-mixpanel-lexicon.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Compile TypeScript
+        # Explicitly specify the TypeScript environment because tsconfig.json is ignored when input files are specified
         run: npx tsc scripts/uploadMixpanelLexicon.ts --esModuleInterop --lib esnext
       - name: Upload Lexicon
         if: github.ref_name == 'main'

--- a/.github/workflows/upload-mixpanel-lexicon.yml
+++ b/.github/workflows/upload-mixpanel-lexicon.yml
@@ -2,8 +2,6 @@ name: Upload Mixpanel Lexicon
 
 on:
   push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:
@@ -17,8 +15,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Compile TypeScript
-        run: npx tsc scripts/uploadMixpanelLexicon.ts --esModuleInterop
+        run: npx tsc scripts/uploadMixpanelLexicon.ts --esModuleInterop --lib es2022
       - name: Upload Lexicon
+        if: github.ref_name == 'main'
         run: node scripts/uploadMixpanelLexicon.js
         env:
           MIXPANEL_PROJECT_ID: ${{ secrets.MIXPANEL_PROJECT_ID }}

--- a/.github/workflows/upload-mixpanel-lexicon.yml
+++ b/.github/workflows/upload-mixpanel-lexicon.yml
@@ -2,6 +2,9 @@ name: Upload Mixpanel Lexicon
 
 on:
   push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/upload-mixpanel-lexicon.yml
+++ b/.github/workflows/upload-mixpanel-lexicon.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Compile TypeScript
-        run: npx tsc scripts/uploadMixpanelLexicon.ts --esModuleInterop --lib
+        run: npx tsc scripts/uploadMixpanelLexicon.ts --esModuleInterop
       - name: Upload Lexicon
         if: github.ref_name == 'main'
         run: node scripts/uploadMixpanelLexicon.js

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
   "extends": "@sindresorhus/tsconfig",
   "compilerOptions": {
     "sourceMap": true,
-    "module": "ES2020",
+    "module": "esnext",
+    "target": "es2023",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "baseUrl": ".",


### PR DESCRIPTION
## What does this PR do?

- The Upload Mixpanel Lexicon workflow broke due to a dependabot update, see context here: https://pixiebrix.slack.com/archives/C023KL47XV4/p1730746145290529
- This PR adds the `es2022` setting to the compile command, and
- Sets the workflow to run on every pull_request to main (but only actually upload the file on merge) so that we can catch breaking changes in the future