### PR TITLE
#9419: move userSelectElementRefs into extended content script platform

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,7 +87,14 @@ module.exports = {
       {
         // This rule is customized below for files in "src/platform"
         boundaries,
-        allowedGlobs: ["**/messenger/**", "**/*.scss*"],
+        allowedGlobs: [
+          "**/messenger/**",
+          "**/*.scss*",
+          // Allow contexts to declare/export context-specific platform protocol. For example, the content script
+          // platform exposes additional methods for selecting elements, etc.
+          // Alternatively, we'd need to move platform-specific bricks into their respective context's folder.
+          "**/platform/*Protocol",
+        ],
       },
     ],
 

--- a/src/bricks/transformers/getAllTransformers.ts
+++ b/src/bricks/transformers/getAllTransformers.ts
@@ -47,7 +47,7 @@ import Retry from "@/bricks/transformers/controlFlow/Retry";
 import DisplayTemporaryInfo from "@/bricks/transformers/temporaryInfo/DisplayTemporaryInfo";
 import TraverseElements from "@/bricks/transformers/traverseElements";
 import { type Brick } from "@/types/brickTypes";
-import { SelectElement } from "@/bricks/transformers/selectElement";
+import SelectElement from "@/bricks/transformers/selectElement";
 import Run from "@/bricks/transformers/controlFlow/Run";
 import ExtensionDiagnostics from "@/bricks/transformers/extensionDiagnostics";
 import { Readable } from "@/bricks/transformers/readable";

--- a/src/bricks/transformers/selectElement.test.ts
+++ b/src/bricks/transformers/selectElement.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { SelectElement } from "@/bricks/transformers/selectElement";
+import SelectElement from "@/bricks/transformers/selectElement";
 import { userSelectElement } from "@/contentScript/pageEditor/elementPicker";
 import { getReferenceForElement } from "@/contentScript/elementReference";
 import { CancelError } from "@/errors/businessErrors";

--- a/src/bricks/transformers/selectElement.ts
+++ b/src/bricks/transformers/selectElement.ts
@@ -23,8 +23,9 @@ import {
 } from "@/platform/capabilities";
 import type { BrickArgs, BrickOptions } from "@/types/runtimeTypes";
 import { propertiesToSchema } from "@/utils/schemaUtils";
+import { isContentScriptPlatformProtocol } from "@/contentScript/platform/contentScriptPlatformProtocol";
 
-export class SelectElement extends TransformerABC {
+class SelectElement extends TransformerABC {
   constructor() {
     super(
       "@pixiebrix/html/select",
@@ -64,8 +65,15 @@ export class SelectElement extends TransformerABC {
     _args: BrickArgs,
     { platform }: BrickOptions,
   ): Promise<unknown> {
+    if (!isContentScriptPlatformProtocol(platform)) {
+      // Should never happen in practice because `getRequiredCapabilities` declares contentScript requirement
+      throw new Error("Expected ContentScriptPlatformProtocol");
+    }
+
     return {
       elements: await platform.userSelectElementRefs(),
     };
   }
 }
+
+export default SelectElement;

--- a/src/contentScript/contentScriptPlatform.ts
+++ b/src/contentScript/contentScriptPlatform.ts
@@ -62,6 +62,7 @@ import { deferLogin } from "@/contentScript/integrations/deferredLoginController
 import { selectionMenuActionRegistry } from "@/contentScript/textSelectionMenu/selectionMenuController";
 import { getExtensionVersion } from "@/utils/extensionUtils";
 import { registerModVariables } from "@/contentScript/stateController/modVariablePolicyController";
+import type { ContentScriptPlatformProtocol } from "@/contentScript/platform/contentScriptPlatformProtocol";
 
 /**
  * @file Platform definition for mods running in a content script
@@ -86,7 +87,10 @@ async function userSelectElementRefs(): Promise<ElementReference[]> {
   return elements.map((element) => getReferenceForElement(element));
 }
 
-class ContentScriptPlatform extends PlatformBase {
+class ContentScriptPlatform
+  extends PlatformBase
+  implements ContentScriptPlatformProtocol
+{
   private readonly _logger = new BackgroundLogger({
     platformName: "contentScript",
   });
@@ -130,7 +134,7 @@ class ContentScriptPlatform extends PlatformBase {
   override alert = window.alert.bind(window);
   override prompt = window.prompt.bind(window);
 
-  override userSelectElementRefs = userSelectElementRefs;
+  userSelectElementRefs = userSelectElementRefs;
 
   // Perform requests via the background so 1/ the host pages CSP doesn't conflict, and 2/ credentials aren't
   // passed to the content script

--- a/src/contentScript/platform/contentScriptPlatformProtocol.ts
+++ b/src/contentScript/platform/contentScriptPlatformProtocol.ts
@@ -1,0 +1,28 @@
+import type { PlatformProtocol } from "@/platform/platformProtocol";
+import type { ElementReference } from "@/types/runtimeTypes";
+
+/**
+ * @file Extended platform protocol for content scripts.
+ */
+
+/**
+ * Extended platform protocol for content scripts.
+ * @since 2.1.8
+ * @see isContentScriptPlatformProtocol
+ */
+export interface ContentScriptPlatformProtocol extends PlatformProtocol {
+  /**
+   * Prompt the user to select one or more elements on a host page.
+   * @since 1.8.10
+   */
+  userSelectElementRefs: () => Promise<ElementReference[]>;
+}
+
+/**
+ * Returns true if platforms is the extended content script platform implementation.
+ */
+export function isContentScriptPlatformProtocol(
+  platform: PlatformProtocol,
+): platform is ContentScriptPlatformProtocol {
+  return "userSelectElementRefs" in platform;
+}

--- a/src/platform/platformBase.ts
+++ b/src/platform/platformBase.ts
@@ -26,7 +26,6 @@ import type { SanitizedIntegrationConfig } from "@/integrations/integrationTypes
 import type { NetworkRequestConfig } from "@/types/networkTypes";
 import type { RemoteResponse } from "@/types/contract";
 import type { JavaScriptPayload } from "@/sandbox/messenger/api";
-import type { ElementReference } from "@/types/runtimeTypes";
 import type { Logger } from "@/types/loggerTypes";
 import type { DebuggerProtocol } from "@/platform/platformTypes/debuggerProtocol";
 import type { AudioProtocol } from "@/platform/platformTypes/audioProtocol";
@@ -91,13 +90,6 @@ export class PlatformBase implements PlatformProtocol {
 
   async runSandboxedJavascript(_args: JavaScriptPayload): Promise<unknown> {
     throw new PlatformCapabilityNotAvailableError(this.platformName, "sandbox");
-  }
-
-  async userSelectElementRefs(): Promise<ElementReference[]> {
-    throw new PlatformCapabilityNotAvailableError(
-      this.platformName,
-      "contentScript",
-    );
   }
 
   get logger(): Logger {

--- a/src/platform/platformProtocol.ts
+++ b/src/platform/platformProtocol.ts
@@ -16,7 +16,6 @@
  */
 
 import type { PlatformCapability } from "@/platform/capabilities";
-import type { ElementReference } from "@/types/runtimeTypes";
 import type { SanitizedIntegrationConfig } from "@/integrations/integrationTypes";
 import type { NetworkRequestConfig } from "@/types/networkTypes";
 import type { RemoteResponse } from "@/types/contract";
@@ -101,14 +100,6 @@ export interface PlatformProtocol {
    * @param data the data to pass to the function
    */
   runSandboxedJavascript: (args: JavaScriptPayload) => Promise<unknown>;
-
-  /**
-   * Prompt the user to select one or more elements on a host page.
-   * @since 1.8.10
-   */
-  // XXX: this method only makes sense in the context of a content script. We might choose to exclude it from
-  // the platform protocol.
-  userSelectElementRefs: () => Promise<ElementReference[]>;
 
   /**
    * Perform an API request.

--- a/src/testUtils/platformMock.ts
+++ b/src/testUtils/platformMock.ts
@@ -34,7 +34,6 @@ export const platformMock: PlatformProtocol = {
   open: jest.fn(),
   alert: jest.fn(),
   prompt: jest.fn(),
-  userSelectElementRefs: jest.fn(),
   request: jest.fn(),
   runSandboxedJavascript: jest.fn(),
   form: jest.fn(),


### PR DESCRIPTION
## What does this PR do?

- Part of #9419
- Defines an extended content script platform protocol type
- Move `userSelectElementRefs` method into an extended content script platform

## Discussion

- There are other bricks that reference the `contentScript` module:
  - Some of these affordances need to be moved to platform protocol, e.g.: re-initializing mods: https://github.com/pixiebrix/pixiebrix-extension/blob/a4812c9a2cc022c74856220a0d39de33694fd266/src/bricks/effects/reactivate.ts#L20-L20 
  - Some of these utilities need to be moved out of the `contentScript` module as they'd be relevant to any context with `dom` access/capabilities

## Future Work

- As noted in https://github.com/pixiebrix/pixiebrix-extension/pull/9420, a lot of we'll defer until monorepo  / web platform as it will be easier to reliably spot problems

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
