### PR TITLE
removing srcdoc sandbox iframe hack

### DIFF
--- a/scripts/__snapshots__/manifest.test.js.snap
+++ b/scripts/__snapshots__/manifest.test.js.snap
@@ -44,8 +44,9 @@ exports[`customizeManifest release builds beta 1`] = `
         "contentScript.js",
       ],
       "match_about_blank": true,
+      "match_origin_as_fallback": true,
       "matches": [
-        "*://*/*",
+        "<all_urls>",
       ],
       "run_at": "document_idle",
     },
@@ -196,8 +197,9 @@ exports[`customizeManifest release builds stable 1`] = `
         "contentScript.js",
       ],
       "match_about_blank": true,
+      "match_origin_as_fallback": true,
       "matches": [
-        "*://*/*",
+        "<all_urls>",
       ],
       "run_at": "document_idle",
     },

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,13 +24,14 @@
   },
   "content_scripts": [
     {
-      "matches": ["*://*/*"],
+      "matches": ["<all_urls>"],
       "exclude_matches": ["https://*.googleapis.com/*"],
       "js": ["contentScript.js"],
       "css": ["contentScript.css"],
       "all_frames": true,
       "match_about_blank": true,
-      "run_at": "document_idle"
+      "run_at": "document_idle",
+      "match_origin_as_fallback": true
     },
     {
       "matches": ["https://*/*"],


### PR DESCRIPTION
## What does this PR do?

- Removes the hack we were using to work-around the issue of the content script not running in sandbox srcdoc iframes since the underlying chromium bug is now fixed.
  - https://issues.chromium.org/issues/355256366?pli=1

## Future Work

- Clean up the unused feature flag once this is released and stable.

## Checklist

- [N/A] Added jest or playwright tests and/or storybook stories (Already covered by existing test)

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
