### PR TITLE
#9338 Add Rich Text Editor toolbar buttons

### DIFF
--- a/knip.mjs
+++ b/knip.mjs
@@ -133,6 +133,7 @@ const knipConfig = {
     "@tiptap/pm",
     "@tiptap/starter-kit",
     "@tiptap/react",
+    "@tiptap/extension-underline",
   ],
   // False positive for PackageInstance.featureFlag
   ignoreMembers: ["featureFlag"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@rjsf/core": "^5.22.3",
         "@rjsf/utils": "^5.22.3",
         "@szhsin/react-menu": "^4.2.2",
+        "@tiptap/extension-underline": "^2.9.1",
         "@tiptap/pm": "^2.9.1",
         "@tiptap/react": "^2.9.1",
         "@tiptap/starter-kit": "^2.9.1",
@@ -8256,6 +8257,18 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.9.1.tgz",
       "integrity": "sha512-LAxc0SeeiPiAVBwksczeA7BJSZb6WtVpYhy5Esvy9K0mK5kttB4KxtnXWeQzMIJZQbza65yftGKfQlexf/Y7yg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-2.9.1.tgz",
+      "integrity": "sha512-IrUsIqKPgD7GcAjr4D+RC0WvLHUDBTMkD8uPNEoeD1uH9t9zFyDfMRPnx/z3/6Gf6fTh3HzLcHGibiW2HiMi2A==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@rjsf/core": "^5.22.3",
     "@rjsf/utils": "^5.22.3",
     "@szhsin/react-menu": "^4.2.2",
+    "@tiptap/extension-underline": "^2.9.1",
     "@tiptap/pm": "^2.9.1",
     "@tiptap/react": "^2.9.1",
     "@tiptap/starter-kit": "^2.9.1",

--- a/src/components/richTextEditor/RichTextEditor.module.scss
+++ b/src/components/richTextEditor/RichTextEditor.module.scss
@@ -42,9 +42,7 @@
   }
 }
 
-.toolbar {
-  border-bottom: 1px solid #ced4da;
-
+.toolbarButtons {
   :global(.btn) {
     &:global(.active) {
       color: #007bff;
@@ -64,4 +62,10 @@
     border: none;
     box-shadow: none;
   }
+}
+
+.toolbar {
+  border-bottom: 1px solid #ced4da;
+
+  @extend .toolbarButtons;
 }

--- a/src/components/richTextEditor/RichTextEditor.module.scss
+++ b/src/components/richTextEditor/RichTextEditor.module.scss
@@ -43,6 +43,10 @@
 }
 
 .toolbarButtons {
+  :global(.btn-group) {
+    flex-direction: row;
+  }
+
   :global(.btn) {
     &:global(.active) {
       color: #007bff;

--- a/src/components/richTextEditor/RichTextEditor.test.tsx
+++ b/src/components/richTextEditor/RichTextEditor.test.tsx
@@ -30,17 +30,29 @@ describe("RichTextEditor", () => {
     expect(editor?.innerHTML).toBe("<p>regular<em>and italic</em></p>");
   });
 
-  test("applies both bold and italic formatting using toolbar buttons", async () => {
+  test("applies underline formatting using toolbar button", async () => {
+    render(<RichTextEditor />);
+
+    const editor = screen.getByRole("textbox");
+    await user.type(editor, "regular");
+    await user.click(screen.getByRole("button", { name: "Underline" }));
+    await user.type(editor, "and underlined");
+
+    expect(editor?.innerHTML).toBe("<p>regular<u>and underlined</u></p>");
+  });
+
+  test("applies bold, italic and underline formatting using toolbar buttons", async () => {
     render(<RichTextEditor />);
 
     const editor = screen.getByRole("textbox");
     await user.type(editor, "regular");
     await user.click(screen.getByRole("button", { name: "Bold" }));
     await user.click(screen.getByRole("button", { name: "Italic" }));
-    await user.type(editor, "both bold and italic");
+    await user.click(screen.getByRole("button", { name: "Underline" }));
+    await user.type(editor, "all formats");
 
     expect(editor?.innerHTML).toBe(
-      "<p>regular<strong><em>both bold and italic</em></strong></p>",
+      "<p>regular<strong><em><u>all formats</u></em></strong></p>",
     );
   });
 

--- a/src/components/richTextEditor/RichTextEditor.test.tsx
+++ b/src/components/richTextEditor/RichTextEditor.test.tsx
@@ -35,6 +35,11 @@ describe("RichTextEditor", () => {
 
     const editor = screen.getByRole("textbox");
     await user.type(editor, "regular");
+
+    // Open the overflow menu
+    await user.click(
+      screen.getByRole("button", { name: "More editing options" }),
+    );
     await user.click(screen.getByRole("button", { name: "Underline" }));
     await user.type(editor, "and underlined");
 
@@ -48,6 +53,11 @@ describe("RichTextEditor", () => {
     await user.type(editor, "regular");
     await user.click(screen.getByRole("button", { name: "Bold" }));
     await user.click(screen.getByRole("button", { name: "Italic" }));
+
+    // Open the overflow menu
+    await user.click(
+      screen.getByRole("button", { name: "More editing options" }),
+    );
     await user.click(screen.getByRole("button", { name: "Underline" }));
     await user.type(editor, "all formats");
 
@@ -136,5 +146,20 @@ describe("RichTextEditor", () => {
       await user.click(screen.getByRole("button", { name: "Bullet List" }));
       expect(editor?.innerHTML).toBe("<p>list item</p>");
     });
+  });
+
+  test("applies strikethrough formatting using toolbar button", async () => {
+    render(<RichTextEditor />);
+
+    const editor = screen.getByRole("textbox");
+    await user.type(editor, "regular");
+
+    await user.click(
+      screen.getByRole("button", { name: "More editing options" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Strikethrough" }));
+    await user.type(editor, "struck through");
+
+    expect(editor?.innerHTML).toBe("<p>regular<s>struck through</s></p>");
   });
 });

--- a/src/components/richTextEditor/RichTextEditor.test.tsx
+++ b/src/components/richTextEditor/RichTextEditor.test.tsx
@@ -92,4 +92,49 @@ describe("RichTextEditor", () => {
       expect(editorElement?.innerHTML).toBe("<p>Hello World</p>");
     });
   });
+
+  describe("lists", () => {
+    test("applies bullet list formatting using toolbar button", async () => {
+      render(<RichTextEditor />);
+
+      const editor = screen.getByRole("textbox");
+      await user.type(editor, "first item");
+      await user.click(screen.getByRole("button", { name: "Bullet List" }));
+
+      expect(editor?.innerHTML).toBe("<ul><li><p>first item</p></li></ul>");
+
+      await user.type(editor, "{enter}second item");
+      expect(editor?.innerHTML).toBe(
+        "<ul><li><p>first item</p></li><li><p>second item</p></li></ul>",
+      );
+    });
+
+    test("applies numbered list formatting using toolbar button", async () => {
+      render(<RichTextEditor />);
+
+      const editor = screen.getByRole("textbox");
+      await user.type(editor, "first item");
+      await user.click(screen.getByRole("button", { name: "Numbered List" }));
+
+      expect(editor?.innerHTML).toBe("<ol><li><p>first item</p></li></ol>");
+
+      await user.type(editor, "{enter}second item");
+      expect(editor?.innerHTML).toBe(
+        "<ol><li><p>first item</p></li><li><p>second item</p></li></ol>",
+      );
+    });
+
+    test("can remove list formatting", async () => {
+      render(<RichTextEditor />);
+
+      const editor = screen.getByRole("textbox");
+      await user.type(editor, "list item");
+
+      await user.click(screen.getByRole("button", { name: "Bullet List" }));
+      expect(editor?.innerHTML).toBe("<ul><li><p>list item</p></li></ul>");
+
+      await user.click(screen.getByRole("button", { name: "Bullet List" }));
+      expect(editor?.innerHTML).toBe("<p>list item</p>");
+    });
+  });
 });

--- a/src/components/richTextEditor/RichTextEditor.tsx
+++ b/src/components/richTextEditor/RichTextEditor.tsx
@@ -18,6 +18,7 @@
 import styles from "./RichTextEditor.module.scss";
 import { EditorProvider, type EditorProviderProps } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
+import { Underline } from "@tiptap/extension-underline";
 import React from "react";
 import Toolbar from "@/components/richTextEditor/toolbar/Toolbar";
 
@@ -26,7 +27,7 @@ const RichTextEditor: React.FunctionComponent<EditorProviderProps> = (
 ) => (
   <div className={styles.root}>
     <EditorProvider
-      extensions={[StarterKit]}
+      extensions={[StarterKit, Underline]}
       slotBefore={<Toolbar />}
       {...props}
     />

--- a/src/components/richTextEditor/toolbar/BulletedListButton.tsx
+++ b/src/components/richTextEditor/toolbar/BulletedListButton.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { useCurrentEditor } from "@tiptap/react";
+import { Button } from "react-bootstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faListUl } from "@fortawesome/free-solid-svg-icons";
+
+const BulletedListButton: React.FunctionComponent = () => {
+  const { editor } = useCurrentEditor();
+
+  if (!editor) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="default"
+      onClick={() => editor.chain().focus().toggleBulletList().run()}
+      disabled={
+        editor.isEditable
+          ? !editor.can().chain().focus().toggleBulletList().run()
+          : true
+      }
+      active={editor.isActive("bulletList")}
+      aria-label="Bullet List"
+    >
+      <FontAwesomeIcon icon={faListUl} />
+    </Button>
+  );
+};
+
+export default BulletedListButton;

--- a/src/components/richTextEditor/toolbar/HorizontalRuleButton.tsx
+++ b/src/components/richTextEditor/toolbar/HorizontalRuleButton.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { useCurrentEditor } from "@tiptap/react";
+import { Button } from "react-bootstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faMinusSquare } from "@fortawesome/free-solid-svg-icons";
+
+const HorizontalRuleButton: React.FunctionComponent = () => {
+  const { editor } = useCurrentEditor();
+
+  if (!editor) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="default"
+      onClick={() => editor.chain().focus().setHorizontalRule().run()}
+      disabled={
+        editor.isEditable
+          ? !editor.can().chain().focus().setHorizontalRule().run()
+          : true
+      }
+      aria-label="Horizontal Rule"
+    >
+      <FontAwesomeIcon icon={faMinusSquare} />
+    </Button>
+  );
+};
+
+export default HorizontalRuleButton;

--- a/src/components/richTextEditor/toolbar/NumberedListButton.tsx
+++ b/src/components/richTextEditor/toolbar/NumberedListButton.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { useCurrentEditor } from "@tiptap/react";
+import { Button } from "react-bootstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faListOl } from "@fortawesome/free-solid-svg-icons";
+
+const NumberedListButton: React.FunctionComponent = () => {
+  const { editor } = useCurrentEditor();
+
+  if (!editor) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="default"
+      onClick={() => editor.chain().focus().toggleOrderedList().run()}
+      disabled={
+        editor.isEditable
+          ? !editor.can().chain().focus().toggleOrderedList().run()
+          : true
+      }
+      active={editor.isActive("orderedList")}
+      aria-label="Numbered List"
+    >
+      <FontAwesomeIcon icon={faListOl} />
+    </Button>
+  );
+};
+
+export default NumberedListButton;

--- a/src/components/richTextEditor/toolbar/RemoveTextFormattingButton.tsx
+++ b/src/components/richTextEditor/toolbar/RemoveTextFormattingButton.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { useCurrentEditor } from "@tiptap/react";
 import { Button } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faMinus } from "@fortawesome/free-solid-svg-icons";
+import { faRemoveFormat } from "@fortawesome/free-solid-svg-icons";
 
-const HorizontalRuleButton: React.FunctionComponent = () => {
+const RemoveTextFormattingButton: React.FunctionComponent = () => {
   const { editor } = useCurrentEditor();
 
   if (!editor) {
@@ -14,17 +14,17 @@ const HorizontalRuleButton: React.FunctionComponent = () => {
   return (
     <Button
       variant="default"
-      onClick={() => editor.chain().focus().setHorizontalRule().run()}
+      onClick={() => editor.chain().focus().unsetAllMarks().run()}
       disabled={
         editor.isEditable
-          ? !editor.can().chain().focus().setHorizontalRule().run()
+          ? !editor.can().chain().focus().unsetAllMarks().run()
           : true
       }
-      aria-label="Horizontal Rule"
+      aria-label="Remove Formatting"
     >
-      <FontAwesomeIcon icon={faMinus} />
+      <FontAwesomeIcon icon={faRemoveFormat} />
     </Button>
   );
 };
 
-export default HorizontalRuleButton;
+export default RemoveTextFormattingButton;

--- a/src/components/richTextEditor/toolbar/StrikethroughButton.tsx
+++ b/src/components/richTextEditor/toolbar/StrikethroughButton.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { useCurrentEditor } from "@tiptap/react";
+import { Button } from "react-bootstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faStrikethrough } from "@fortawesome/free-solid-svg-icons";
+
+const StrikethroughButton: React.FunctionComponent = () => {
+  const { editor } = useCurrentEditor();
+
+  if (!editor) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="default"
+      onClick={() => editor.chain().focus().toggleStrike().run()}
+      disabled={
+        editor.isEditable
+          ? !editor.can().chain().focus().toggleStrike().run()
+          : true
+      }
+      active={editor.isActive("strike")}
+      aria-label="Strikethrough"
+    >
+      <FontAwesomeIcon icon={faStrikethrough} />
+    </Button>
+  );
+};
+
+export default StrikethroughButton;

--- a/src/components/richTextEditor/toolbar/Toolbar.tsx
+++ b/src/components/richTextEditor/toolbar/Toolbar.tsx
@@ -16,7 +16,15 @@
  */
 
 import React from "react";
-import { ButtonGroup, ButtonToolbar } from "react-bootstrap";
+import {
+  ButtonGroup,
+  ButtonToolbar,
+  Button,
+  Popover,
+  OverlayTrigger,
+} from "react-bootstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEllipsisH } from "@fortawesome/free-solid-svg-icons";
 import styles from "@/components/richTextEditor/RichTextEditor.module.scss";
 import HeadingLevelDropdown from "@/components/richTextEditor/toolbar/HeadingLevelDropdown";
 import UnderlineButton from "@/components/richTextEditor/toolbar/UnderlineButton";
@@ -26,29 +34,52 @@ import StrikethroughButton from "@/components/richTextEditor/toolbar/Strikethrou
 import BulletedListButton from "@/components/richTextEditor/toolbar/BulletedListButton";
 import NumberedListButton from "@/components/richTextEditor/toolbar/NumberedListButton";
 import HorizontalRuleButton from "@/components/richTextEditor/toolbar/HorizontalRuleButton";
+import RemoveTextFormattingButton from "@/components/richTextEditor/toolbar/RemoveTextFormattingButton";
 // Required for font-awesome styles to be available in IsolatedComponents
 import "@fortawesome/fontawesome-svg-core/styles.css";
 
-const Toolbar: React.FunctionComponent = () => (
-  <ButtonToolbar
-    className={styles.toolbar}
-    aria-label="Rich-Text Editor Toolbar"
-  >
-    <HeadingLevelDropdown />
-    <ButtonGroup size="sm">
-      <BoldButton />
-      <ItalicButton />
-      <UnderlineButton />
-      <StrikethroughButton />
-    </ButtonGroup>
-    <ButtonGroup size="sm" className="ml-2">
-      <BulletedListButton />
-      <NumberedListButton />
-    </ButtonGroup>
-    <ButtonGroup size="sm" className="ml-2">
-      <HorizontalRuleButton />
-    </ButtonGroup>
-  </ButtonToolbar>
-);
+const Toolbar: React.FunctionComponent = () => {
+  const OverflowPopover = (
+    <Popover id="toolbar-overflow-popover" className={styles.toolbarButtons}>
+      <ButtonGroup size="sm">
+        <UnderlineButton />
+        <StrikethroughButton />
+        <HorizontalRuleButton />
+        <RemoveTextFormattingButton />
+      </ButtonGroup>
+    </Popover>
+  );
+
+  return (
+    <ButtonToolbar
+      className={styles.toolbar}
+      aria-label="Rich-Text Editor Toolbar"
+    >
+      <HeadingLevelDropdown />
+      <ButtonGroup size="sm" className="ml-2">
+        <BoldButton />
+        <ItalicButton />
+      </ButtonGroup>
+
+      <ButtonGroup size="sm" className="ml-2">
+        <BulletedListButton />
+        <NumberedListButton />
+      </ButtonGroup>
+
+      <ButtonGroup size="sm">
+        <OverlayTrigger
+          trigger="click"
+          placement="bottom"
+          rootClose
+          overlay={OverflowPopover}
+        >
+          <Button variant="default" aria-label="More editing options">
+            <FontAwesomeIcon icon={faEllipsisH} />
+          </Button>
+        </OverlayTrigger>
+      </ButtonGroup>
+    </ButtonToolbar>
+  );
+};
 
 export default Toolbar;

--- a/src/components/richTextEditor/toolbar/Toolbar.tsx
+++ b/src/components/richTextEditor/toolbar/Toolbar.tsx
@@ -41,9 +41,11 @@ import "@fortawesome/fontawesome-svg-core/styles.css";
 const Toolbar: React.FunctionComponent = () => {
   const OverflowPopover = (
     <Popover id="toolbar-overflow-popover" className={styles.toolbarButtons}>
-      <ButtonGroup size="sm">
+      <ButtonGroup size="sm" className="mr-2">
         <UnderlineButton />
         <StrikethroughButton />
+      </ButtonGroup>
+      <ButtonGroup size="sm">
         <HorizontalRuleButton />
         <RemoveTextFormattingButton />
       </ButtonGroup>
@@ -56,12 +58,12 @@ const Toolbar: React.FunctionComponent = () => {
       aria-label="Rich-Text Editor Toolbar"
     >
       <HeadingLevelDropdown />
-      <ButtonGroup size="sm" className="ml-2">
+      <ButtonGroup size="sm" className="mr-2">
         <BoldButton />
         <ItalicButton />
       </ButtonGroup>
 
-      <ButtonGroup size="sm" className="ml-2">
+      <ButtonGroup size="sm" className="mr-2">
         <BulletedListButton />
         <NumberedListButton />
       </ButtonGroup>

--- a/src/components/richTextEditor/toolbar/Toolbar.tsx
+++ b/src/components/richTextEditor/toolbar/Toolbar.tsx
@@ -22,8 +22,10 @@ import HeadingLevelDropdown from "@/components/richTextEditor/toolbar/HeadingLev
 import UnderlineButton from "@/components/richTextEditor/toolbar/UnderlineButton";
 import BoldButton from "@/components/richTextEditor/toolbar/BoldButton";
 import ItalicButton from "@/components/richTextEditor/toolbar/ItalicButton";
+import StrikethroughButton from "@/components/richTextEditor/toolbar/StrikethroughButton";
 import BulletedListButton from "@/components/richTextEditor/toolbar/BulletedListButton";
 import NumberedListButton from "@/components/richTextEditor/toolbar/NumberedListButton";
+import HorizontalRuleButton from "@/components/richTextEditor/toolbar/HorizontalRuleButton";
 // Required for font-awesome styles to be available in IsolatedComponents
 import "@fortawesome/fontawesome-svg-core/styles.css";
 
@@ -37,10 +39,14 @@ const Toolbar: React.FunctionComponent = () => (
       <BoldButton />
       <ItalicButton />
       <UnderlineButton />
+      <StrikethroughButton />
     </ButtonGroup>
     <ButtonGroup size="sm" className="ml-2">
       <BulletedListButton />
       <NumberedListButton />
+    </ButtonGroup>
+    <ButtonGroup size="sm" className="ml-2">
+      <HorizontalRuleButton />
     </ButtonGroup>
   </ButtonToolbar>
 );

--- a/src/components/richTextEditor/toolbar/Toolbar.tsx
+++ b/src/components/richTextEditor/toolbar/Toolbar.tsx
@@ -22,6 +22,8 @@ import HeadingLevelDropdown from "@/components/richTextEditor/toolbar/HeadingLev
 import UnderlineButton from "@/components/richTextEditor/toolbar/UnderlineButton";
 import BoldButton from "@/components/richTextEditor/toolbar/BoldButton";
 import ItalicButton from "@/components/richTextEditor/toolbar/ItalicButton";
+import BulletedListButton from "@/components/richTextEditor/toolbar/BulletedListButton";
+import NumberedListButton from "@/components/richTextEditor/toolbar/NumberedListButton";
 // Required for font-awesome styles to be available in IsolatedComponents
 import "@fortawesome/fontawesome-svg-core/styles.css";
 
@@ -35,6 +37,10 @@ const Toolbar: React.FunctionComponent = () => (
       <BoldButton />
       <ItalicButton />
       <UnderlineButton />
+    </ButtonGroup>
+    <ButtonGroup size="sm" className="ml-2">
+      <BulletedListButton />
+      <NumberedListButton />
     </ButtonGroup>
   </ButtonToolbar>
 );

--- a/src/components/richTextEditor/toolbar/Toolbar.tsx
+++ b/src/components/richTextEditor/toolbar/Toolbar.tsx
@@ -18,11 +18,12 @@
 import React from "react";
 import { ButtonGroup, ButtonToolbar } from "react-bootstrap";
 import styles from "@/components/richTextEditor/RichTextEditor.module.scss";
+import HeadingLevelDropdown from "@/components/richTextEditor/toolbar/HeadingLevelDropdown";
+import UnderlineButton from "@/components/richTextEditor/toolbar/UnderlineButton";
 import BoldButton from "@/components/richTextEditor/toolbar/BoldButton";
 import ItalicButton from "@/components/richTextEditor/toolbar/ItalicButton";
 // Required for font-awesome styles to be available in IsolatedComponents
 import "@fortawesome/fontawesome-svg-core/styles.css";
-import HeadingLevelDropdown from "@/components/richTextEditor/toolbar/HeadingLevelDropdown";
 
 const Toolbar: React.FunctionComponent = () => (
   <ButtonToolbar
@@ -33,6 +34,7 @@ const Toolbar: React.FunctionComponent = () => (
     <ButtonGroup size="sm">
       <BoldButton />
       <ItalicButton />
+      <UnderlineButton />
     </ButtonGroup>
   </ButtonToolbar>
 );

--- a/src/components/richTextEditor/toolbar/UnderlineButton.tsx
+++ b/src/components/richTextEditor/toolbar/UnderlineButton.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { useCurrentEditor } from "@tiptap/react";
+import { Button } from "react-bootstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faUnderline } from "@fortawesome/free-solid-svg-icons";
+
+const UnderlineButton: React.FunctionComponent = () => {
+  const { editor } = useCurrentEditor();
+
+  if (!editor) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="default"
+      onClick={() => editor.chain().focus().toggleUnderline().run()}
+      disabled={
+        editor.isEditable
+          ? !editor.can().chain().focus().toggleUnderline().run()
+          : true
+      }
+      active={editor.isActive("underline")}
+      aria-label="Underline"
+    >
+      <FontAwesomeIcon icon={faUnderline} />
+    </Button>
+  );
+};
+
+export default UnderlineButton;


### PR DESCRIPTION
## What does this PR do?

- Part of #9338
- Adds the following buttons to the Rich Text Editor toolbar:
    - Underline
    - Strikethrough
    - Numbered List
    - Bulleted List
    - Horizontal rule
- [x] TODO: Collapse buttons under ellipsis menu when screen is too narrow
- [x] TODO: Add remaining test cases for horizontal rule and strikethrough

## Discussion

- I'm aware that the button toolbar actions have some obvious repetition that can be extracted. I propose we focus on doing that in a future slice, per sake of time.

## Demo


<img width="448" alt="image" src="https://github.com/user-attachments/assets/5d7a481c-4aa1-49bb-8dd9-06cb920d2f88">

<img width="452" alt="image" src="https://github.com/user-attachments/assets/90f1397a-82a3-4dde-a0f2-553b69cd7ed4">



## Future Work

- The following buttons need to be added to a follow-up slice:
    - Link button 
        - Url insertion dialog was more complicated than I anticipated. [See this branch here for progress on that](https://github.com/pixiebrix/pixiebrix-extension/compare/main...feature/9338_add_link_toolbar_action)
        - Please ask me for a sync update on this one
    - Blockquote button
        - Blockquote doesn't seem to have any styling applied to it in any of our document renderers. We might considering adding this button to nice-to-have
