### PR TITLE
#3164: drop deprecated `act` hook wrapper method

### DIFF
--- a/src/activation/useActivateMod.test.ts
+++ b/src/activation/useActivateMod.test.ts
@@ -49,6 +49,7 @@ import {
   type EditablePackageMetadata,
 } from "@/types/contract";
 import { activatableDeploymentFactory } from "@/testUtils/factories/deploymentFactories";
+import { act } from "@testing-library/react-hooks";
 
 jest.mock("@/contentScript/messenger/api");
 jest.mock("@/utils/notify");
@@ -177,7 +178,6 @@ describe("useActivateMod", () => {
     const {
       result: { current: activateMod },
       getReduxStore,
-      act,
     } = renderHook(() => useActivateMod("extensionConsole"), {
       setupRedux(dispatch, { store }) {
         jest.spyOn(store, "dispatch");
@@ -250,7 +250,6 @@ describe("useActivateMod", () => {
     const {
       result: { current: activateMod },
       getReduxStore,
-      act,
     } = renderHook(() => useActivateMod("marketplace"), {
       setupRedux(dispatch, { store }) {
         jest.spyOn(store, "dispatch");
@@ -323,7 +322,6 @@ describe("useActivateMod", () => {
 
     const {
       result: { current: activateMod },
-      act,
     } = renderHook(() => useActivateMod("marketplace"), {
       setupRedux(dispatch, { store }) {
         jest.spyOn(store, "dispatch");

--- a/src/extensionConsole/pages/mods/utils/useReactivateMod.test.ts
+++ b/src/extensionConsole/pages/mods/utils/useReactivateMod.test.ts
@@ -22,6 +22,7 @@ import { deactivateMod } from "@/store/deactivateModHelpers";
 import { type ModComponentsRootState } from "@/store/modComponents/modComponentTypes";
 import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { selectActivatedModComponents } from "@/store/modComponents/modComponentSelectors";
+import { act } from "@testing-library/react-hooks";
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -32,7 +33,6 @@ test("deactivates mod components", async () => {
 
   const {
     result: { current: reactivateMod },
-    act,
     getReduxStore,
   } = renderHook(() => useReactivateMod(), {
     setupRedux(dispatch) {
@@ -64,7 +64,6 @@ test("dispatches activate mod action", async () => {
 
   const {
     result: { current: reactivateMod },
-    act,
   } = renderHook(() => useReactivateMod(), {
     setupRedux(dispatch) {
       dispatch(

--- a/src/extensionConsole/pages/settings/useDeploymentKeySetting.test.ts
+++ b/src/extensionConsole/pages/settings/useDeploymentKeySetting.test.ts
@@ -19,6 +19,7 @@ import { deploymentKeyStorage } from "@/auth/deploymentKey";
 import { renderHook } from "@/extensionConsole/testHelpers";
 import useDeploymentKeySetting from "@/extensionConsole/pages/settings/useDeploymentKeySetting";
 import { deploymentKeyFactory } from "@/testUtils/factories/authFactories";
+import { act } from "@testing-library/react-hooks";
 
 describe("useDeploymentKeySettings", () => {
   beforeEach(async () => {
@@ -28,7 +29,7 @@ describe("useDeploymentKeySettings", () => {
   it("sets deployment key", async () => {
     const target = deploymentKeyFactory();
 
-    const { result, act } = renderHook(() => useDeploymentKeySetting());
+    const { result } = renderHook(() => useDeploymentKeySetting());
 
     const [value, setValue] = result.current;
     expect(value).toBeUndefined();
@@ -45,7 +46,7 @@ describe("useDeploymentKeySettings", () => {
 
     await deploymentKeyStorage.set(original);
 
-    const { result, act, waitForNextUpdate } = renderHook(() =>
+    const { result, waitForNextUpdate } = renderHook(() =>
       useDeploymentKeySetting(),
     );
 
@@ -63,7 +64,7 @@ describe("useDeploymentKeySettings", () => {
   });
 
   it("rejects invalid deployment key", async () => {
-    const { result, act } = renderHook(() => useDeploymentKeySetting());
+    const { result } = renderHook(() => useDeploymentKeySetting());
 
     const [_value, setValue] = result.current;
 

--- a/src/hooks/useAsyncState.test.ts
+++ b/src/hooks/useAsyncState.test.ts
@@ -18,6 +18,7 @@
 import pDefer from "p-defer";
 import useAsyncState from "@/hooks/useAsyncState";
 import { renderHook } from "@/pageEditor/testHelpers";
+import { act } from "@testing-library/react-hooks";
 
 describe("useAsyncState", () => {
   it("should handle resolve promise", async () => {
@@ -96,7 +97,7 @@ describe("useAsyncState", () => {
     let deferred = pDefer<number>();
     let factory = async () => deferred.promise;
 
-    const { result, rerender, act } = renderHook(
+    const { result, rerender } = renderHook(
       ({ factory, dependency }) => useAsyncState(factory, [dependency]),
       {
         initialProps: {
@@ -145,7 +146,7 @@ describe("useAsyncState", () => {
 
   it("should handle refetch for same arguments", async () => {
     const originalFactory = async () => 42;
-    const { result, rerender, waitFor, act } = renderHook(
+    const { result, rerender, waitFor } = renderHook(
       (props) => useAsyncState(props, []),
       {
         initialProps: originalFactory,

--- a/src/pageEditor/documentBuilder/hooks/useDuplicateElement.test.ts
+++ b/src/pageEditor/documentBuilder/hooks/useDuplicateElement.test.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+/* eslint-disable testing-library/no-node-access -- false positive on body/children when accessing document paths */
 
 import { toExpression } from "@/utils/expressionUtils";
 import useDuplicateElement from "@/pageEditor/documentBuilder/hooks/useDuplicateElement";

--- a/src/pageEditor/documentBuilder/hooks/useDuplicateElement.test.ts
+++ b/src/pageEditor/documentBuilder/hooks/useDuplicateElement.test.ts
@@ -23,6 +23,7 @@ import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
 import { autoUUIDSequence } from "@/testUtils/factories/stringFactories";
 import { type BrickConfig } from "@/bricks/types";
 import { validateRegistryId } from "@/types/helpers";
+import { act } from "@testing-library/react-hooks";
 
 const staticDocumentConfig: BrickConfig = {
   id: validateRegistryId("@pixiebrix/document"),
@@ -118,7 +119,7 @@ describe("useDuplicateElement", () => {
       },
     );
 
-    await wrapper.act(async () => {
+    await act(async () => {
       await wrapper.result.current("body.0.children.0.children.0.children.0");
     });
 
@@ -151,7 +152,7 @@ describe("useDuplicateElement", () => {
       },
     );
 
-    await wrapper.act(async () => {
+    await act(async () => {
       await wrapper.result.current("body.0.children.0.children.0.children.0");
     });
 

--- a/src/pageEditor/hooks/useBuildAndValidateMod.test.ts
+++ b/src/pageEditor/hooks/useBuildAndValidateMod.test.ts
@@ -21,7 +21,7 @@ import {
   lookupStarterBrick,
 } from "@/pageEditor/starterBricks/base";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
-import { hookAct, renderHook } from "@/pageEditor/testHelpers";
+import { renderHook } from "@/pageEditor/testHelpers";
 import {
   type StarterBrickDefinitionLike,
   type StarterBrickDefinitionProp,
@@ -44,6 +44,7 @@ import { actions as editorActions } from "@/pageEditor/store/editor/editorSlice"
 import { normalizeModDefinition } from "@/utils/modUtils";
 import { DefinitionKinds } from "@/types/registryTypes";
 import { adapter } from "@/pageEditor/starterBricks/adapter";
+import { act } from "@testing-library/react-hooks";
 
 jest.mock("@/pageEditor/starterBricks/base", () => ({
   ...jest.requireActual("@/pageEditor/starterBricks/base"),
@@ -145,7 +146,7 @@ describe("useBuildAndValidateMod", () => {
         },
       });
 
-      await hookAct(async () => {
+      await act(async () => {
         const actualModDefinition = await result.current.buildAndValidateMod({
           sourceModDefinition: modDefinition,
           draftModComponents: [
@@ -205,7 +206,7 @@ describe("useBuildAndValidateMod", () => {
 
     const state = getReduxStore().getState().options as ModComponentState;
 
-    await hookAct(async () => {
+    await act(async () => {
       await expect(
         result.current.buildAndValidateMod({
           sourceModDefinition: activatedModDefinition,

--- a/src/pageEditor/hooks/useCreateModFromMod.test.ts
+++ b/src/pageEditor/hooks/useCreateModFromMod.test.ts
@@ -20,7 +20,7 @@ import {
   modComponentDefinitionFactory,
   modDefinitionFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
-import { hookAct, renderHook } from "@/pageEditor/testHelpers";
+import { renderHook } from "@/pageEditor/testHelpers";
 import useCreateModFromMod from "@/pageEditor/hooks/useCreateModFromMod";
 import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 import { actions as modComponentActions } from "@/store/modComponents/modComponentSlice";
@@ -32,6 +32,7 @@ import useCheckModStarterBrickInvariants from "@/pageEditor/hooks/useCheckModSta
 import { API_PATHS } from "@/data/service/urlPaths";
 import { timestampFactory } from "@/testUtils/factories/stringFactories";
 import { DataIntegrityError } from "@/pageEditor/hooks/useBuildAndValidateMod";
+import { act } from "@testing-library/react-hooks";
 
 const reportEventMock = jest.mocked(reportEvent);
 jest.mock("@/telemetry/trace");
@@ -64,7 +65,7 @@ describe("useCreateModFromMod", () => {
       .onPost(API_PATHS.BRICKS)
       .reply(200, { updated_at: timestampFactory() });
 
-    const { result, act } = renderHook(() => useCreateModFromMod(), {
+    const { result } = renderHook(() => useCreateModFromMod(), {
       setupRedux(dispatch) {
         dispatch(
           modComponentActions.activateMod({
@@ -116,7 +117,7 @@ describe("useCreateModFromMod", () => {
       },
     });
 
-    await hookAct(async () => {
+    await act(async () => {
       await expect(
         result.current.createModFromMod(
           sourceModDefinition,
@@ -153,7 +154,7 @@ describe("useCreateModFromMod", () => {
       },
     });
 
-    await hookAct(async () => {
+    await act(async () => {
       await expect(
         result.current.createModFromMod(
           sourceModDefinition,

--- a/src/pageEditor/hooks/useCreateModFromModComponent.test.ts
+++ b/src/pageEditor/hooks/useCreateModFromModComponent.test.ts
@@ -24,6 +24,7 @@ import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
 import { API_PATHS } from "@/data/service/urlPaths";
 import { actions as editorActions } from "@/pageEditor/store/editor/editorSlice";
+import { act } from "@testing-library/react-hooks";
 
 const reportEventMock = jest.mocked(reportEvent);
 
@@ -55,7 +56,7 @@ describe("useCreateModFromModComponent", () => {
 
     appApiMock.onGet(API_PATHS.BRICKS).reply(200, []);
 
-    const { result, act } = renderHook(() => useCreateModFromModComponent(), {
+    const { result } = renderHook(() => useCreateModFromModComponent(), {
       setupRedux(dispatch) {
         dispatch(editorActions.addModComponentFormState(menuItemFormState));
       },

--- a/src/pageEditor/hooks/useDeleteDraftModComponent.test.ts
+++ b/src/pageEditor/hooks/useDeleteDraftModComponent.test.ts
@@ -24,6 +24,7 @@ import {
 import { removeDraftModComponents } from "@/contentScript/messenger/api";
 import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
 import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
+import { act } from "@testing-library/react-hooks";
 
 beforeEach(() => {
   jest.resetAllMocks();
@@ -44,7 +45,6 @@ describe("useDeleteModComponent", () => {
     const {
       result: { current: deleteDraftModComponent },
       getReduxStore,
-      act,
     } = renderHook(() => useDeleteDraftModComponent(), {
       setupRedux(dispatch, { store }) {
         jest.spyOn(store, "dispatch");

--- a/src/pageEditor/hooks/useSaveMod.test.ts
+++ b/src/pageEditor/hooks/useSaveMod.test.ts
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { hookAct, renderHook } from "@/pageEditor/testHelpers";
+import { renderHook } from "@/pageEditor/testHelpers";
 import useSaveMod, { isModEditable } from "@/pageEditor/hooks/useSaveMod";
 import { validateRegistryId } from "@/types/helpers";
 import { appApiMock } from "@/testUtils/appApiMock";
@@ -42,6 +42,7 @@ import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
 import { createPrivateSharing } from "@/utils/registryUtils";
 import { timestampFactory } from "@/testUtils/factories/stringFactories";
 import { propertiesToSchema } from "@/utils/schemaUtils";
+import { act } from "@testing-library/react-hooks";
 
 const modId = validateRegistryId("@test/mod");
 
@@ -119,7 +120,7 @@ describe("useSaveMod", () => {
 
     await waitForEffect();
 
-    await hookAct(async () => {
+    await act(async () => {
       await result.current(modId);
     });
 
@@ -156,7 +157,7 @@ describe("useSaveMod", () => {
 
     await waitForEffect();
 
-    await hookAct(async () => {
+    await act(async () => {
       await result.current(modId);
     });
 
@@ -212,7 +213,7 @@ describe("useSaveMod", () => {
 
     await waitForEffect();
 
-    await hookAct(async () => {
+    await act(async () => {
       await result.current(modId);
     });
 
@@ -267,7 +268,7 @@ describe("useSaveMod", () => {
 
     await waitForEffect();
 
-    await hookAct(async () => {
+    await act(async () => {
       await result.current(modId);
     });
 
@@ -323,7 +324,7 @@ describe("useSaveMod", () => {
 
     const { dispatch } = getReduxStore();
 
-    await hookAct(async () => {
+    await act(async () => {
       await result.current(temporaryModMetadata.id);
     });
 

--- a/src/pageEditor/testHelpers.ts
+++ b/src/pageEditor/testHelpers.ts
@@ -71,5 +71,4 @@ export * from "@testing-library/react";
 // eslint-disable-next-line import/export -- override render
 export { renderWithWrappers as render };
 export { renderHookWithWrappers as renderHook };
-export { act as hookAct } from "@testing-library/react-hooks";
 export { userEvent } from "@testing-library/user-event";

--- a/src/testUtils/testHelpers.tsx
+++ b/src/testUtils/testHelpers.tsx
@@ -207,11 +207,6 @@ type HookWrapperResult<
   getReduxStore(): EnhancedStore<S, A, M>;
 
   /**
-   * The act function which should be used with the renderHook
-   */
-  act(callback: () => Promise<void>): Promise<undefined>;
-
-  /**
    * Await all async side effects
    */
   waitForEffect(): Promise<void>;
@@ -277,7 +272,6 @@ export function createRenderHookWithWrappers(configureStore: ConfigureStore) {
       getReduxStore() {
         return store;
       },
-      act: actHook,
       async waitForEffect() {
         await actHook(async () => {
           // Awaiting the async state update


### PR DESCRIPTION
## What does this PR do?

- Part of #3164
- Drops `act` from wrapper in favor of importing from `@testing-library/react-hooks` so it's easier to find/replace during `testing-library/react` upgrade. (React 18 drops separate `@testing-library/react-hooks` library, so there's a single `act` hook)

## Discussion

- Alternative would be to continue to export `hookAct` from `testHelpers` and rename/replace uses during React 18/testing library upgrade

## Future Work

- Drop/rework other hooks: https://github.com/testing-library/react-hooks-testing-library/blob/chore/migration-guide/MIGRATION_GUIDE.md 

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
