### PR TITLE
#9419: add registry lookup to platform protocol

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,7 +87,14 @@ module.exports = {
       {
         // This rule is customized below for files in "src/platform"
         boundaries,
-        allowedGlobs: ["**/messenger/**", "**/*.scss*"],
+        allowedGlobs: [
+          "**/messenger/**",
+          "**/*.scss*",
+          // Allow contexts to declare/export context-specific platform protocol. For example, the content script
+          // platform exposes additional methods for selecting elements, etc.
+          // Alternatively, we'd need to move platform-specific bricks into their respective context's folder.
+          "**/platform/*Protocol",
+        ],
       },
     ],
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -90,7 +90,7 @@ const config = {
   ],
   setupFilesAfterEnv: [
     "<rootDir>/src/testUtils/testAfterEnv.ts",
-    "<rootDir>/src/testUtils/injectRegistries.ts",
+    "<rootDir>/src/testUtils/injectPlatform.ts",
     "<rootDir>/src/testUtils/extendedExpectations.ts",
     "jest-extended/all",
   ],

--- a/src/analysis/analysisVisitors/pageStateAnalysis/modVariableSchemasVisitor.ts
+++ b/src/analysis/analysisVisitors/pageStateAnalysis/modVariableSchemasVisitor.ts
@@ -49,10 +49,10 @@ class ModVariableSchemasVisitor extends PipelineVisitor {
   ): void {
     super.visitBrick(position, brickConfig, extra);
 
-    const { block } = this.allBricks.get(brickConfig.id) ?? {};
+    const { brick } = this.allBricks.get(brickConfig.id) ?? {};
 
-    if (block?.getModVariableSchema) {
-      this.schemaPromises.push(block.getModVariableSchema?.(brickConfig));
+    if (brick?.getModVariableSchema) {
+      this.schemaPromises.push(brick.getModVariableSchema?.(brickConfig));
     }
   }
 

--- a/src/analysis/analysisVisitors/selectorAnalysis.ts
+++ b/src/analysis/analysisVisitors/selectorAnalysis.ts
@@ -336,7 +336,7 @@ class SelectorAnalysis extends AnalysisVisitorWithResolvedBricksABC {
 
     try {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- wrapped in try/catch
-      brick = this.allBlocks.get(brickConfig.id)!.block;
+      brick = this.allBlocks.get(brickConfig.id)!.brick;
     } catch {
       return;
     }

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -470,8 +470,7 @@ describe("Collecting available vars", () => {
           [
             formState.modComponent.brickPipeline[0]!.id,
             {
-              block: {
-                // HtmlReader's output schema, see @/bricks/readers/HtmlReader.ts
+              brick: {
                 outputSchema,
               },
             },
@@ -819,7 +818,7 @@ describe("Collecting available vars", () => {
             IdentityTransformer.BRICK_ID,
             {
               type: BrickTypes.TRANSFORM,
-              block: new IdentityTransformer(),
+              brick: new IdentityTransformer(),
             },
           ],
         ]),
@@ -1164,7 +1163,7 @@ describe("Collecting available vars", () => {
             CustomFormRenderer.BRICK_ID,
             {
               type: "renderer",
-              block: new CustomFormRenderer(),
+              brick: new CustomFormRenderer(),
             },
           ],
         ]),

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
@@ -437,7 +437,7 @@ class VarAnalysis extends PipelineExpressionVisitor implements Analysis {
    * @param blockConfig the block configuration
    */
   private safeGetOutputSchema(blockConfig: BrickConfig): Schema {
-    const block = this.allBlocks.get(blockConfig.id)?.block;
+    const block = this.allBlocks.get(blockConfig.id)?.brick;
 
     if (!block) {
       return {};
@@ -641,7 +641,7 @@ class VarAnalysis extends PipelineExpressionVisitor implements Analysis {
       const block = extra.parentNode?.id
         ? this.allBlocks.get(extra.parentNode.id)
         : null;
-      const variableSchema = block?.block.getPipelineVariableSchema?.(
+      const variableSchema = block?.brick.getPipelineVariableSchema?.(
         extra.parentNode,
         extra.pipelinePropName,
       );

--- a/src/background/executor.test.ts
+++ b/src/background/executor.test.ts
@@ -68,8 +68,8 @@ describe("requestRunInAllFrames", () => {
     const meta: MessengerMeta = messengerMetaFactory();
 
     const promise = requestRunInAllFrames.call(meta, {
-      blockId: registryIdFactory(),
-      blockArgs: unsafeAssumeValidArg({}),
+      brickId: registryIdFactory(),
+      brickArgs: unsafeAssumeValidArg({}),
       options: optionsFactory(),
     });
     await expect(promise).resolves.toStrictEqual([]);
@@ -85,8 +85,8 @@ describe("requestRunInAllFrames", () => {
     const meta: MessengerMeta = messengerMetaFactory();
 
     const promise = requestRunInAllFrames.call(meta, {
-      blockId: registryIdFactory(),
-      blockArgs: unsafeAssumeValidArg({}),
+      brickId: registryIdFactory(),
+      brickArgs: unsafeAssumeValidArg({}),
       options: optionsFactory(),
     });
 
@@ -105,8 +105,8 @@ describe("requestRunInAllFrames", () => {
     const meta: MessengerMeta = messengerMetaFactory();
 
     const promise = requestRunInAllFrames.call(meta, {
-      blockId: registryIdFactory(),
-      blockArgs: unsafeAssumeValidArg({}),
+      brickId: registryIdFactory(),
+      brickArgs: unsafeAssumeValidArg({}),
       options: optionsFactory(),
     });
 

--- a/src/bricks/brickFilterHelpers.ts
+++ b/src/bricks/brickFilterHelpers.ts
@@ -99,6 +99,6 @@ export function makeIsBrickAllowedForPipeline(
     }
   }
 
-  return ({ type, block }: TypedBrickPair) =>
-    type !== excludedType || ALWAYS_SHOW.has(block.id);
+  return ({ type, brick }: TypedBrickPair) =>
+    type !== excludedType || ALWAYS_SHOW.has(brick.id);
 }

--- a/src/bricks/readers/readerUtils.ts
+++ b/src/bricks/readers/readerUtils.ts
@@ -16,7 +16,7 @@
  */
 
 import { type ReaderConfig } from "@/bricks/types";
-import brickRegistry from "@/bricks/registry";
+import { getPlatform } from "@/platform/platformContext";
 import ArrayCompositeReader from "@/bricks/readers/ArrayCompositeReader";
 import { isPlainObject, mapValues } from "lodash";
 import CompositeReader from "@/bricks/readers/CompositeReader";
@@ -29,7 +29,9 @@ export async function mergeReaders(
   readerConfig: ReaderConfig,
 ): Promise<Reader> {
   if (typeof readerConfig === "string") {
-    return brickRegistry.lookup(readerConfig) as Promise<Reader>;
+    return getPlatform().registry.bricks.lookup(
+      readerConfig,
+    ) as Promise<Reader>;
   }
 
   if (Array.isArray(readerConfig)) {

--- a/src/bricks/registerBuiltinBricks.ts
+++ b/src/bricks/registerBuiltinBricks.ts
@@ -33,7 +33,7 @@ function registerBuiltinBricks(): void {
   }
 
   brickRegistry.register([
-    ...getAllTransformers(brickRegistry),
+    ...getAllTransformers(),
     ...getAllEffects(),
     ...getAllRenderers(),
     ...getAllReaders(),

--- a/src/bricks/registry.test.ts
+++ b/src/bricks/registry.test.ts
@@ -55,7 +55,7 @@ describe("bricksMap", () => {
     const typedBrick = typedBricks.get(brick.id);
 
     expect(typedBrick!.type).toBe("reader");
-    expect(typedBrick!.block).toBe(brick);
+    expect(typedBrick!.brick).toBe(brick);
   });
 
   test("returns bricks of multiple registrations", async () => {
@@ -66,7 +66,7 @@ describe("bricksMap", () => {
 
     for (const brick of bricks) {
       expect(enrichedBlocks.get(brick.id)!.type).toBe("reader");
-      expect(enrichedBlocks.get(brick.id)!.block).toBe(brick);
+      expect(enrichedBlocks.get(brick.id)!.brick).toBe(brick);
     }
   });
 

--- a/src/bricks/registry.ts
+++ b/src/bricks/registry.ts
@@ -25,10 +25,10 @@ import { partial } from "lodash";
 import { allSettled } from "@/utils/promiseUtils";
 
 /**
- * A brick along with inferred/calculated information
+ * A brick along with its inferred/calculated information
  */
 export type TypedBrickPair = {
-  block: Brick;
+  brick: Brick;
   type: BrickType | null;
 };
 
@@ -68,7 +68,7 @@ class BrickRegistry extends MemoryRegistry<RegistryId, Brick> {
         //  this module? getType references the brickRegistry in order to calculate the type for composite bricks
         //  that are defined as a pipeline of other blocks.
         typeCache.set(item.id, {
-          block: item,
+          brick: item,
           type: await getType(item),
         });
       }),
@@ -102,7 +102,6 @@ class BrickRegistry extends MemoryRegistry<RegistryId, Brick> {
 
 /**
  * The singleton brick registry instance
- * @see initRuntime
  */
 const registry = new BrickRegistry();
 

--- a/src/bricks/transformers/GetBrickInterfaceTransformer.test.ts
+++ b/src/bricks/transformers/GetBrickInterfaceTransformer.test.ts
@@ -23,7 +23,7 @@ import GetBrickInterfaceTransformer from "@/bricks/transformers/GetBrickInterfac
 import { pick } from "lodash";
 import { BusinessError } from "@/errors/businessErrors";
 
-const brick = new GetBrickInterfaceTransformer(brickRegistry);
+const brick = new GetBrickInterfaceTransformer();
 
 beforeEach(() => {
   brickRegistry.clear();

--- a/src/bricks/transformers/GetBrickInterfaceTransformer.ts
+++ b/src/bricks/transformers/GetBrickInterfaceTransformer.ts
@@ -16,11 +16,10 @@
  */
 
 import { TransformerABC } from "@/types/bricks/transformerTypes";
-import { type BrickArgs } from "@/types/runtimeTypes";
+import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { validateRegistryId } from "@/types/helpers";
-import type { RegistryId, RegistryProtocol } from "@/types/registryTypes";
-import type { Brick } from "@/types/brickTypes";
+import type { RegistryId } from "@/types/registryTypes";
 import { BusinessError, PropError } from "@/errors/businessErrors";
 import { propertiesToSchema } from "@/utils/schemaUtils";
 
@@ -34,7 +33,7 @@ import { propertiesToSchema } from "@/utils/schemaUtils";
 class GetBrickInterfaceTransformer extends TransformerABC {
   static BRICK_ID = validateRegistryId("@pixiebrix/reflect/brick-get");
 
-  constructor(private readonly registry: RegistryProtocol<RegistryId, Brick>) {
+  constructor() {
     super(
       GetBrickInterfaceTransformer.BRICK_ID,
       "[Experimental] Get Brick Interface",
@@ -90,9 +89,10 @@ class GetBrickInterfaceTransformer extends TransformerABC {
     ["id", "name", "inputSchema", "outputSchema"],
   );
 
-  async transform({
-    registryId,
-  }: BrickArgs<{ registryId: string }>): Promise<unknown> {
+  async transform(
+    { registryId }: BrickArgs<{ registryId: string }>,
+    { platform }: BrickOptions,
+  ): Promise<unknown> {
     try {
       validateRegistryId(registryId);
     } catch {
@@ -107,7 +107,7 @@ class GetBrickInterfaceTransformer extends TransformerABC {
     let brick;
 
     try {
-      brick = await this.registry.lookup(registryId as RegistryId);
+      brick = await platform.registry.bricks.lookup(registryId as RegistryId);
     } catch {
       throw new BusinessError(
         "Could not find brick with registry id: " + registryId,

--- a/src/bricks/transformers/RunBrickByIdTransformer.test.ts
+++ b/src/bricks/transformers/RunBrickByIdTransformer.test.ts
@@ -23,7 +23,7 @@ import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 import { InputValidationError } from "@/bricks/errors";
 import { BusinessError } from "@/errors/businessErrors";
 
-const brick = new RunBrickByIdTransformer(brickRegistry);
+const brick = new RunBrickByIdTransformer();
 
 beforeEach(() => {
   brickRegistry.clear();

--- a/src/bricks/transformers/RunBrickByIdTransformer.ts
+++ b/src/bricks/transformers/RunBrickByIdTransformer.ts
@@ -23,8 +23,7 @@ import {
 } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { validateRegistryId } from "@/types/helpers";
-import type { RegistryId, RegistryProtocol } from "@/types/registryTypes";
-import type { Brick } from "@/types/brickTypes";
+import type { RegistryId } from "@/types/registryTypes";
 import { BusinessError, PropError } from "@/errors/businessErrors";
 import { throwIfInvalidInput } from "@/runtime/runtimeUtils";
 import { propertiesToSchema } from "@/utils/schemaUtils";
@@ -39,7 +38,7 @@ import { propertiesToSchema } from "@/utils/schemaUtils";
 class RunBrickByIdTransformer extends TransformerABC {
   static BRICK_ID = validateRegistryId("@pixiebrix/reflect/run");
 
-  constructor(private readonly registry: RegistryProtocol<RegistryId, Brick>) {
+  constructor() {
     super(
       RunBrickByIdTransformer.BRICK_ID,
       "[Experimental] Run Brick by ID",
@@ -83,7 +82,9 @@ class RunBrickByIdTransformer extends TransformerABC {
     let brick;
 
     try {
-      brick = await this.registry.lookup(registryId as RegistryId);
+      brick = await options.platform.registry.bricks.lookup(
+        registryId as RegistryId,
+      );
     } catch {
       throw new BusinessError(
         "Could not find brick with registry id: " + registryId,

--- a/src/bricks/transformers/brickFactory.ts
+++ b/src/bricks/transformers/brickFactory.ts
@@ -40,6 +40,7 @@ import {
 import {
   DefinitionKinds,
   type Metadata,
+  type Registry,
   type RegistryId,
   type SemVerString,
 } from "@/types/registryTypes";
@@ -56,12 +57,8 @@ import {
   inputProperties,
   unionSchemaDefinitionTypes,
 } from "@/utils/schemaUtils";
-import type BaseRegistry from "@/registry/memoryRegistry";
 import type { PlatformCapability } from "@/platform/capabilities";
 import { runHeadlessPipeline } from "@/contentScript/messenger/api";
-
-// Interface to avoid circular dependency with the implementation
-type BrickRegistryProtocol = BaseRegistry<RegistryId, Brick>;
 
 export type BrickDefinition = {
   /**
@@ -141,7 +138,7 @@ class UserDefinedBrick extends BrickABC {
   readonly version?: SemVerString;
 
   constructor(
-    private readonly registry: BrickRegistryProtocol,
+    private readonly registry: Registry<RegistryId, Brick>,
     public readonly component: BrickDefinition,
   ) {
     const { id, name, description, version } = component.metadata;
@@ -392,7 +389,7 @@ class UserDefinedBrick extends BrickABC {
 
 // Put registry first for easier partial application
 export function fromJS(
-  registry: BrickRegistryProtocol,
+  registry: Registry<RegistryId, Brick>,
   component: UnknownObject,
 ): Brick {
   if (component.kind == null) {

--- a/src/bricks/transformers/getAllTransformers.ts
+++ b/src/bricks/transformers/getAllTransformers.ts
@@ -57,7 +57,6 @@ import ConvertDocument from "@/bricks/transformers/convertDocument";
 import { SearchText } from "@/bricks/transformers/searchText";
 import { WithAsyncModVariable } from "@/bricks/transformers/controlFlow/WithAsyncModVariable";
 import { JavaScriptTransformer } from "@/bricks/transformers/javascript";
-import type { RegistryId, RegistryProtocol } from "@/types/registryTypes";
 import RunBrickByIdTransformer from "@/bricks/transformers/RunBrickByIdTransformer";
 import GetBrickInterfaceTransformer from "@/bricks/transformers/GetBrickInterfaceTransformer";
 import RunMetadataTransformer from "@/bricks/transformers/RunMetadataTransformer";
@@ -66,9 +65,7 @@ import LocalPrompt from "@/bricks/transformers/ai/LocalPrompt";
 import LocalChatCompletionTransformer from "@/bricks/transformers/ai/LocalChatCompletion";
 import LocalSummarization from "@/bricks/transformers/ai/LocalSummarization";
 
-function getAllTransformers(
-  registry: RegistryProtocol<RegistryId, Brick>,
-): Brick[] {
+function getAllTransformers(): Brick[] {
   return [
     new JavaScriptTransformer(),
     new JQTransformer(),
@@ -106,8 +103,8 @@ function getAllTransformers(
     new ExtensionDiagnostics(),
 
     // Reflection/Meta Bricks
-    new RunBrickByIdTransformer(registry),
-    new GetBrickInterfaceTransformer(registry),
+    new RunBrickByIdTransformer(),
+    new GetBrickInterfaceTransformer(),
     new RunMetadataTransformer(),
 
     // Control Flow Bricks

--- a/src/bricks/transformers/getAllTransformers.ts
+++ b/src/bricks/transformers/getAllTransformers.ts
@@ -47,7 +47,7 @@ import Retry from "@/bricks/transformers/controlFlow/Retry";
 import DisplayTemporaryInfo from "@/bricks/transformers/temporaryInfo/DisplayTemporaryInfo";
 import TraverseElements from "@/bricks/transformers/traverseElements";
 import { type Brick } from "@/types/brickTypes";
-import { SelectElement } from "@/bricks/transformers/selectElement";
+import SelectElement from "@/bricks/transformers/selectElement";
 import Run from "@/bricks/transformers/controlFlow/Run";
 import ExtensionDiagnostics from "@/bricks/transformers/extensionDiagnostics";
 import { Readable } from "@/bricks/transformers/readable";

--- a/src/bricks/transformers/selectElement.test.ts
+++ b/src/bricks/transformers/selectElement.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { SelectElement } from "@/bricks/transformers/selectElement";
+import SelectElement from "@/bricks/transformers/selectElement";
 import { userSelectElement } from "@/contentScript/pageEditor/elementPicker";
 import { getReferenceForElement } from "@/contentScript/elementReference";
 import { CancelError } from "@/errors/businessErrors";

--- a/src/bricks/transformers/selectElement.ts
+++ b/src/bricks/transformers/selectElement.ts
@@ -23,8 +23,9 @@ import {
 } from "@/platform/capabilities";
 import type { BrickArgs, BrickOptions } from "@/types/runtimeTypes";
 import { propertiesToSchema } from "@/utils/schemaUtils";
+import { isContentScriptPlatformProtocol } from "@/contentScript/platform/contentScriptPlatformProtocol";
 
-export class SelectElement extends TransformerABC {
+class SelectElement extends TransformerABC {
   constructor() {
     super(
       "@pixiebrix/html/select",
@@ -64,8 +65,15 @@ export class SelectElement extends TransformerABC {
     _args: BrickArgs,
     { platform }: BrickOptions,
   ): Promise<unknown> {
+    if (!isContentScriptPlatformProtocol(platform)) {
+      // Should never happen in practice because `getRequiredCapabilities` declares contentScript requirement
+      throw new Error("Expected ContentScriptPlatformProtocol");
+    }
+
     return {
       elements: await platform.userSelectElementRefs(),
     };
   }
 }
+
+export default SelectElement;

--- a/src/components/fields/schemaFields/widgets/varPopup/SourceLabel.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/SourceLabel.tsx
@@ -48,7 +48,7 @@ const SourceLabel: React.FunctionComponent<SourceLabelProps> = ({
       } else {
         label =
           brickConfig.label ??
-          allBricks.get(brickConfig.id)?.block?.name ??
+          allBricks.get(brickConfig.id)?.brick?.name ??
           source;
       }
     }

--- a/src/contentScript/contentScriptCore.ts
+++ b/src/contentScript/contentScriptCore.ts
@@ -25,7 +25,6 @@ import registerExternalMessenger from "@/background/messenger/external/registrat
 import registerMessenger from "@/contentScript/messenger/registration";
 import registerBuiltinBricks from "@/bricks/registerBuiltinBricks";
 import registerContribBricks from "@/contrib/registerContribBricks";
-import brickRegistry from "@/bricks/registry";
 import { initNavigation } from "@/contentScript/lifecycle";
 import { initTelemetry } from "@/background/messenger/api";
 import { initToaster } from "@/utils/notify";
@@ -38,7 +37,6 @@ import { onUncaughtError } from "@/errors/errorHelpers";
 import initFloatingActions from "@/components/floatingActions/initFloatingActions";
 import { initSidebarActivation } from "@/contentScript/sidebarActivation";
 import { initPerformanceMonitoring } from "@/contentScript/performanceMonitoring";
-import { initRuntime } from "@/runtime/reducePipeline";
 import { setPlatform } from "@/platform/platformContext";
 import { markDocumentAsFocusableByUser } from "@/utils/focusTracker";
 import contentScriptPlatform from "@/contentScript/contentScriptPlatform";
@@ -76,9 +74,6 @@ export async function init(): Promise<void> {
   registerBuiltinBricks();
   registerContribBricks();
   markDocumentAsFocusableByUser();
-  // Since 1.8.2, the brick registry was de-coupled from the runtime to avoid circular dependencies
-  // Since 1.8.10, we inject the platform into the runtime
-  initRuntime(brickRegistry);
   initDeferredLoginController();
 
   initTelemetry();

--- a/src/contentScript/contentScriptPlatform.ts
+++ b/src/contentScript/contentScriptPlatform.ts
@@ -62,6 +62,7 @@ import { deferLogin } from "@/contentScript/integrations/deferredLoginController
 import { selectionMenuActionRegistry } from "@/contentScript/textSelectionMenu/selectionMenuController";
 import { getExtensionVersion } from "@/utils/extensionUtils";
 import { registerModVariables } from "@/contentScript/stateController/modVariablePolicyController";
+import type { ContentScriptPlatformProtocol } from "@/contentScript/platform/contentScriptPlatformProtocol";
 
 /**
  * @file Platform definition for mods running in a content script
@@ -86,7 +87,10 @@ async function userSelectElementRefs(): Promise<ElementReference[]> {
   return elements.map((element) => getReferenceForElement(element));
 }
 
-class ContentScriptPlatform extends PlatformBase {
+class ContentScriptPlatform
+  extends PlatformBase
+  implements ContentScriptPlatformProtocol
+{
   private readonly _logger = new BackgroundLogger({
     platformName: "contentScript",
   });
@@ -130,7 +134,7 @@ class ContentScriptPlatform extends PlatformBase {
   override alert = window.alert.bind(window);
   override prompt = window.prompt.bind(window);
 
-  override userSelectElementRefs = userSelectElementRefs;
+  userSelectElementRefs = userSelectElementRefs;
 
   // Perform requests via the background so 1/ the host pages CSP doesn't conflict, and 2/ credentials aren't
   // passed to the content script

--- a/src/contentScript/contentScriptPlatform.ts
+++ b/src/contentScript/contentScriptPlatform.ts
@@ -63,6 +63,8 @@ import { selectionMenuActionRegistry } from "@/contentScript/textSelectionMenu/s
 import { getExtensionVersion } from "@/utils/extensionUtils";
 import { registerModVariables } from "@/contentScript/stateController/modVariablePolicyController";
 import type { ContentScriptPlatformProtocol } from "@/contentScript/platform/contentScriptPlatformProtocol";
+import brickRegistry from "@/bricks/registry";
+import starterBrickRegistry from "@/starterBricks/registry";
 
 /**
  * @file Platform definition for mods running in a content script
@@ -100,6 +102,7 @@ class ContentScriptPlatform
   }
 
   override capabilities: PlatformCapability[] = [
+    "registry",
     "dom",
     "pageScript",
     "contentScript",
@@ -166,6 +169,13 @@ class ContentScriptPlatform
   override form = ephemeralForm;
 
   override runSandboxedJavascript = runUserJs;
+
+  override get registry(): PlatformProtocol["registry"] {
+    return {
+      bricks: brickRegistry,
+      starterBricks: starterBrickRegistry,
+    };
+  }
 
   override get templates(): PlatformProtocol["templates"] {
     return {

--- a/src/contentScript/contentScriptPlatform.ts
+++ b/src/contentScript/contentScriptPlatform.ts
@@ -71,6 +71,11 @@ import starterBrickRegistry from "@/starterBricks/registry";
  * @see PlatformProtocol
  */
 
+expectContext(
+  "contentScript",
+  "contentScriptPlatform imported directly/indirectly from another context",
+);
+
 async function playSound(sound: string): Promise<void> {
   const audio = new Audio(browser.runtime.getURL(`audio/${sound}.mp3`));
   // NOTE: this does not wait for the sound effect to complete

--- a/src/contentScript/executor.ts
+++ b/src/contentScript/executor.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import brickRegistry from "@/bricks/registry";
 import { type RunBrickRequest } from "@/contentScript/messenger/runBrickTypes";
 import { BusinessError } from "@/errors/businessErrors";
 import contentScriptPlatform from "@/contentScript/contentScriptPlatform";
@@ -25,14 +24,14 @@ import contentScriptPlatform from "@/contentScript/contentScriptPlatform";
  */
 export async function runBrick(request: RunBrickRequest): Promise<unknown> {
   // XXX: validate sourceTabId? Can't use childTabs because we also support `window: broadcast`
-  const { blockId, blockArgs, options } = request;
-  const brick = await brickRegistry.lookup(blockId);
+  const { brickId, brickArgs, options } = request;
+  const brick = await contentScriptPlatform.registry.bricks.lookup(brickId);
   const logger = contentScriptPlatform.logger.childLogger(
     options.messageContext,
   );
 
   try {
-    return await brick.run(blockArgs, {
+    return await brick.run(brickArgs, {
       platform: contentScriptPlatform,
       ctxt: options.ctxt as UnknownObject,
       meta: options.meta,

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -746,8 +746,11 @@ export async function initNavigation() {
 }
 
 /**
- * Test helper method to reset lifecycle module state. Simpler to use than Jest's isolateModules/resetModules which
- * has gotchas with getPlatform() and other module-level state.
+ * Test helper method to reset lifecycle module state.
+ *
+ * Simpler to use than Jest's isolateModules/resetModules which seem to have gotchas with getPlatform() and other
+ * module-level state.
+ * @internal
  */
 export function TEST_reset(): void {
   _initialFrameLoad = true;

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -16,7 +16,6 @@
  */
 
 import { getModComponentState } from "@/store/modComponents/modComponentStorage";
-import starterBrickRegistry from "@/starterBricks/registry";
 import { updateNavigationId } from "@/contentScript/context";
 import * as sidebar from "@/contentScript/sidebarController";
 import { NAVIGATION_RULES } from "@/contrib/navigationRules";
@@ -56,6 +55,7 @@ import { notifyNavigationComplete } from "@/contentScript/sidebarController";
 import pDefer from "p-defer";
 import { assertNotNullish } from "@/utils/nullishUtils";
 import { selectActivatedModComponents } from "@/store/modComponents/modComponentSelectors";
+import contentScriptPlatform from "@/contentScript/contentScriptPlatform";
 
 /**
  * True if handling the initial frame load.
@@ -483,7 +483,9 @@ async function loadActivatedModComponents(): Promise<StarterBrick[]> {
         ]) => {
           try {
             const starterBrick =
-              await starterBrickRegistry.lookup(starterBrickId);
+              await contentScriptPlatform.registry.starterBricks.lookup(
+                starterBrickId,
+              );
 
             // It's tempting to call starterBrick.isAvailable here and skip if it's not available.
             // However, that would cause the starter brick to be unavailable for the entire frame session

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -744,3 +744,16 @@ export async function initNavigation() {
     _draftModComponentStarterBrickMap.clear();
   });
 }
+
+/**
+ * Test helper method to reset lifecycle module state. Simpler to use than Jest's isolateModules/resetModules which
+ * has gotchas with getPlatform() and other module-level state.
+ */
+export function TEST_reset(): void {
+  _initialFrameLoad = true;
+  pendingFrameLoadPromise = null;
+  _runningStarterBricks.clear();
+  _activatedModComponentStarterBrickMap.clear();
+  _draftModComponentStarterBrickMap.clear();
+  lastUrl = undefined;
+}

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -55,7 +55,8 @@ import { notifyNavigationComplete } from "@/contentScript/sidebarController";
 import pDefer from "p-defer";
 import { assertNotNullish } from "@/utils/nullishUtils";
 import { selectActivatedModComponents } from "@/store/modComponents/modComponentSelectors";
-import contentScriptPlatform from "@/contentScript/contentScriptPlatform";
+// Can't reference contentScriptPlatform directly because some bricks currently reference this module
+import { getPlatform } from "@/platform/platformContext";
 
 /**
  * True if handling the initial frame load.
@@ -483,9 +484,7 @@ async function loadActivatedModComponents(): Promise<StarterBrick[]> {
         ]) => {
           try {
             const starterBrick =
-              await contentScriptPlatform.registry.starterBricks.lookup(
-                starterBrickId,
-              );
+              await getPlatform().registry.starterBricks.lookup(starterBrickId);
 
             // It's tempting to call starterBrick.isAvailable here and skip if it's not available.
             // However, that would cause the starter brick to be unavailable for the entire frame session

--- a/src/contentScript/platform/contentScriptPlatformProtocol.ts
+++ b/src/contentScript/platform/contentScriptPlatformProtocol.ts
@@ -1,0 +1,28 @@
+import type { PlatformProtocol } from "@/platform/platformProtocol";
+import type { ElementReference } from "@/types/runtimeTypes";
+
+/**
+ * @file Extended platform protocol for content scripts.
+ */
+
+/**
+ * Extended platform protocol for content scripts.
+ * @since 2.1.8
+ * @see isContentScriptPlatformProtocol
+ */
+export interface ContentScriptPlatformProtocol extends PlatformProtocol {
+  /**
+   * Prompt the user to select one or more elements on a host page.
+   * @since 1.8.10
+   */
+  userSelectElementRefs: () => Promise<ElementReference[]>;
+}
+
+/**
+ * Returns true if platforms is the extended content script platform implementation.
+ */
+export function isContentScriptPlatformProtocol(
+  platform: PlatformProtocol,
+): platform is ContentScriptPlatformProtocol {
+  return "userSelectElementRefs" in platform;
+}

--- a/src/extensionPages/extensionPagePlatform.ts
+++ b/src/extensionPages/extensionPagePlatform.ts
@@ -30,6 +30,8 @@ import type { SanitizedIntegrationConfig } from "@/integrations/integrationTypes
 import type { NetworkRequestConfig } from "@/types/networkTypes";
 import type { RemoteResponse } from "@/types/contract";
 import integrationRegistry from "@/integrations/registry";
+import brickRegistry from "@/bricks/registry";
+import starterBrickRegistry from "@/starterBricks/registry";
 import { performConfiguredRequest } from "@/background/requests";
 import { getExtensionVersion } from "@/utils/extensionUtils";
 import { type Nullishable } from "@/utils/nullishUtils";
@@ -43,6 +45,7 @@ import { type Nullishable } from "@/utils/nullishUtils";
  */
 class ExtensionPagePlatform extends PlatformBase {
   override capabilities: PlatformCapability[] = [
+    "registry",
     "dom",
     "alert",
     "toast",
@@ -64,6 +67,13 @@ class ExtensionPagePlatform extends PlatformBase {
 
   override get logger() {
     return this._logger;
+  }
+
+  override get registry(): PlatformProtocol["registry"] {
+    return {
+      bricks: brickRegistry,
+      starterBricks: starterBrickRegistry,
+    };
   }
 
   // Support tracing for bricks run in the sidebar and clearing logs in Page Editor/Extension Console. See PanelBody.tsx

--- a/src/pageEditor/modals/addBrickModal/AddBrickModal.tsx
+++ b/src/pageEditor/modals/addBrickModal/AddBrickModal.tsx
@@ -226,17 +226,17 @@ const AddBrickModal: React.FC = () => {
     }
 
     let typedBricks = [...allBricks.values()].filter(
-      ({ block }) => block.featureFlag == null || flagOn(block.featureFlag),
+      ({ brick }) => brick.featureFlag == null || flagOn(brick.featureFlag),
     );
 
     if (themeName === AUTOMATION_ANYWHERE_PARTNER_KEY) {
       typedBricks = typedBricks.filter(
         // eslint-disable-next-line security/detect-object-injection -- constant
-        (typed) => !taggedBrickIds[TAG_UIPATH]?.has(typed.block.id),
+        (typed) => !taggedBrickIds[TAG_UIPATH]?.has(typed.brick.id),
       );
     }
 
-    return typedBricks.map(({ block }) => block);
+    return typedBricks.map(({ brick }) => brick);
   }, [allBricks, isLoadingTags, themeName, taggedBrickIds, flagOn]);
 
   const searchResults = useBrickSearch(

--- a/src/pageEditor/starterBricks/pipelineMapping.ts
+++ b/src/pageEditor/starterBricks/pipelineMapping.ts
@@ -54,7 +54,7 @@ class NormalizePipelineVisitor extends PipelineVisitor {
         this.blockMap,
       );
     } else {
-      const propertiesSchema = typedBlock.block?.inputSchema?.properties ?? {};
+      const propertiesSchema = typedBlock.brick?.inputSchema?.properties ?? {};
       const emptySubPipelineProperties = Object.entries(propertiesSchema)
         .filter(
           ([prop, fieldSchema]) =>

--- a/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
@@ -46,7 +46,7 @@ const EditorNodeConfigPanel: React.FC = () => {
 
     const brick = await brickRegistry.lookup(brickId);
     return {
-      block: brick,
+      brick,
       type: await getType(brick),
     };
   }, [brickId]);
@@ -65,7 +65,7 @@ const EditorNodeConfigPanel: React.FC = () => {
       <AnalysisResult className="mb-3" />
 
       <h6 className="mb-3 d-flex justify-content-between flex-wrap gap-2">
-        {brickInfo?.block.name}
+        {brickInfo?.brick.name}
         {showDocumentationLink && (
           <a
             href={`${MARKETPLACE_URL}${listingId}/?utm_source=pixiebrix&utm_medium=page_editor&utm_campaign=docs&utm_content=view_docs_link`}
@@ -82,7 +82,7 @@ const EditorNodeConfigPanel: React.FC = () => {
             name={`${brickFieldName}.label`}
             label="Step Name"
             className="flex-grow-1"
-            placeholder={brickInfo?.block.name}
+            placeholder={brickInfo?.brick.name}
           />
           <OutputVariableField
             brickInfo={brickInfo}

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes/useGetBrickContentProps.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes/useGetBrickContentProps.tsx
@@ -60,7 +60,7 @@ export function useGetBrickContentProps() {
       brickConfig,
       traceRecord,
     }: BrickContentProps): BrickNodeContentProps => {
-      const brick = allBricks?.get(brickConfig.id)?.block;
+      const brick = allBricks?.get(brickConfig.id)?.brick;
 
       if (isLoadingBricks || !brick) {
         return { brickLabel: "Loading..." };

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes/useGetIsBrickPipelineExpanded.ts
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes/useGetIsBrickPipelineExpanded.ts
@@ -34,7 +34,7 @@ export function useGetIsBrickPipelineExpanded() {
 
   return useCallback(
     ({ brickConfig }: GetIsBrickPipelineExpandedProps) => {
-      const brick = allBricks?.get(brickConfig.id)?.block;
+      const brick = allBricks?.get(brickConfig.id)?.brick;
 
       const subPipelines = getSubPipelinesForBrick(brick, brickConfig);
       const hasSubPipelines = !isEmpty(subPipelines);

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes/useGetSubPipelineNodes.ts
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes/useGetSubPipelineNodes.ts
@@ -170,7 +170,7 @@ export function useGetSubPipelineNodes() {
 
       const isNodeActive = nodeId === activeNodeId;
 
-      const brick = allBricks?.get(brickConfig.id)?.block;
+      const brick = allBricks?.get(brickConfig.id)?.brick;
       const subPipelines = getSubPipelinesForBrick(brick, brickConfig);
 
       const nodes: EditorNodeProps[] = [];

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes/useLastBrickHandling.ts
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes/useLastBrickHandling.ts
@@ -36,7 +36,7 @@ export function useGetLastBrickHandling() {
 
       // Don't show append if the last brick is a renderer
       const showAppend =
-        !lastBrick?.block || lastBrick.type !== BrickTypes.RENDERER;
+        !lastBrick?.brick || lastBrick.type !== BrickTypes.RENDERER;
 
       return {
         lastIndex,

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes/useMapBrickToNodes.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes/useMapBrickToNodes.tsx
@@ -213,7 +213,7 @@ export function useMapBrickToNodes(): (args: MapBrickToNodesArgs) => MapOutput {
       const { instanceId } = brickConfig;
       assertNotNullish(instanceId, "instanceId is required");
 
-      const brick = allBricks?.get(brickConfig.id)?.block;
+      const brick = allBricks?.get(brickConfig.id)?.brick;
       const isNodeActive = instanceId === activeNodeId;
 
       const subPipelines = getSubPipelinesForBrick(brick, brickConfig);

--- a/src/platform/capabilities.ts
+++ b/src/platform/capabilities.ts
@@ -20,6 +20,8 @@
  * @internal
  */
 export const platformCapabilities = [
+  // Access to the PixieBrix package registry
+  "registry",
   // Access to a DOM - but not necessarily visible to a user
   "dom",
   // Access the host-page Javascript context

--- a/src/platform/platformBase.ts
+++ b/src/platform/platformBase.ts
@@ -26,7 +26,6 @@ import type { SanitizedIntegrationConfig } from "@/integrations/integrationTypes
 import type { NetworkRequestConfig } from "@/types/networkTypes";
 import type { RemoteResponse } from "@/types/contract";
 import type { JavaScriptPayload } from "@/sandbox/messenger/api";
-import type { ElementReference } from "@/types/runtimeTypes";
 import type { Logger } from "@/types/loggerTypes";
 import type { DebuggerProtocol } from "@/platform/platformTypes/debuggerProtocol";
 import type { AudioProtocol } from "@/platform/platformTypes/audioProtocol";
@@ -91,13 +90,6 @@ export class PlatformBase implements PlatformProtocol {
 
   async runSandboxedJavascript(_args: JavaScriptPayload): Promise<unknown> {
     throw new PlatformCapabilityNotAvailableError(this.platformName, "sandbox");
-  }
-
-  async userSelectElementRefs(): Promise<ElementReference[]> {
-    throw new PlatformCapabilityNotAvailableError(
-      this.platformName,
-      "contentScript",
-    );
   }
 
   get logger(): Logger {

--- a/src/platform/platformBase.ts
+++ b/src/platform/platformBase.ts
@@ -42,6 +42,7 @@ import type { PanelProtocol } from "@/platform/platformTypes/panelProtocol";
 import type { QuickBarProtocol } from "@/platform/platformTypes/quickBarProtocol";
 import type { ModComponentRef } from "@/types/modComponentTypes";
 import type { CaptureProtocol } from "@/platform/platformTypes/captureProtocol";
+import type { RegistryProtocol } from "@/platform/platformTypes/registryProtocol";
 
 /**
  * Base protocol with no capabilities implemented.
@@ -90,6 +91,13 @@ export class PlatformBase implements PlatformProtocol {
 
   async runSandboxedJavascript(_args: JavaScriptPayload): Promise<unknown> {
     throw new PlatformCapabilityNotAvailableError(this.platformName, "sandbox");
+  }
+
+  get registry(): RegistryProtocol {
+    throw new PlatformCapabilityNotAvailableError(
+      this.platformName,
+      "registry",
+    );
   }
 
   get logger(): Logger {

--- a/src/platform/platformProtocol.ts
+++ b/src/platform/platformProtocol.ts
@@ -38,6 +38,7 @@ import type { PanelProtocol } from "@/platform/platformTypes/panelProtocol";
 import type { QuickBarProtocol } from "@/platform/platformTypes/quickBarProtocol";
 import type { ModComponentRef } from "@/types/modComponentTypes";
 import type { CaptureProtocol } from "@/platform/platformTypes/captureProtocol";
+import type { RegistryProtocol } from "@/platform/platformTypes/registryProtocol";
 
 /**
  * A protocol for the platform/environment running the mods.
@@ -102,13 +103,18 @@ export interface PlatformProtocol {
   runSandboxedJavascript: (args: JavaScriptPayload) => Promise<unknown>;
 
   /**
-   * Perform an API request.
+   * Perform a (potentially-authenticated) API request.
    * @since 1.8.10
    */
   request: <TData>(
     integrationConfig: Nullishable<SanitizedIntegrationConfig>,
     requestConfig: NetworkRequestConfig,
   ) => Promise<RemoteResponse<TData>>;
+
+  /**
+   * The package registry protocol for the platform.
+   */
+  get registry(): RegistryProtocol;
 
   /**
    * The runtime logger for the platform.

--- a/src/platform/platformProtocol.ts
+++ b/src/platform/platformProtocol.ts
@@ -16,7 +16,6 @@
  */
 
 import type { PlatformCapability } from "@/platform/capabilities";
-import type { ElementReference } from "@/types/runtimeTypes";
 import type { SanitizedIntegrationConfig } from "@/integrations/integrationTypes";
 import type { NetworkRequestConfig } from "@/types/networkTypes";
 import type { RemoteResponse } from "@/types/contract";
@@ -101,14 +100,6 @@ export interface PlatformProtocol {
    * @param data the data to pass to the function
    */
   runSandboxedJavascript: (args: JavaScriptPayload) => Promise<unknown>;
-
-  /**
-   * Prompt the user to select one or more elements on a host page.
-   * @since 1.8.10
-   */
-  // XXX: this method only makes sense in the context of a content script. We might choose to exclude it from
-  // the platform protocol.
-  userSelectElementRefs: () => Promise<ElementReference[]>;
 
   /**
    * Perform an API request.

--- a/src/platform/platformTypes/registryProtocol.ts
+++ b/src/platform/platformTypes/registryProtocol.ts
@@ -15,35 +15,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type MessageContext } from "@/types/loggerTypes";
-import { type RegistryId } from "@/types/registryTypes";
-import { type BrickArgs, type RunMetadata } from "@/types/runtimeTypes";
-import { type Availability } from "@/types/availabilityTypes";
+import type { Registry, RegistryId } from "@/types/registryTypes";
+import type { Brick } from "@/types/brickTypes";
+import type { StarterBrick } from "@/types/starterBrickTypes";
 
 /**
- * @see BrickOptions
+ * Public interface for the Quick Bar registry.
+ * @since 1.8.10
  */
-export interface RemoteBrickOptions {
+export interface RegistryProtocol {
   /**
-   * Available variables for the brick execution.
+   * Registry of bricks.
    */
-  ctxt: unknown;
-  /**
-   * Run metadata for the brick execution.
-   */
-  meta: RunMetadata;
-  /**
-   * Logging context for the brick execution.
-   */
-  messageContext: MessageContext;
-  maxRetries?: number;
-  isAvailable?: Availability;
-}
+  bricks: Registry<RegistryId, Brick>;
 
-export interface RunBrickRequest {
-  sourceTabId?: number;
-  nonce?: string;
-  brickId: RegistryId;
-  brickArgs?: BrickArgs;
-  options: RemoteBrickOptions;
+  /**
+   * Registry of bricks.
+   */
+  starterBricks: Registry<RegistryId, StarterBrick>;
 }

--- a/src/platform/platformTypes/registryProtocol.ts
+++ b/src/platform/platformTypes/registryProtocol.ts
@@ -30,7 +30,7 @@ export interface RegistryProtocol {
   bricks: Registry<RegistryId, Brick>;
 
   /**
-   * Registry of bricks.
+   * Registry of starter bricks.
    */
   starterBricks: Registry<RegistryId, StarterBrick>;
 }

--- a/src/registry/memoryRegistry.ts
+++ b/src/registry/memoryRegistry.ts
@@ -21,7 +21,7 @@ import { expectContext } from "@/utils/expectContext";
 import {
   type DefinitionKind,
   DoesNotExistError,
-  type EnumerableRegistryProtocol,
+  type EnumerableRegistry,
   type RegistryId,
   type RegistryItem,
 } from "@/types/registryTypes";
@@ -68,7 +68,7 @@ export const clearPackages = async () => {
 class MemoryRegistry<
   Id extends RegistryId = RegistryId,
   Item extends RegistryItem<Id> = RegistryItem<Id>,
-> implements EnumerableRegistryProtocol<Id, Item>
+> implements EnumerableRegistry<Id, Item>
 {
   /**
    * Registered built-in items. Used to keep track of built-ins across cache clears.

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -60,49 +60,23 @@ import { type UUID } from "@/types/stringTypes";
 import {
   type BrickArgs,
   type BrickArgsContext,
-  type SelectorRoot,
-  type RenderedArgs,
   type IntegrationContext,
   type OptionsArgs,
   type PipelineExpression,
+  type RenderedArgs,
   type RunMetadata,
+  type SelectorRoot,
 } from "@/types/runtimeTypes";
 import { isPipelineClosureExpression } from "@/utils/expressionUtils";
 import extendModVariableContext from "@/runtime/extendModVariableContext";
 import { isObject } from "@/utils/objectUtils";
-import type {
-  RegistryId,
-  RegistryProtocol,
-  SemVerString,
-} from "@/types/registryTypes";
-import type { Brick } from "@/types/brickTypes";
+import type { SemVerString } from "@/types/registryTypes";
 import getType from "@/runtime/getType";
 import { getPlatform } from "@/platform/platformContext";
-import { type Nullishable, assertNotNullish } from "@/utils/nullishUtils";
+import { assertNotNullish, type Nullishable } from "@/utils/nullishUtils";
 import { nowTimestamp } from "@/utils/timeUtils";
 import { flagOn } from "@/auth/featureFlagStorage";
 import castError from "@/utils/castError";
-
-// Introduce a layer of indirection to avoid cyclical dependency between runtime and registry
-// eslint-disable-next-line local-rules/persistBackgroundData -- Static
-let brickRegistry: RegistryProtocol<RegistryId, Brick> = {
-  async lookup(): Promise<Brick> {
-    throw new Error(
-      "Runtime was not initialized. Call initRuntime before running mods.",
-    );
-  },
-};
-
-/**
- * Initialize the runtime with the given brick registry.
- * @param registry brick registry to use for looking up bricks
- * @since 1.8.2 introduced to eliminate circular dependency between runtime and registry
- */
-export function initRuntime(
-  registry: RegistryProtocol<RegistryId, Brick>,
-): void {
-  brickRegistry = registry;
-}
 
 /**
  * CommonOptions for running pipelines and bricks
@@ -294,7 +268,7 @@ function getPipelineLexicalEnvironment({
 async function resolveBrickConfig(
   config: BrickConfig,
 ): Promise<ResolvedBrickConfig> {
-  const brick = await brickRegistry.lookup(config.id);
+  const brick = await getPlatform().registry.bricks.lookup(config.id);
   return {
     config,
     brick,
@@ -322,8 +296,8 @@ async function executeBrickWithValidatedProps(
   };
 
   const request: RunBrickRequest = {
-    blockId: config.id,
-    blockArgs: args,
+    brickId: config.id,
+    brickArgs: args,
     options: {
       ...commonOptions,
       meta: options.trace,

--- a/src/testUtils/injectPlatform.ts
+++ b/src/testUtils/injectPlatform.ts
@@ -16,17 +16,11 @@
  */
 
 /**
- * @file Test utilities for injecting registries into the runtime.
- * @since 1.8.2 inject the brick registry into the runtime
+ * @file Test utilities for injecting platform into the runtime.
  * @since 1.8.10 set the ambient platform dynamically
  */
 
-import brickRegistry from "@/bricks/registry";
-import { initRuntime } from "@/runtime/reducePipeline";
 import { setPlatform } from "@/platform/platformContext";
-
-// Since 1.8.2, the runtime is decoupled from the brick registry.
-initRuntime(brickRegistry);
 
 // Use beforeEach so individual tests can cleanly override the ambient platform
 beforeEach(async () => {

--- a/src/testUtils/platformMock.ts
+++ b/src/testUtils/platformMock.ts
@@ -23,6 +23,7 @@ import { SimpleEventTarget } from "@/utils/SimpleEventTarget";
 import type { RunArgs } from "@/types/runtimeTypes";
 import { normalizeSemVerString } from "@/types/helpers";
 import type { ToastProtocol } from "@/platform/platformTypes/toastProtocol";
+import type { RegistryProtocol } from "@/platform/platformTypes/registryProtocol";
 
 /**
  * Implementation of PlatformProtocol that mocks all methods
@@ -78,6 +79,16 @@ export const platformMock: PlatformProtocol = {
   },
   get logger(): Logger {
     return new ConsoleLogger();
+  },
+  get registry(): RegistryProtocol {
+    return {
+      bricks: {
+        lookup: jest.fn(),
+      },
+      starterBricks: {
+        lookup: jest.fn(),
+      },
+    };
   },
   get toasts(): ToastProtocol {
     return {

--- a/src/testUtils/platformMock.ts
+++ b/src/testUtils/platformMock.ts
@@ -34,7 +34,6 @@ export const platformMock: PlatformProtocol = {
   open: jest.fn(),
   alert: jest.fn(),
   prompt: jest.fn(),
-  userSelectElementRefs: jest.fn(),
   request: jest.fn(),
   runSandboxedJavascript: jest.fn(),
   form: jest.fn(),

--- a/src/types/registryTypes.ts
+++ b/src/types/registryTypes.ts
@@ -190,7 +190,7 @@ export class DoesNotExistError extends Error {
  * A registry that can look up items by id.
  * @since 1.8.2
  */
-export interface RegistryProtocol<
+export interface Registry<
   Id extends RegistryId = RegistryId,
   Item extends RegistryItem<Id> = RegistryItem<Id>,
 > {
@@ -200,9 +200,9 @@ export interface RegistryProtocol<
 /**
  * A registry that can enumerate all items accessible to the user.
  */
-export interface EnumerableRegistryProtocol<
+export interface EnumerableRegistry<
   Id extends RegistryId = RegistryId,
   Item extends RegistryItem<Id> = RegistryItem<Id>,
-> extends RegistryProtocol<Id, Item> {
+> extends Registry<Id, Item> {
   all: () => Promise<Item[]>;
 }


### PR DESCRIPTION
## What does this PR do?

- Part of #9419 
- Adds brick/starter brick lookup to the platform protocol
- Removes direct references to the registry lookup in favor of access via platform protocol
- Refactoring: rename `block` -> `brick` on TypedBrickMap

## Discussion

- This PR likely isn't sufficient to completely eliminate the `memoryRegistry.ts` alias in: https://github.com/pixiebrix/pixiebrix-app/pull/4848. But it's a step in the right direction
- There's also probably some places the `brickRegistry` is getting used directly where it shouldn't be (e.g., in inner definition hydration code)

## Future Work

- Fix remaining direct calls from bricks to `contentScript` context. Some of these should be moved to the main platform protocol, others to the content script platform: https://github.com/pixiebrix/pixiebrix-extension/blob/a4812c9a2cc022c74856220a0d39de33694fd266/src/bricks/effects/reactivate.ts#L20-L20
- Fix remaining gaps for eliminating memory registry alias: https://github.com/pixiebrix/pixiebrix-app/pull/4848 (will probably wait for monorepo)

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
