### PR TITLE
Fix `useIsMounted` for strict mode

### DIFF
--- a/src/hooks/useIsMounted.ts
+++ b/src/hooks/useIsMounted.ts
@@ -18,17 +18,20 @@
 import { useCallback, useEffect, useRef } from "react";
 
 /**
- * Returns a function that returns true if the component is still mounted.
+ * Returns a function that returns true if the component is mounted.
  */
+// Reference implementation https://usehooks-ts.com/react-hook/use-is-mounted
 function useIsMounted(): () => boolean {
-  const isMountedRef = useRef(true);
+  // Must start as false to support double-render/effect in strict mode
+  const isMountedRef = useRef(false);
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
       isMountedRef.current = false;
-    },
-    [],
-  );
+    };
+  }, []);
 
   return useCallback(() => isMountedRef.current, []);
 }


### PR DESCRIPTION
## What does this PR do?

- Fix bug in `useIsMounted` uncovered by strict mode in React 18 testing library behavior
- On the 2nd render/useEffect the component was considered unmounted

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
