### PR TITLE
#9151 Add MarketplaceActivate and LinkExtension events to lexicon

### DIFF
--- a/src/activation/useActivateMod.ts
+++ b/src/activation/useActivateMod.ts
@@ -90,7 +90,7 @@ function useActivateMod(
       const isReactivate = Boolean(modInstance);
 
       if (source === "extensionConsole") {
-        reportEvent(Events.MARKETPLACE_ACTIVATE, {
+        reportEvent(Events.EXTENSION_CONSOLE_MOD_ACTIVATE, {
           ...selectActivateEventData(modDefinition),
           reactivate: isReactivate,
         });

--- a/src/activation/useActivateMod.ts
+++ b/src/activation/useActivateMod.ts
@@ -90,11 +90,6 @@ function useActivateMod(
       const isReactivate = Boolean(modInstance);
 
       if (source === "extensionConsole") {
-        // Note: The prefix "Marketplace" on the telemetry event name
-        // here is legacy terminology from before the public marketplace
-        // was created. It refers to the mod-list part of the mod component
-        // console, to distinguish that from the workshop.
-        // It's being kept to keep our metrics history clean.
         reportEvent(Events.MARKETPLACE_ACTIVATE, {
           ...selectActivateEventData(modDefinition),
           reactivate: isReactivate,

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -16,15 +16,17 @@
  */
 
 export const Events = {
-  ACTIVATION_INTEGRATION_CONFIG_SELECT: "AuthWidgetSelect",
-  ACTIVATION_INTEGRATION_REFRESH: "AuthWidgetRefresh",
   ACTIVATION_INTEGRATION_ADD_NEW_CLICK: "AuthWidgetShowAddNew",
   ACTIVATION_INTEGRATION_ADD_NEW_CLOSE: "AuthWidgetHideAddNew",
+  ACTIVATION_INTEGRATION_CONFIG_SELECT: "AuthWidgetSelect",
+  ACTIVATION_INTEGRATION_REFRESH: "AuthWidgetRefresh",
 
   BRICK_ADD: "BrickAdd",
   BRICK_COMMENTS_UPDATE: "BrickCommentsUpdate",
 
   BROWSER_ACTION_RESTRICTED_URL: "BrowserActionRestrictedUrl",
+
+  BUTTON_CLICK: "MenuItemClick",
 
   CUSTOM_USER_EVENT: "CustomUserEvent",
 
@@ -33,20 +35,20 @@ export const Events = {
   DEPLOYMENT_ACTIVATE: "DeploymentActivate",
   DEPLOYMENT_DEACTIVATE_ALL: "DeploymentDeactivateAll",
   DEPLOYMENT_DEACTIVATE_UNASSIGNED: "DeploymentDeactivateUnassigned",
-  DEPLOYMENT_REJECT_VERSION: "DeploymentRejectVersion",
-  DEPLOYMENT_REJECT_PERMISSIONS: "DeploymentRejectPermissions",
-  DEPLOYMENT_SYNC: "DeploymentSync",
   DEPLOYMENT_LIST: "DeploymentList",
+  DEPLOYMENT_REJECT_PERMISSIONS: "DeploymentRejectPermissions",
+  DEPLOYMENT_REJECT_VERSION: "DeploymentRejectVersion",
+  DEPLOYMENT_SYNC: "DeploymentSync",
   DEPLOYMENT_UPDATE_LIST: "DeploymentUpdateList",
 
-  DEVTOOLS_OPEN: "DevToolsOpen",
   DEVTOOLS_CLOSE: "DevToolsClose",
+  DEVTOOLS_OPEN: "DevToolsOpen",
 
   FACTORY_RESET: "FactoryReset",
 
   FLOATING_ACTION_BUTTON_CLICK: "FloatingQuickBarButtonClick",
-  FLOATING_ACTION_BUTTON_REPOSITION: "FloatingQuickBarButtonRepositioned",
   FLOATING_ACTION_BUTTON_ON_SCREEN_HIDE: "FloatingQuickBarButtonOnScreenHide",
+  FLOATING_ACTION_BUTTON_REPOSITION: "FloatingQuickBarButtonRepositioned",
 
   GOOGLE_FILE_PICKER_EVENT: "GoogleFilePickerEvent",
 
@@ -57,69 +59,63 @@ export const Events = {
   IDB_RECOVER_CONNECTION: "IDBRecoverConnection",
   IDB_UNRESPONSIVE_BANNER: "IDBUnresponsiveBanner",
 
-  INTEGRATION_WIDGET_SELECT: "IntegrationWidgetSelect",
+  INTEGRATION_ADD: "ServiceAdd",
   INTEGRATION_WIDGET_CLEAR: "IntegrationWidgetClear",
-  INTEGRATION_WIDGET_REFRESH: "IntegrationWidgetRefresh",
   INTEGRATION_WIDGET_CONFIGURE_LINK_CLICK:
     "IntegrationWidgetConfigureLinkClick",
-
-  INTEGRATION_ADD: "ServiceAdd",
+  INTEGRATION_WIDGET_REFRESH: "IntegrationWidgetRefresh",
+  INTEGRATION_WIDGET_SELECT: "IntegrationWidgetSelect",
 
   LINK_EXTENSION: "LinkExtension",
 
   MARKETPLACE_ACTIVATE: "MarketplaceActivate",
   MARKETPLACE_REJECT_PERMISSIONS: "MarketplaceRejectPermissions",
 
-  BUTTON_CLICK: "MenuItemClick",
+  MODS_PAGE_VIEW: "BlueprintsPageView",
 
   MOD_ACTIVATE: "InstallBlueprint",
   MOD_ACTIVATION_CANCEL: "CancelModActivation",
   MOD_ACTIVATION_SUBMIT: "SubmitModActivation",
-  MOD_CREATE_NEW: "ExtensionAddNew",
   MOD_ADD_STARTER_BRICK: "ModAddStarterBrick",
   MOD_COMPONENT_CLOUD_ACTIVATE: "ExtensionCloudActivate",
   MOD_COMPONENT_REMOVE: "ExtensionRemove",
+  MOD_CREATE_NEW: "ExtensionAddNew",
   MOD_REMOVE: "BlueprintRemove",
 
-  PACKAGE_DELETE: "BrickDelete",
-
-  MODS_PAGE_VIEW: "BlueprintsPageView",
-
+  OAUTH2_LOGIN_ERROR: "OAuth2LoginError",
   OAUTH2_LOGIN_START: "OAuth2LoginStart",
   OAUTH2_LOGIN_SUCCESS: "OAuth2LoginSuccess",
-  OAUTH2_LOGIN_ERROR: "OAuth2LoginError",
 
   ORGANIZATION_EXTENSION_LINK: "OrganizationExtensionLink",
 
-  PAGE_EDITOR_MOD_COMPONENT_UPDATE: "PageEditorCreate",
-  PAGE_EDITOR_OPEN: "PageEditorOpen",
+  PACKAGE_DELETE: "BrickDelete",
+  PANEL_ADD: "PanelAdd",
+
+  PAGE_EDITOR_CLEAR_CHANGES: "PageEditorReset",
   PAGE_EDITOR_MANUAL_RUN: "PageEditorManualRun",
   PAGE_EDITOR_MOD_COMPONENT_ERROR: "PageEditorExtensionError",
   PAGE_EDITOR_MOD_COMPONENT_REMOVE: "PageEditorRemove",
-  PAGE_EDITOR_CLEAR_CHANGES: "PageEditorReset",
-  PAGE_EDITOR_VIEW_TEMPLATES: "PageEditorViewTemplates",
+  PAGE_EDITOR_MOD_COMPONENT_UPDATE: "PageEditorCreate",
   PAGE_EDITOR_MOD_CREATE: "PageEditorModCreate",
-  PAGE_EDITOR_MOD_UPDATE: "PageEditorModUpdate",
   PAGE_EDITOR_MOD_SAVE_ERROR: "PageEditorModSaveError",
-
-  PAGE_EDITOR_SESSION_START: "PageEditorSessionStart",
+  PAGE_EDITOR_MOD_UPDATE: "PageEditorModUpdate",
+  PAGE_EDITOR_OPEN: "PageEditorOpen",
   PAGE_EDITOR_SESSION_END: "PageEditorSessionEnd",
-
+  PAGE_EDITOR_SESSION_START: "PageEditorSessionStart",
+  PAGE_EDITOR_VIEW_TEMPLATES: "PageEditorViewTemplates",
   PAGE_EDITOR_WALKTHROUGH_LINK_CLICK: "PageEditorWalkthroughLinkClick",
-  PAGE_EDITOR_WALKTHROUGH_MODAL_VIEW: "PageEditorWalkthroughModalView",
   PAGE_EDITOR_WALKTHROUGH_MODAL_CLOSE: "PageEditorWalkthroughModalClose",
+  PAGE_EDITOR_WALKTHROUGH_MODAL_VIEW: "PageEditorWalkthroughModalView",
 
-  VAR_POPOVER_SHOW: "VarPopoverShow",
-  VAR_POPOVER_SELECT: "VarPopoverSelect",
-
-  PANEL_ADD: "PanelAdd",
+  PERFORMANCE_MESSENGER_MANY_TABS_BROADCAST:
+    "PerformanceMessengerManyTabsBroadcast",
 
   PIXIEBRIX_INSTALL: "PixieBrixInstall",
   PIXIEBRIX_RELOAD: "PixieBrixReload",
   PIXIEBRIX_UPDATE: "PixieBrixUpdate",
 
-  SCHEMA_SELECT_WIDGET_SELECT: "SchemaSelectWidgetSelect",
   SCHEMA_SELECT_WIDGET_CLEAR: "SchemaSelectWidgetClear",
+  SCHEMA_SELECT_WIDGET_SELECT: "SchemaSelectWidgetSelect",
 
   SELECT_GOOGLE_SPREADSHEET_CANCELLED: "SelectGoogleSpreadsheetCancelled",
   SELECT_GOOGLE_SPREADSHEET_ENSURE_TOKEN_START:
@@ -132,31 +128,29 @@ export const Events = {
   SELECT_GOOGLE_SPREADSHEET_START: "SelectGoogleSpreadsheetStart",
   SELECT_GOOGLE_SPREADSHEET_VIEW_WARNING: "SelectGoogleSpreadsheetViewWarning",
 
+  SETTINGS_EXPERIMENTAL_CONFIGURE: "SettingsExperimentalConfigure",
   SIDEBAR_HIDE: "SidePanelHide",
   SIDEBAR_SHOW: "SidePanelShow",
   SIDEBAR_TAB_CLOSE: "SidebarTabClose",
 
+  SHORTCUT_SNIPPET_RUN: "TextCommandRun",
   SNOOZE_UPDATES: "SnoozeUpdates",
-  SETTINGS_EXPERIMENTAL_CONFIGURE: "SettingsExperimentalConfigure",
-
   START_MOD_ACTIVATE: "StartInstallBlueprint",
 
+  TOUR_END: "TourEnd",
   TOUR_START: "TourStart",
   TOUR_STEP: "TourStep",
-  TOUR_END: "TourEnd",
 
   TRIGGER_RUN: "TriggerRun",
-  PERFORMANCE_MESSENGER_MANY_TABS_BROADCAST:
-    "PerformanceMessengerManyTabsBroadcast",
 
   UNINITIALIZED_GAPI_GATE_VIEW: "UninitializedGapiGateView",
-
   UNSUPPORTED_BROWSER_GATE_VIEW: "UnsupportedBrowserGateView",
+
+  VAR_POPOVER_SELECT: "VarPopoverSelect",
+  VAR_POPOVER_SHOW: "VarPopoverShow",
 
   VIEW_ERROR: "ViewError",
   VIEW_SIDEBAR_PANEL: "ViewSidePanelPanel",
 
   ZAPIER_KEY_COPY: "ZapierKeyCopy",
-
-  SHORTCUT_SNIPPET_RUN: "TextCommandRun",
 } as const;

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -44,6 +44,8 @@ export const Events = {
   DEVTOOLS_CLOSE: "DevToolsClose",
   DEVTOOLS_OPEN: "DevToolsOpen",
 
+  EXTENSION_CONSOLE_MOD_ACTIVATE: "MarketplaceActivate",
+
   FACTORY_RESET: "FactoryReset",
 
   FLOATING_ACTION_BUTTON_CLICK: "FloatingQuickBarButtonClick",
@@ -68,7 +70,6 @@ export const Events = {
 
   LINK_EXTENSION: "LinkExtension",
 
-  MARKETPLACE_ACTIVATE: "MarketplaceActivate",
   MARKETPLACE_REJECT_PERMISSIONS: "MarketplaceRejectPermissions",
 
   MODS_PAGE_VIEW: "BlueprintsPageView",

--- a/src/telemetry/lexicon.ts
+++ b/src/telemetry/lexicon.ts
@@ -27,6 +27,7 @@ const LexiconTags = {
   ENTERPRISE: "enterprise",
   TEAM: "team",
   OBSOLETE: "obsolete",
+  AUTHENTICATION: "authentication",
 } as const;
 
 type LexiconTag = ValueOf<typeof LexiconTags>;
@@ -308,6 +309,15 @@ export const lexicon: LexiconMap = {
       )} event, which is reported when activating a mod ` +
       "in the Extension Console.",
     tags: [LexiconTags.PAGE_EDITOR],
+  },
+  LINK_EXTENSION: {
+    description:
+      "Triggered when the PixieBrix Extension authentication is obtained or updated by via visiting " +
+      "the Admin Console after successfully logging in. If authenticated, the Admin " +
+      "Console sends auth info in the PixieBrix Extension, a process we call 'linking'. If the " +
+      "extension is not linked, the user will be blocked by 'Link Extension' screens in the Extension Console, Page Editor, " +
+      "and Sidebar, as the majority of extension features will not work without authentication.",
+    tags: [LexiconTags.AUTHENTICATION],
   },
   PAGE_EDITOR_CLEAR_CHANGES: {
     description:

--- a/src/telemetry/lexicon.ts
+++ b/src/telemetry/lexicon.ts
@@ -319,6 +319,16 @@ export const lexicon: LexiconMap = {
       "and Sidebar, as the majority of extension features will not work without authentication.",
     tags: [LexiconTags.AUTHENTICATION],
   },
+  MARKETPLACE_ACTIVATE: {
+    description:
+      "[DEPRECATED] Triggered when a user clicks the 'Activate' button in the Extension Console on the mod " +
+      "activation page. Does not indicate activation success.\n" +
+      `This event is deprecated in favor of the ${getDisplayName(
+        "MOD_ACTIVATE",
+      )} event.`,
+    hidden: true,
+    tags: [LexiconTags.MOD_ACTIVATION, LexiconTags.EXTENSION_CONSOLE],
+  },
   PAGE_EDITOR_CLEAR_CHANGES: {
     description:
       "Reported when Clear Changes is clicked in 3-dot action action menu for a mod/mod component in the Page Editor",

--- a/src/telemetry/lexicon.ts
+++ b/src/telemetry/lexicon.ts
@@ -209,6 +209,16 @@ export const lexicon: LexiconMap = {
       "DevTools in the Extension Console or on internal chrome pages).",
     tags: [LexiconTags.PAGE_EDITOR],
   },
+  EXTENSION_CONSOLE_MOD_ACTIVATE: {
+    description:
+      "[DEPRECATED] Triggered when a user clicks the 'Activate' button in the Extension Console on the mod " +
+      "activation page. Does not indicate activation success.\n" +
+      `This event is deprecated in favor of the ${getDisplayName(
+        "MOD_ACTIVATE",
+      )} event, filtered by event property source='extensionConsole'.`,
+    hidden: true,
+    tags: [LexiconTags.MOD_ACTIVATION, LexiconTags.EXTENSION_CONSOLE],
+  },
   FACTORY_RESET: {
     description:
       "Reported when a user performs a factory reset of the PixieBrix Extension, which is available via " +
@@ -318,16 +328,6 @@ export const lexicon: LexiconMap = {
       "extension is not linked, the user will be blocked by 'Link Extension' screens in the Extension Console, Page Editor, " +
       "and Sidebar, as the majority of extension features will not work without authentication.",
     tags: [LexiconTags.AUTHENTICATION],
-  },
-  MARKETPLACE_ACTIVATE: {
-    description:
-      "[DEPRECATED] Triggered when a user clicks the 'Activate' button in the Extension Console on the mod " +
-      "activation page. Does not indicate activation success.\n" +
-      `This event is deprecated in favor of the ${getDisplayName(
-        "MOD_ACTIVATE",
-      )} event.`,
-    hidden: true,
-    tags: [LexiconTags.MOD_ACTIVATION, LexiconTags.EXTENSION_CONSOLE],
   },
   PAGE_EDITOR_CLEAR_CHANGES: {
     description:

--- a/src/telemetry/lexicon.ts
+++ b/src/telemetry/lexicon.ts
@@ -67,6 +67,23 @@ type LexiconMap = {
 
 // @ts-expect-error -- TODO: Remove this when the Lexicon is fully implemented https://github.com/pixiebrix/pixiebrix-extension/issues/9151
 export const lexicon: LexiconMap = {
+  ACTIVATION_INTEGRATION_ADD_NEW_CLICK: {
+    description:
+      "Reported on the mod activation page in the Extension Console when a user selects the '+ Add new' option to " +
+      "create a new integration configuration for the mod. A modal should appear for the user to create the configuration, " +
+      "but this event is triggered specifically when '+ Add new' option is clicked." +
+      "\n" +
+      `Not to be confused with the ${getDisplayName(
+        "INTEGRATION_WIDGET_CONFIGURE_LINK_CLICK",
+      )} event, which is reported in the Page Editor.`,
+    tags: [LexiconTags.MOD_ACTIVATION, LexiconTags.EXTENSION_CONSOLE],
+  },
+  ACTIVATION_INTEGRATION_ADD_NEW_CLOSE: {
+    description:
+      "Reported on the mod activation page in the Extension Console when a user closes the modal for creating a new " +
+      "integration configuration for the mod (either by clicking 'Cancel', 'Save' or 'X' in the modal).",
+    tags: [LexiconTags.MOD_ACTIVATION, LexiconTags.EXTENSION_CONSOLE],
+  },
   ACTIVATION_INTEGRATION_CONFIG_SELECT: {
     description:
       "Reported on the mod activation page in the Extension Console when a user selects an option in the dropdown menu " +
@@ -86,23 +103,6 @@ export const lexicon: LexiconMap = {
       `Not to be confused with the ${getDisplayName(
         "INTEGRATION_WIDGET_REFRESH",
       )} event, which is reported in the Page Editor.`,
-    tags: [LexiconTags.MOD_ACTIVATION, LexiconTags.EXTENSION_CONSOLE],
-  },
-  ACTIVATION_INTEGRATION_ADD_NEW_CLICK: {
-    description:
-      "Reported on the mod activation page in the Extension Console when a user selects the '+ Add new' option to " +
-      "create a new integration configuration for the mod. A modal should appear for the user to create the configuration, " +
-      "but this event is triggered specifically when '+ Add new' option is clicked." +
-      "\n" +
-      `Not to be confused with the ${getDisplayName(
-        "INTEGRATION_WIDGET_CONFIGURE_LINK_CLICK",
-      )} event, which is reported in the Page Editor.`,
-    tags: [LexiconTags.MOD_ACTIVATION, LexiconTags.EXTENSION_CONSOLE],
-  },
-  ACTIVATION_INTEGRATION_ADD_NEW_CLOSE: {
-    description:
-      "Reported on the mod activation page in the Extension Console when a user closes the modal for creating a new " +
-      "integration configuration for the mod (either by clicking 'Cancel', 'Save' or 'X' in the modal).",
     tags: [LexiconTags.MOD_ACTIVATION, LexiconTags.EXTENSION_CONSOLE],
   },
   BRICK_ADD: {
@@ -127,11 +127,6 @@ export const lexicon: LexiconMap = {
       "Event reported from the 'Send Telemetry' brick in a mod. Mod developers can customize the `eventName` " +
       "property and add additional properties to this event at will.",
     tags: [LexiconTags.MOD_RUNTIME],
-  },
-  PAGE_EDITOR_CLEAR_CHANGES: {
-    description:
-      "Reported when Clear Changes is clicked in 3-dot action action menu for a mod/mod component in the Page Editor",
-    tags: [LexiconTags.PAGE_EDITOR],
   },
   DATA_PANEL_TAB_VIEW: {
     description:
@@ -162,12 +157,13 @@ export const lexicon: LexiconMap = {
       "is assigned to a deployment by belonging to a group assigned to the deployment.",
     tags: [LexiconTags.TEAM],
   },
-  DEPLOYMENT_REJECT_VERSION: {
+  DEPLOYMENT_LIST: {
     description:
-      "Reported on the Mods Page in the Extension Console when a user is prompted to update the Extension " +
-      "in order to activate a deployed mod. The event is triggered after the user clicks 'Activate' on the deployment " +
-      "activation modal.",
-    tags: [LexiconTags.TEAM, LexiconTags.EXTENSION_CONSOLE],
+      "Reported every 5 minutes from the background when the PixieBrix Extension fetches deployments for users" +
+      "that belong to a team, with a list of all deployment ids for that user. This event is only reported for " +
+      "certain teams as specified by the `report-background-deployments` feature flag (see the Django Admin for a list " +
+      "of users with this flag).",
+    tags: [LexiconTags.TEAM, LexiconTags.ENTERPRISE],
   },
   DEPLOYMENT_REJECT_PERMISSIONS: {
     description:
@@ -176,19 +172,18 @@ export const lexicon: LexiconMap = {
       "the team deployment banner in the Extension Console.",
     tags: [LexiconTags.TEAM, LexiconTags.EXTENSION_CONSOLE],
   },
+  DEPLOYMENT_REJECT_VERSION: {
+    description:
+      "Reported on the Mods Page in the Extension Console when a user is prompted to update the Extension " +
+      "in order to activate a deployed mod. The event is triggered after the user clicks 'Activate' on the deployment " +
+      "activation modal.",
+    tags: [LexiconTags.TEAM, LexiconTags.EXTENSION_CONSOLE],
+  },
   DEPLOYMENT_SYNC: {
     description:
       "Reported every 5 minutes from the background when the PixieBrix Extension checks for deployment updates for users " +
       "that belong to a team. See event properties for information on update prompt status (the prompt shown to users " +
       "to activate deployed mods that can't be auto-activated in the background). This event is only reported for " +
-      "certain teams as specified by the `report-background-deployments` feature flag (see the Django Admin for a list " +
-      "of users with this flag).",
-    tags: [LexiconTags.TEAM, LexiconTags.ENTERPRISE],
-  },
-  DEPLOYMENT_LIST: {
-    description:
-      "Reported every 5 minutes from the background when the PixieBrix Extension fetches deployments for users" +
-      "that belong to a team, with a list of all deployment ids for that user. This event is only reported for " +
       "certain teams as specified by the `report-background-deployments` feature flag (see the Django Admin for a list " +
       "of users with this flag).",
     tags: [LexiconTags.TEAM, LexiconTags.ENTERPRISE],
@@ -201,15 +196,15 @@ export const lexicon: LexiconMap = {
       "Admin for a list of users with this flag).",
     tags: [LexiconTags.TEAM, LexiconTags.ENTERPRISE],
   },
-  DEVTOOLS_OPEN: {
-    description:
-      "Reported when the a user opens the DevTools on any modifiable web page (e.g. this event is not reported when opening the " +
-      "DevTools in the Extension Console or on internal chrome pages).",
-    tags: [LexiconTags.PAGE_EDITOR],
-  },
   DEVTOOLS_CLOSE: {
     description:
       "Reported when the DevTools are closed on any modifiable web page (e.g. this event is not reported when opening the " +
+      "DevTools in the Extension Console or on internal chrome pages).",
+    tags: [LexiconTags.PAGE_EDITOR],
+  },
+  DEVTOOLS_OPEN: {
+    description:
+      "Reported when the a user opens the DevTools on any modifiable web page (e.g. this event is not reported when opening the " +
       "DevTools in the Extension Console or on internal chrome pages).",
     tags: [LexiconTags.PAGE_EDITOR],
   },
@@ -224,17 +219,17 @@ export const lexicon: LexiconMap = {
       "Reported when a user clicks the floating action button on any web page for which it is shown.",
     tags: [LexiconTags.MOD_RUNTIME],
   },
-  FLOATING_ACTION_BUTTON_REPOSITION: {
-    description:
-      "Reported when the floating action button is repositioned on the page by clicking the drag handle and moving " +
-      "the button to a new location. Only reported once per page load.",
-    tags: [LexiconTags.MOD_RUNTIME],
-  },
   FLOATING_ACTION_BUTTON_ON_SCREEN_HIDE: {
     description:
       "Reported when the floating action button is hidden by clicking the 'Hide Button' button " +
       "that appears when hovering over the floating action button. Sets the Floating Action Button setting to 'disabled' " +
       "in the Extension Console settings.",
+    tags: [LexiconTags.MOD_RUNTIME],
+  },
+  FLOATING_ACTION_BUTTON_REPOSITION: {
+    description:
+      "Reported when the floating action button is repositioned on the page by clicking the drag handle and moving " +
+      "the button to a new location. Only reported once per page load.",
     tags: [LexiconTags.MOD_RUNTIME],
   },
   GOOGLE_FILE_PICKER_EVENT: {
@@ -275,21 +270,21 @@ export const lexicon: LexiconMap = {
       "your browser' for IndexedDB (IDB) errors is shown in the Extension Console",
     tags: [LexiconTags.EXTENSION_CONSOLE],
   },
-  INTEGRATION_WIDGET_SELECT: {
-    description:
-      "Reported in the Page Editor when a user selects a configuration from the integration field dropdown for a brick that uses an " +
-      "integration." +
-      "\n" +
-      `Not to be confused with the ${getDisplayName(
-        "ACTIVATION_INTEGRATION_CONFIG_SELECT",
-      )} event, which is reported when activating a mod ` +
-      "in the Extension Console.",
-    tags: [LexiconTags.PAGE_EDITOR],
-  },
   INTEGRATION_WIDGET_CLEAR: {
     description:
       "Reported in the Page Editor when a user clears the integration field for a brick that uses an integration " +
       "by clicking the 'X' button in the field.",
+    tags: [LexiconTags.PAGE_EDITOR],
+  },
+  INTEGRATION_WIDGET_CONFIGURE_LINK_CLICK: {
+    description:
+      "Reported in the Page Editor when a user clicks the 'Configure additional integrations here' link included " +
+      "underneath integration fields for bricks that use integrations." +
+      "\n" +
+      `Not to be confused with the ${getDisplayName(
+        "ACTIVATION_INTEGRATION_ADD_NEW_CLICK",
+      )} event, which is reported when activating a mod ` +
+      "in the Extension Console.",
     tags: [LexiconTags.PAGE_EDITOR],
   },
   INTEGRATION_WIDGET_REFRESH: {
@@ -303,15 +298,20 @@ export const lexicon: LexiconMap = {
       "in the Extension Console.",
     tags: [LexiconTags.PAGE_EDITOR],
   },
-  INTEGRATION_WIDGET_CONFIGURE_LINK_CLICK: {
+  INTEGRATION_WIDGET_SELECT: {
     description:
-      "Reported in the Page Editor when a user clicks the 'Configure additional integrations here' link included " +
-      "underneath integration fields for bricks that use integrations." +
+      "Reported in the Page Editor when a user selects a configuration from the integration field dropdown for a brick that uses an " +
+      "integration." +
       "\n" +
       `Not to be confused with the ${getDisplayName(
-        "ACTIVATION_INTEGRATION_ADD_NEW_CLICK",
+        "ACTIVATION_INTEGRATION_CONFIG_SELECT",
       )} event, which is reported when activating a mod ` +
       "in the Extension Console.",
+    tags: [LexiconTags.PAGE_EDITOR],
+  },
+  PAGE_EDITOR_CLEAR_CHANGES: {
+    description:
+      "Reported when Clear Changes is clicked in 3-dot action action menu for a mod/mod component in the Page Editor",
     tags: [LexiconTags.PAGE_EDITOR],
   },
 };


### PR DESCRIPTION
## What does this PR do?

- Part of #9151
- Also alphabetizes events.ts and lexicon.ts
- Deprecates `MarketplaceActivate` in favor of `ModActivate` (see description)
- Renames display name `MarketplaceActivate` -> `ExtensionConsoleModActivate`
- [x] Follow-up with team to confirm if anyone is still using `MarketplaceActivate`
