### PR TITLE
#3164: add explicit `PropsWithChildren` to types

### DIFF
--- a/src/__mocks__/@/components/DelayedRender.tsx
+++ b/src/__mocks__/@/components/DelayedRender.tsx
@@ -15,11 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import React from "react";
+import { EmptyObject } from "type-fest";
 
 /**
  * A mock for DelayedRender, because otherwise you have to use jest fake timers in tests.
  */
-const DelayedRender: React.FC = ({ children }) => (
+const DelayedRender: React.FC<React.PropsWithChildren<EmptyObject>> = ({
+  children,
+}) => (
   // Unlike the real DelayedRender, this wraps in a div so that we can add a data-testid for testing
   <div data-testid="DelayedRender">{children}</div>
 );

--- a/src/__mocks__/@/components/Stylesheets.tsx
+++ b/src/__mocks__/@/components/Stylesheets.tsx
@@ -21,10 +21,12 @@ import { castArray, uniq } from "lodash";
 /**
  * A mock for Stylesheets, because otherwise you have to use jest fake timers in tests.
  */
-export const Stylesheets: React.FC<{
-  href: string | string[];
-  mountOnLoad?: boolean;
-}> = ({ href, children }) => {
+export const Stylesheets: React.FC<
+  React.PropsWithChildren<{
+    href: string | string[];
+    mountOnLoad?: boolean;
+  }>
+> = ({ href, children }) => {
   const urls = uniq(castArray(href));
 
   return (

--- a/src/auth/RequireAuth.tsx
+++ b/src/auth/RequireAuth.tsx
@@ -129,7 +129,7 @@ const useRequiredAuth = () => {
  *   token-based authentication.
  * - Therefore, also check the extension has the Authentication header token from the server.
  */
-const RequireAuth: React.FC<RequireAuthProps> = ({
+const RequireAuth: React.FC<React.PropsWithChildren<RequireAuthProps>> = ({
   children,
   LoginPage,
   ignoreApiError = false,

--- a/src/auth/RequireScope.tsx
+++ b/src/auth/RequireScope.tsx
@@ -31,7 +31,9 @@ type RequireScopeProps = {
  * Ensures that the user has the required scope to view the page.
  * The auth error is not handled here, it is the responsibility of a parent component.
  */
-export const RequireScope: React.FunctionComponent<RequireScopeProps> = ({
+export const RequireScope: React.FunctionComponent<
+  React.PropsWithChildren<RequireScopeProps>
+> = ({
   isRequired = true,
   scopeSettingsTitle,
   scopeSettingsDescription,

--- a/src/bricks/transformers/ephemeralForm/EphemeralForm.tsx
+++ b/src/bricks/transformers/ephemeralForm/EphemeralForm.tsx
@@ -28,17 +28,20 @@ import useReportError from "@/hooks/useReportError";
 import IsolatedComponent from "@/components/IsolatedComponent";
 import { type EphemeralFormContentProps } from "./EphemeralFormContent";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import { type EmptyObject } from "type-fest";
 
-const ModalLayout: React.FC = ({ children }) => (
+const ModalLayout: React.FC<React.PropsWithChildren<EmptyObject>> = ({
+  children,
+}) => (
   // Don't use React Bootstrap's Modal because we want to customize the classes in the layout
   <div className="modal-content">
     <div className="modal-body">{children}</div>
   </div>
 );
 
-const PanelLayout: React.FC = ({ children }) => (
-  <div className="p-3">{children}</div>
-);
+const PanelLayout: React.FC<React.PropsWithChildren<EmptyObject>> = ({
+  children,
+}) => <div className="p-3">{children}</div>;
 
 const IsolatedEphemeralFormContent: React.FunctionComponent<
   EphemeralFormContentProps

--- a/src/bricks/transformers/temporaryInfo/EphemeralPanel.tsx
+++ b/src/bricks/transformers/temporaryInfo/EphemeralPanel.tsx
@@ -40,18 +40,16 @@ import { assertNotNullish } from "@/utils/nullishUtils";
 
 type Mode = "modal" | "popover";
 
-const ModalLayout: React.FC<{ className?: string }> = ({
-  className,
-  children,
-}) => (
+const ModalLayout: React.FC<
+  React.PropsWithChildren<{ className?: string }>
+> = ({ className, children }) => (
   // Don't use React Bootstrap's Modal because we want to customize the classes in the layout
   <div className={cx("modal-content", className)}>{children}</div>
 );
 
-const PopoverLayout: React.FC<{ className?: string }> = ({
-  className,
-  children,
-}) => (
+const PopoverLayout: React.FC<
+  React.PropsWithChildren<{ className?: string }>
+> = ({ className, children }) => (
   // Don't use React Bootstrap's Modal because we want to customize the classes in the layout
   // data-iframe-height is used by iframe-resizer
   <div className={cx("popover", className)} data-iframe-height="">

--- a/src/components/Centered.tsx
+++ b/src/components/Centered.tsx
@@ -18,10 +18,12 @@
 import React from "react";
 import cx from "classnames";
 
-const Centered: React.FunctionComponent<{
-  isScrollable?: boolean;
-  vertically?: boolean;
-}> = ({ isScrollable = false, vertically = false, children }) => (
+const Centered: React.FunctionComponent<
+  React.PropsWithChildren<{
+    isScrollable?: boolean;
+    vertically?: boolean;
+  }>
+> = ({ isScrollable = false, vertically = false, children }) => (
   <div
     className={cx("d-flex flex-column mx-auto mt-4 pb-2 max-550 text-center", {
       "h-100 overflow-auto": isScrollable,

--- a/src/components/DelayedRender.tsx
+++ b/src/components/DelayedRender.tsx
@@ -23,7 +23,10 @@ type Props = {
 };
 
 /** Component used to reduce flashing */
-const DelayedRender: React.FC<Props> = ({ children, millis }) => {
+const DelayedRender: React.FC<React.PropsWithChildren<Props>> = ({
+  children,
+  millis,
+}) => {
   const isShown = useTimeoutState(millis);
   // The hidden element allows us to preload the content (and images) while hidden.
   // Replacing this with `null` defeats the purpose of this component

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -108,7 +108,7 @@ export const DefaultErrorComponent: React.FC<ErrorDisplayProps> = ({
 
 class ErrorBoundary<
   Props extends BoundaryProps = BoundaryProps,
-> extends Component<Props, ErrorState> {
+> extends Component<React.PropsWithChildren<Props>, ErrorState> {
   override state: ErrorState = {
     error: undefined,
     hasError: false,

--- a/src/components/InvalidatedContextGate.tsx
+++ b/src/components/InvalidatedContextGate.tsx
@@ -64,7 +64,7 @@ const InformationPanel: React.FunctionComponent<ContextInvalidatedProps> = ({
  * Use `<AbortSignalGate signal={onContextInvalidated.signal}>` if you just want to unmount the children instead.
  */
 const InvalidatedContextGate: React.FunctionComponent<
-  ContextInvalidatedProps
+  React.PropsWithChildren<ContextInvalidatedProps>
 > = ({ children, ...props }) => {
   const wasContextInvalidated = useContextInvalidated();
 

--- a/src/components/Stylesheets.tsx
+++ b/src/components/Stylesheets.tsx
@@ -52,16 +52,18 @@ async function extractFontFaceRulesToMainDocument(
  *
  * Does not support changing the initial href(s)
  */
-export const Stylesheets: React.FC<{
-  href?: string | string[];
-  /**
-   * If true, we mount the component after the stylesheets are loaded.
-   * Chrome doesn't focus on the hidden elements so we want to make sure that component is rendered after the stylesheets are loaded.
-   * If false, we mount the component immediately.
-   * Include the DOM to start loading the subresources too
-   */
-  mountOnLoad?: boolean;
-}> = ({ href, children, mountOnLoad = false }) => {
+export const Stylesheets: React.FC<
+  React.PropsWithChildren<{
+    href?: string | string[];
+    /**
+     * If true, we mount the component after the stylesheets are loaded.
+     * Chrome doesn't focus on the hidden elements so we want to make sure that component is rendered after the stylesheets are loaded.
+     * If false, we mount the component immediately.
+     * Include the DOM to start loading the subresources too
+     */
+    mountOnLoad?: boolean;
+  }>
+> = ({ href, children, mountOnLoad = false }) => {
   const [resolved, setResolved] = useState<string[]>([]);
   if (!href?.length) {
     // Shortcut if no stylesheets are needed

--- a/src/components/banner/Banner.tsx
+++ b/src/components/banner/Banner.tsx
@@ -24,7 +24,7 @@ export interface BannerProps {
   variant?: BannerVariant;
 }
 
-const Banner: React.FunctionComponent<BannerProps> = ({
+const Banner: React.FunctionComponent<React.PropsWithChildren<BannerProps>> = ({
   variant,
   children,
 }) => (

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -133,7 +133,7 @@ const defaultRenderStatus: RenderStatus = ({ status }) => (
 
 const emptyObject = {} as const;
 
-const Form: React.FC<FormProps> = ({
+const Form: React.FC<React.PropsWithChildren<FormProps>> = ({
   // Default to {} to be defensive against callers that pass through null/undefined form state when uninitialized
   initialValues = emptyObject,
   children,

--- a/src/components/form/widgets/KeyNameWidget.tsx
+++ b/src/components/form/widgets/KeyNameWidget.tsx
@@ -24,7 +24,7 @@ const KeyNameWidget: React.FC<FormControlProps> = (props) => (
     <InputGroup.Prepend>
       <InputGroup.Text>@</InputGroup.Text>
     </InputGroup.Prepend>
-    <Form.Control {...props} />
+    <Form.Control {...props} as="input" />
   </InputGroup>
 );
 

--- a/src/components/formBuilder/DescriptionField.tsx
+++ b/src/components/formBuilder/DescriptionField.tsx
@@ -38,7 +38,7 @@ export const DescriptionField: React.VoidFunctionComponent<
       {typeof description === "string" ? (
         <MarkdownLazy markdown={description} />
       ) : (
-        { description }
+        <>{description}</>
       )}
     </div>
   );

--- a/src/components/formBuilder/DescriptionFieldTemplate.tsx
+++ b/src/components/formBuilder/DescriptionFieldTemplate.tsx
@@ -37,7 +37,7 @@ const DescriptionFieldTemplate: React.VoidFunctionComponent<
       {typeof description === "string" ? (
         <MarkdownLazy markdown={description} />
       ) : (
-        { description }
+        <>{description}</>
       )}
     </div>
   );

--- a/src/components/logViewer/details/OutputDetail.tsx
+++ b/src/components/logViewer/details/OutputDetail.tsx
@@ -24,7 +24,7 @@ const OutputDetail: React.FunctionComponent<{
   data: SetRequired<LogEntry, "data">["data"];
 }> = ({ data }) => (
   <>
-    {data.outputKey && <code>{data.outputKey}</code>}
+    {data.outputKey != null && <code>{String(data.outputKey)}</code>}
     <JsonTree data={data.output} />
   </>
 );

--- a/src/components/onboarding/OnboardingChecklistCard.tsx
+++ b/src/components/onboarding/OnboardingChecklistCard.tsx
@@ -23,13 +23,15 @@ import styles from "./OnboardingChecklistCard.module.scss";
 import Loader from "@/components/Loader";
 import cx from "classnames";
 
-export const OnboardingStep: React.FunctionComponent<{
-  number: number;
-  title?: string;
-  completed?: boolean;
-  active?: boolean;
-  isLoading?: boolean;
-}> = ({ number, title, completed, active, isLoading = false, children }) => {
+export const OnboardingStep: React.FunctionComponent<
+  React.PropsWithChildren<{
+    number: number;
+    title?: string;
+    completed?: boolean;
+    active?: boolean;
+    isLoading?: boolean;
+  }>
+> = ({ number, title, completed, active, isLoading = false, children }) => {
   const circleIconStyle = completed
     ? styles.circleIconSuccess
     : active
@@ -71,9 +73,11 @@ export const OnboardingStep: React.FunctionComponent<{
   );
 };
 
-const OnboardingChecklistCard: React.FunctionComponent<{
-  title?: string;
-}> = ({ title, children }) => {
+const OnboardingChecklistCard: React.FunctionComponent<
+  React.PropsWithChildren<{
+    title?: string;
+  }>
+> = ({ title, children }) => {
   const checklistCard = (
     <Card className={styles.checklistCard}>
       <ListGroup>{children}</ListGroup>

--- a/src/extensionConsole/components/RequireBrickRegistry.tsx
+++ b/src/extensionConsole/components/RequireBrickRegistry.tsx
@@ -21,11 +21,14 @@ import brickRegistry from "@/bricks/registry";
 import integrationRegistry from "@/integrations/registry";
 import starterBrickRegistry from "@/starterBricks/registry";
 import AsyncStateGate from "@/components/AsyncStateGate";
+import type { EmptyObject } from "type-fest";
 
 /**
  * Loading gate that requires brick definitions to be available before rendering children.
  */
-const RequireBrickRegistry: React.FC = ({ children }) => {
+const RequireBrickRegistry: React.FC<React.PropsWithChildren<EmptyObject>> = ({
+  children,
+}) => {
   const state = useAsyncState(
     async () =>
       Promise.all([

--- a/src/extensionConsole/pages/activateMod/ActivateModCard.tsx
+++ b/src/extensionConsole/pages/activateMod/ActivateModCard.tsx
@@ -96,7 +96,7 @@ const ActivateModCard: React.FC<{
   } = useActivateModWizard(modDefinition);
 
   const activateMod = useActivateMod("extensionConsole");
-  const [activationError, setActivationError] = useState<unknown>();
+  const [activationError, setActivationError] = useState<string | undefined>();
   const [createMilestone] = useCreateMilestoneMutation();
 
   const { hasMilestone } = useMilestones();
@@ -127,7 +127,9 @@ const ActivateModCard: React.FC<{
           />
         </Card.Header>
         <Card.Body className={styles.wizardBody}>
-          {activationError && <Alert variant="danger">{activationError}</Alert>}
+          {activationError != null && (
+            <Alert variant="danger">{activationError}</Alert>
+          )}
 
           {instructions && (
             <div>

--- a/src/extensionConsole/pages/deployments/DeploymentsContext.test.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentsContext.test.tsx
@@ -74,7 +74,7 @@ const Component: React.FC = () => {
       <AsyncButton onClick={async () => deployments.update()}>
         Update
       </AsyncButton>
-      {deployments.error && (
+      {deployments.error != null && (
         <div data-testid="Error">{getErrorMessage(deployments.error)}</div>
       )}
     </div>

--- a/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
@@ -56,6 +56,7 @@ import { RestrictedFeatures } from "@/auth/featureFlags";
 import { selectModInstances } from "@/store/modComponents/modInstanceSelectors";
 import type { ModInstance } from "@/types/modInstanceTypes";
 import { type AppDispatch } from "@/extensionConsole/store";
+import { type EmptyObject } from "type-fest";
 
 export type DeploymentsState = {
   /**
@@ -301,7 +302,9 @@ const DeploymentsContext = React.createContext<DeploymentsState>(defaultValue);
  * @see DeploymentBanner
  * @see useOnboarding
  */
-export const DeploymentsProvider: React.FC = ({ children }) => {
+export const DeploymentsProvider: React.FC<
+  React.PropsWithChildren<EmptyObject>
+> = ({ children }) => {
   const deployments = useDeployments();
 
   return (

--- a/src/extensionConsole/pages/mods/modals/shareModals/PublishModModals.test.tsx
+++ b/src/extensionConsole/pages/mods/modals/shareModals/PublishModModals.test.tsx
@@ -30,6 +30,7 @@ import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinition
 import { metadataFactory } from "@/testUtils/factories/metadataFactory";
 import { authStateFactory } from "@/testUtils/factories/authFactories";
 import { API_PATHS } from "@/data/service/urlPaths";
+import { type EmptyObject } from "type-fest";
 
 let modDefinition: ModDefinition;
 let auth: AuthState;
@@ -44,7 +45,9 @@ jest.mock("@/modDefinitions/modDefinitionHooks", () => ({
 /**
  * Wrapper component to fetch marketplace listings because the PublishRecipeModals component does not fetch.
  */
-const MarketplaceListingsWrapper: React.FC = ({ children }) => {
+const MarketplaceListingsWrapper: React.FC<
+  React.PropsWithChildren<EmptyObject>
+> = ({ children }) => {
   useGetMarketplaceListingsQuery();
   return <>{children}</>;
 };

--- a/src/extensionConsole/pages/onboarding/SetupPage.tsx
+++ b/src/extensionConsole/pages/onboarding/SetupPage.tsx
@@ -37,10 +37,11 @@ import integrationRegistry from "@/integrations/registry";
 import reportError from "@/telemetry/reportError";
 import useReportError from "@/hooks/useReportError";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import { type EmptyObject } from "type-fest";
 
-const Layout: React.FunctionComponent = ({ children }) => (
-  <div className="mt-5 w-100 max-550 mx-auto">{children}</div>
-);
+const Layout: React.FunctionComponent<React.PropsWithChildren<EmptyObject>> = ({
+  children,
+}) => <div className="mt-5 w-100 max-550 mx-auto">{children}</div>;
 
 /**
  * Extension Setup Page, guiding user to link to PixieBrix or connect via partner authentication.

--- a/src/extensionConsole/pages/packageEditor/referenceTab/DetailSection.tsx
+++ b/src/extensionConsole/pages/packageEditor/referenceTab/DetailSection.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 
-const DetailSection: React.FunctionComponent<{ title: string }> = ({
-  title,
-  children,
-}) => (
+const DetailSection: React.FunctionComponent<
+  React.PropsWithChildren<{ title: string }>
+> = ({ title, children }) => (
   <div className="my-4">
     <div className="font-weight-bold">{title}</div>
     <div className="py-2">{children}</div>

--- a/src/extensionConsole/pages/settings/SettingsPage.tsx
+++ b/src/extensionConsole/pages/settings/SettingsPage.tsx
@@ -29,13 +29,14 @@ import { useSelector } from "react-redux";
 import StorageSettings from "@/extensionConsole/pages/settings/StorageSettings";
 import GeneralSettings from "@/extensionConsole/pages/settings/GeneralSettings";
 import { FeatureFlags, RestrictedFeatures } from "@/auth/featureFlags";
+import { type EmptyObject } from "type-fest";
 
 // eslint-disable-next-line prefer-destructuring -- process.env substitution
 const DEBUG = process.env.DEBUG;
 
-const Section: React.FunctionComponent = ({ children }) => (
-  <div className="mb-4">{children}</div>
-);
+const Section: React.FunctionComponent<
+  React.PropsWithChildren<EmptyObject>
+> = ({ children }) => <div className="mb-4">{children}</div>;
 
 const SettingsPage: React.FunctionComponent = () => {
   const organization = useSelector(selectOrganization);

--- a/src/hooks/useFlags.test.tsx
+++ b/src/hooks/useFlags.test.tsx
@@ -36,7 +36,10 @@ import { API_PATHS } from "@/data/service/urlPaths";
 
 const testFlag = featureFlagFactory();
 
-const TestComponent: React.FC<{ name: string }> = ({ name, children }) => {
+const TestComponent: React.FC<React.PropsWithChildren<{ name: string }>> = ({
+  name,
+  children,
+}) => {
   const { flagOn } = useFlags();
 
   return (

--- a/src/pageEditor/components/DimensionGate.tsx
+++ b/src/pageEditor/components/DimensionGate.tsx
@@ -26,6 +26,7 @@ import devtoolsDockingContextMenu from "@img/devtools-docking-context-menu.png";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEllipsisV } from "@fortawesome/free-solid-svg-icons";
 import devtoolsDockBottomIcon from "@img/devtools-dock-bottom-icon.svg";
+import { type EmptyObject } from "type-fest";
 
 export const GatePanel: React.FunctionComponent = () => {
   const dispatch = useDispatch();
@@ -89,7 +90,9 @@ export const GatePanel: React.FunctionComponent = () => {
 /**
  * A React component to show a warning if the frame is in portrait layout.
  */
-const DimensionGate: React.FunctionComponent = ({ children }) => {
+const DimensionGate: React.FunctionComponent<
+  React.PropsWithChildren<EmptyObject>
+> = ({ children }) => {
   const isDimensionsWarningDismissed = useSelector(
     selectIsDimensionsWarningDismissed,
   );

--- a/src/pageEditor/context/TabInspectionGate.tsx
+++ b/src/pageEditor/context/TabInspectionGate.tsx
@@ -24,6 +24,7 @@ import useAsyncState from "@/hooks/useAsyncState";
 import { queryTabs } from "@/background/messenger/api";
 import { Button } from "react-bootstrap";
 import { getErrorMessage } from "@/errors/errorHelpers";
+import { type EmptyObject } from "type-fest";
 
 /**
  * Tab inspection selection component.
@@ -77,7 +78,9 @@ const TabSelector: React.FC<{ onSelect: (tabId: number) => void }> = ({
  *
  * @since 1.8.10
  */
-const TabInspectionGate: React.FC = ({ children }) => {
+const TabInspectionGate: React.FC<React.PropsWithChildren<EmptyObject>> = ({
+  children,
+}) => {
   const [showTabSelector, setShowTabSelector] = useState(false);
 
   useEffect(() => {

--- a/src/pageEditor/documentBuilder/preview/elementsPreview/Basic.tsx
+++ b/src/pageEditor/documentBuilder/preview/elementsPreview/Basic.tsx
@@ -30,7 +30,7 @@ type BasicProps = PreviewComponentProps & {
   documentBuilderComponent: DocumentBuilderComponent;
 };
 
-const Basic: React.FunctionComponent<BasicProps> = ({
+const Basic: React.FunctionComponent<React.PropsWithChildren<BasicProps>> = ({
   elementType,
   documentBuilderComponent: { Component, props },
   children,

--- a/src/pageEditor/documentBuilder/preview/elementsPreview/Button.tsx
+++ b/src/pageEditor/documentBuilder/preview/elementsPreview/Button.tsx
@@ -33,7 +33,7 @@ type ButtonProps = PreviewComponentProps & {
   buttonProps: ButtonElementConfig;
 };
 
-const Button: React.FunctionComponent<ButtonProps> = ({
+const Button: React.FunctionComponent<React.PropsWithChildren<ButtonProps>> = ({
   element,
   children,
   className,

--- a/src/pageEditor/documentBuilder/preview/elementsPreview/Card.tsx
+++ b/src/pageEditor/documentBuilder/preview/elementsPreview/Card.tsx
@@ -31,7 +31,7 @@ type CardProps = PreviewComponentProps & {
   documentBuilderComponent: DocumentBuilderComponent;
 };
 
-const Card: React.FunctionComponent<CardProps> = ({
+const Card: React.FunctionComponent<React.PropsWithChildren<CardProps>> = ({
   element,
   documentBuilderComponent: { Component, props },
   children,

--- a/src/pageEditor/documentBuilder/preview/elementsPreview/Container.tsx
+++ b/src/pageEditor/documentBuilder/preview/elementsPreview/Container.tsx
@@ -31,7 +31,9 @@ type ContainerProps = PreviewComponentProps & {
   documentBuilderComponent: DocumentBuilderComponent;
 };
 
-const Container: React.FunctionComponent<ContainerProps> = ({
+const Container: React.FunctionComponent<
+  React.PropsWithChildren<ContainerProps>
+> = ({
   element,
   documentBuilderComponent: { Component, props },
   children,

--- a/src/pageEditor/documentBuilder/preview/elementsPreview/Image.tsx
+++ b/src/pageEditor/documentBuilder/preview/elementsPreview/Image.tsx
@@ -33,7 +33,7 @@ type ImageProps = PreviewComponentProps & {
   documentBuilderComponent: DocumentBuilderComponent;
 };
 
-const Image: React.FunctionComponent<ImageProps> = ({
+const Image: React.FunctionComponent<React.PropsWithChildren<ImageProps>> = ({
   elementType,
   documentBuilderComponent: { Component, props },
   children,

--- a/src/pageEditor/documentBuilder/preview/elementsPreview/List.tsx
+++ b/src/pageEditor/documentBuilder/preview/elementsPreview/List.tsx
@@ -30,7 +30,7 @@ type ListProps = PreviewComponentProps & {
   element: DocumentBuilderElement;
 };
 
-const List: React.FunctionComponent<ListProps> = ({
+const List: React.FunctionComponent<React.PropsWithChildren<ListProps>> = ({
   element,
   children,
   className,
@@ -63,8 +63,10 @@ const List: React.FunctionComponent<ListProps> = ({
         isHovered={isHovered}
         isActive={isActive}
       />
-      <div className="text-muted">List: {arrayValue}</div>
-      <div className="text-muted">Element key: @{elementKey || "element"}</div>
+      <div className="text-muted">List: {String(arrayValue)}</div>
+      <div className="text-muted">
+        Element key: @{elementKey ? String(elementKey) : "element"}
+      </div>
       {children}
     </div>
   );

--- a/src/pageEditor/documentBuilder/preview/elementsPreview/Pipeline.tsx
+++ b/src/pageEditor/documentBuilder/preview/elementsPreview/Pipeline.tsx
@@ -30,7 +30,9 @@ type PipelineProps = PreviewComponentProps & {
   element: DocumentBuilderElement;
 };
 
-const Pipeline: React.FunctionComponent<PipelineProps> = ({
+const Pipeline: React.FunctionComponent<
+  React.PropsWithChildren<PipelineProps>
+> = ({
   element,
   children,
   className,

--- a/src/pageEditor/documentBuilder/preview/elementsPreview/Unknown.tsx
+++ b/src/pageEditor/documentBuilder/preview/elementsPreview/Unknown.tsx
@@ -27,7 +27,9 @@ type UnknownProps = PreviewComponentProps & {
   documentBuilderComponent: DocumentBuilderComponent;
 };
 
-const Unknown: React.FunctionComponent<UnknownProps> = ({
+const Unknown: React.FunctionComponent<
+  React.PropsWithChildren<UnknownProps>
+> = ({
   documentBuilderComponent: { Component, props },
   children,
   className,

--- a/src/pageEditor/fields/CollapsibleFieldSection.tsx
+++ b/src/pageEditor/fields/CollapsibleFieldSection.tsx
@@ -22,21 +22,25 @@ import cx from "classnames";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronRight } from "@fortawesome/free-solid-svg-icons";
 
-export const UncollapsibleFieldSection: React.FC<{
-  title: React.ReactNode;
-}> = ({ title, children }) => (
+export const UncollapsibleFieldSection: React.FC<
+  React.PropsWithChildren<{
+    title: React.ReactNode;
+  }>
+> = ({ title, children }) => (
   <div className={styles.root}>
     <div className={styles.header}>{title}</div>
     <div className={styles.body}>{children}</div>
   </div>
 );
 
-const CollapsibleFieldSection: React.FC<{
-  title: React.ReactNode;
-  toggleExpanded: () => void;
-  expanded?: boolean;
-  bodyRef?: React.MutableRefObject<HTMLDivElement | null>;
-}> = ({ title, toggleExpanded, expanded, children, bodyRef }) => {
+const CollapsibleFieldSection: React.FC<
+  React.PropsWithChildren<{
+    title: React.ReactNode;
+    toggleExpanded: () => void;
+    expanded?: boolean;
+    bodyRef?: React.MutableRefObject<HTMLDivElement | null>;
+  }>
+> = ({ title, toggleExpanded, expanded, children, bodyRef }) => {
   const headerRef = useRef<HTMLButtonElement | null>(null);
 
   const onToggle = (event: React.MouseEvent | React.KeyboardEvent) => {

--- a/src/pageEditor/modListingPanel/ModListItem.tsx
+++ b/src/pageEditor/modListingPanel/ModListItem.tsx
@@ -39,9 +39,11 @@ import { useGetModDefinitionQuery } from "@/data/service/api";
 import { type ModMetadata } from "@/types/modComponentTypes";
 import ModActionMenu from "@/pageEditor/modListingPanel/ModActionMenu";
 
-const ModListItem: React.FC<{
-  modMetadata: ModMetadata;
-}> = ({ modMetadata, children }) => {
+const ModListItem: React.FC<
+  React.PropsWithChildren<{
+    modMetadata: ModMetadata;
+  }>
+> = ({ modMetadata, children }) => {
   const dispatch = useDispatch();
   const activeModId = useSelector(selectActiveModId);
   const expandedModId = useSelector(selectExpandedModId);

--- a/src/pageEditor/modListingPanel/ModListingPanel.tsx
+++ b/src/pageEditor/modListingPanel/ModListingPanel.tsx
@@ -40,9 +40,11 @@ import { FeatureFlags } from "@/auth/featureFlags";
  * conflicts with our own layout.
  */
 const CollapsedElement: React.FC<
-  Omit<React.ComponentProps<typeof BootstrapCollapse>, "children"> & {
-    className?: string;
-  }
+  React.PropsWithChildren<
+    Omit<React.ComponentProps<typeof BootstrapCollapse>, "children"> & {
+      className?: string;
+    }
+  >
 > = ({ children, className, ...props }) => (
   <BootstrapCollapse unmountOnExit={true} {...props}>
     <div className={className}>{children}</div>

--- a/src/pageEditor/panes/insert/InsertPane.tsx
+++ b/src/pageEditor/panes/insert/InsertPane.tsx
@@ -24,6 +24,7 @@ import InsertButtonPane from "@/pageEditor/panes/insert/InsertButtonPane";
 import useEscapeHandler from "@/pageEditor/hooks/useEscapeHandler";
 import { inspectedTab } from "@/pageEditor/context/connection";
 import { cancelSelect } from "@/contentScript/messenger/api";
+import { type EmptyObject } from "type-fest";
 
 type InsertPaneContextProps = {
   insertingStarterBrickType: StarterBrickType | null;
@@ -56,7 +57,7 @@ export function useInsertPane(): InsertPaneContextProps {
   return useContext(InsertPaneContext);
 }
 
-const InsertPane: React.FC = () => {
+const InsertPane: React.FC<React.PropsWithChildren<EmptyObject>> = () => {
   const { insertingStarterBrickType, setInsertingStarterBrickType } =
     useInsertPane();
 

--- a/src/pageEditor/tabs/editTab/dataPanel/DataTabPane.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataTabPane.tsx
@@ -33,9 +33,11 @@ import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
  * @param children the tab content
  */
 const DataTabPane: React.FC<
-  TabPaneProps & {
-    isDeveloperOnly?: boolean;
-  }
+  React.PropsWithChildren<
+    TabPaneProps & {
+      isDeveloperOnly?: boolean;
+    }
+  >
 > = ({ children, isDeveloperOnly = false, ...tabProps }) => (
   <Tab.Pane
     className={dataPanelStyles.tabPane}

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/nodeSummary.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/nodeSummary.tsx
@@ -36,6 +36,7 @@ export function getBrickPipelineNodeSummary(
 
   if (
     brickConfig.id === CommentEffect.BRICK_ID &&
+    typeof brickConfig.config.comment === "string" &&
     !isNullOrBlank(brickConfig.config.comment)
   ) {
     return <div className={styles.comment}>{brickConfig.config.comment}</div>;

--- a/src/pageEditor/tabs/effect/BrickPreview.tsx
+++ b/src/pageEditor/tabs/effect/BrickPreview.tsx
@@ -142,7 +142,7 @@ const BrickPreview: React.FunctionComponent<{
   traceRecord: Nullishable<TraceRecord>;
   previewRefreshMillis?: 250;
   // eslint-disable-next-line complexity -- complex due to formik
-}> = ({ brickConfig, starterBrick, traceRecord, previewRefreshMillis }) => {
+}> = ({ brickConfig, traceRecord, previewRefreshMillis }) => {
   const [{ isRunning, output }, dispatch] = useReducer(previewSlice.reducer, {
     ...initialState,
     outputKey: brickConfig.outputKey,
@@ -286,7 +286,7 @@ const BrickPreview: React.FunctionComponent<{
         </>
       )}
 
-      {output && !isError && !isEmpty(output) && (
+      {output != null && !isError && !isEmpty(output) && (
         <DataTabJsonTree
           data={output}
           searchable
@@ -296,11 +296,11 @@ const BrickPreview: React.FunctionComponent<{
         />
       )}
 
-      {output && !isError && isEmpty(output) && (
+      {output != null && !isError && isEmpty(output) && (
         <div className="text-muted mt-2">Brick produced empty output</div>
       )}
 
-      {output && isError && (
+      {output != null && isError && (
         <div className="text-danger mt-2">{getErrorMessage(output)}</div>
       )}
     </div>

--- a/src/tinyPages/RestrictedUrlPopupApp.tsx
+++ b/src/tinyPages/RestrictedUrlPopupApp.tsx
@@ -37,17 +37,16 @@ async function openInActiveTab(event: React.MouseEvent<HTMLAnchorElement>) {
     url: event.currentTarget.href,
   });
 
-  // TODO: Drop conditon after we drop the browser action popover since this
-  // component will only be shown in the sidebar
+  // TODO: Drop condition after we drop the browser action popover since this
+  //  component will only be shown in the sidebar
   if (!isBrowserSidebarTopFrame()) {
     window.close();
   }
 }
 
-const RestrictedUrlContent: React.FC<{ extensionConsoleLink?: boolean }> = ({
-  children,
-  extensionConsoleLink = true,
-}) => (
+const RestrictedUrlContent: React.FC<
+  React.PropsWithChildren<{ extensionConsoleLink?: boolean }>
+> = ({ children, extensionConsoleLink = true }) => (
   <div className="p-3">
     {children}
     <div className="mt-2">


### PR DESCRIPTION
## What does this PR do?

- Part of #3164
- FLUP from https://github.com/pixiebrix/pixiebrix-extension/pull/9394
- The type is redundant because FC/FunctionComponent already include PropsWithChildren in React < 18

## Discussion

- I didn't use Codemod because it would add the type even where it wasn't necessary: https://github.com/eps1lon/types-react-codemod
- We could consider writing a Codemod to convert other calls to `React.VFC` which would correctly enforce the lack of children in React 17. After upgrading to React 18, we could do the mass rename

## Future Work

- Define a eslint rule with auto-fix for standardizing on `React.FC` or `React.FunctionComponent`

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
