### PR TITLE
#3164: drop direct use of `@testing-library/react-hooks`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -135,6 +135,18 @@ module.exports = {
             message:
               'Use this instead: import EmotionShadowRoot from "@/components/EmotionShadowRoot"',
           },
+          {
+            group: ["@testing-library/react-hooks"],
+            importNames: ["renderHook"],
+            message:
+              'Use this instead: import { renderHook } from "@/testUtils/renderWithCommonStore", or the context-specific testHelpers file',
+          },
+          {
+            group: ["@testing-library/react-hooks"],
+            importNames: ["act"],
+            message:
+              'Use this instead: import { act } from "@testing-library/react"',
+          },
         ],
       }),
     ],

--- a/src/activation/useActivateMod.test.ts
+++ b/src/activation/useActivateMod.test.ts
@@ -49,7 +49,7 @@ import {
   type EditablePackageMetadata,
 } from "@/types/contract";
 import { activatableDeploymentFactory } from "@/testUtils/factories/deploymentFactories";
-import { act } from "@testing-library/react-hooks";
+import { act } from "@testing-library/react";
 
 jest.mock("@/contentScript/messenger/api");
 jest.mock("@/utils/notify");

--- a/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.test.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.test.ts
@@ -17,8 +17,8 @@
 
 import { type MenuOptions } from "@/components/fields/schemaFields/widgets/varPopup/menuFilters";
 import useKeyboardNavigation from "@/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation";
-import { renderHook } from "@testing-library/react-hooks";
 import { cloneDeep } from "lodash";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 describe("useKeyboardNavigation", () => {
   it("only sets the default active key path when the menu options change, ignoring referential inequality", async () => {
@@ -48,20 +48,12 @@ describe("useKeyboardNavigation", () => {
       "@input",
     ]);
 
-    expect(result.all).toHaveLength(2);
+    const prevResult = result.current;
 
     rerender({
       ...initialProps,
       menuOptions: cloneDeep(menuOptions),
     });
-
-    expect(result.all).toHaveLength(3);
-
-    const prevResult = result.all[1]!;
-
-    if (prevResult instanceof Error) {
-      throw new TypeError("prevResult is an error");
-    }
 
     expect(prevResult.activeKeyPath).toBe(result.current.activeKeyPath);
   });
@@ -90,18 +82,12 @@ describe("useKeyboardNavigation", () => {
 
     expect(result.current.activeKeyPath).toStrictEqual(["@input"]);
 
+    const prevResult = result.current;
+
     rerender({
       ...initialProps,
       likelyVariable: "@input",
     });
-
-    expect(result.all).toHaveLength(4);
-
-    const prevResult = result.all[2]!;
-
-    if (prevResult instanceof Error) {
-      throw new TypeError("prevResult is an error");
-    }
 
     // Active Key Path is deep equal, but not referentially equal
     expect(prevResult.activeKeyPath).not.toBe(result.current.activeKeyPath);

--- a/src/components/quickBar/useActionGenerators.test.tsx
+++ b/src/components/quickBar/useActionGenerators.test.tsx
@@ -16,11 +16,11 @@
  */
 
 import React from "react";
-import { renderHook } from "@testing-library/react-hooks";
 import useActionGenerators from "@/components/quickBar/useActionGenerators";
 import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import { KBarProvider } from "kbar";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 jest.mock("@/components/quickBar/quickBarRegistry");
 

--- a/src/components/quickBar/useActions.test.tsx
+++ b/src/components/quickBar/useActions.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import React from "react";
-import { act, renderHook } from "@testing-library/react-hooks";
+import { act, waitFor } from "@testing-library/react";
 import useActions from "@/components/quickBar/useActions";
 import { KBarProvider, useKBar } from "kbar";
 import defaultActions, {
@@ -24,6 +24,7 @@ import defaultActions, {
 } from "@/components/quickBar/defaultActions";
 import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
 import { initQuickBarApp } from "@/components/quickBar/QuickBarApp";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 jest.mock("@/auth/featureFlagStorage", () => ({
   flagOn: jest.fn().mockReturnValue(false),
@@ -73,9 +74,11 @@ describe("useActions", () => {
       });
     });
 
-    expect(Object.keys(result.current.actions)).toHaveLength(
-      NUM_DEFAULT_QUICKBAR_ACTIONS + 1,
-    );
+    await waitFor(async () => {
+      expect(Object.keys(result.current.actions)).toHaveLength(
+        NUM_DEFAULT_QUICKBAR_ACTIONS + 1,
+      );
+    });
 
     await act(async () => {
       quickBarRegistry.removeAction("test");

--- a/src/data/service/api.test.tsx
+++ b/src/data/service/api.test.tsx
@@ -23,7 +23,6 @@ import {
   useGetPackageQuery,
   useUpdatePackageMutation,
 } from "@/data/service/api";
-import { renderHook } from "@testing-library/react-hooks";
 import { Provider } from "react-redux";
 import React from "react";
 import { isAxiosError } from "@/errors/networkErrorHelpers";
@@ -33,6 +32,7 @@ import { waitForEffect } from "@/testUtils/testHelpers";
 import { isPlainObject } from "lodash";
 import { appApiMock } from "@/testUtils/appApiMock";
 import { type RegistryId } from "@/types/registryTypes";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 function testStore() {
   return configureStore({

--- a/src/errors/errorHelpers.test.tsx
+++ b/src/errors/errorHelpers.test.tsx
@@ -54,7 +54,6 @@ import {
   RemoteServiceError,
 } from "@/errors/clientRequestErrors";
 import { uuidv4 } from "@/types/helpers";
-import { renderHook } from "@testing-library/react-hooks";
 import { appApi, useGetPackageQuery } from "@/data/service/api";
 import { Provider } from "react-redux";
 import { waitForEffect } from "@/testUtils/testHelpers";
@@ -62,6 +61,7 @@ import { isAxiosError } from "@/errors/networkErrorHelpers";
 import React from "react";
 import { appApiMock } from "@/testUtils/appApiMock";
 import { InteractiveLoginRequiredError } from "@/errors/authErrors";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 function testStore() {
   return configureStore({

--- a/src/extensionConsole/pages/mods/utils/useReactivateMod.test.ts
+++ b/src/extensionConsole/pages/mods/utils/useReactivateMod.test.ts
@@ -22,7 +22,7 @@ import { deactivateMod } from "@/store/deactivateModHelpers";
 import { type ModComponentsRootState } from "@/store/modComponents/modComponentTypes";
 import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { selectActivatedModComponents } from "@/store/modComponents/modComponentSelectors";
-import { act } from "@testing-library/react-hooks";
+import { act } from "@testing-library/react";
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/src/extensionConsole/pages/packageEditor/useSubmitPackage.test.tsx
+++ b/src/extensionConsole/pages/packageEditor/useSubmitPackage.test.tsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 import useSubmitPackage from "@/extensionConsole/pages/packageEditor/useSubmitPackage";
-import { act, renderHook } from "@testing-library/react-hooks";
+import { act } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { type AuthState } from "@/auth/authTypes";
 import integrationsSlice, {
@@ -40,6 +40,7 @@ import notify from "@/utils/notify";
 import { appApiMock } from "@/testUtils/appApiMock";
 import { uuidv4 } from "@/types/helpers";
 import { ModalContext } from "@/components/ConfirmationModal";
+import { renderHook } from "@/extensionConsole/testHelpers";
 
 jest.mock("@/utils/notify");
 jest.mock("@/extensionConsole/pages/mods/utils/useReactivateMod");

--- a/src/extensionConsole/pages/settings/useDeploymentKeySetting.test.ts
+++ b/src/extensionConsole/pages/settings/useDeploymentKeySetting.test.ts
@@ -19,7 +19,7 @@ import { deploymentKeyStorage } from "@/auth/deploymentKey";
 import { renderHook } from "@/extensionConsole/testHelpers";
 import useDeploymentKeySetting from "@/extensionConsole/pages/settings/useDeploymentKeySetting";
 import { deploymentKeyFactory } from "@/testUtils/factories/authFactories";
-import { act } from "@testing-library/react-hooks";
+import { act } from "@testing-library/react";
 import { waitForNextUpdate } from "@/testUtils/renderHookHelpers";
 
 describe("useDeploymentKeySettings", () => {

--- a/src/hooks/useAbortSignal.test.ts
+++ b/src/hooks/useAbortSignal.test.ts
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { renderHook } from "@testing-library/react-hooks";
 import useAbortSignal from "./useAbortSignal";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 it("returns the initial state of the signal", () => {
   const active = renderHook(() => useAbortSignal(new AbortController().signal));

--- a/src/hooks/useAsyncExternalStore.test.ts
+++ b/src/hooks/useAsyncExternalStore.test.ts
@@ -15,9 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { renderHook } from "@testing-library/react-hooks";
 import useAsyncExternalStore from "@/hooks/useAsyncExternalStore";
 import { waitForEffect } from "@/testUtils/testHelpers";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 describe("useAsyncExternalStore", () => {
   it("should subscribe once", async () => {

--- a/src/hooks/useAsyncState.test.ts
+++ b/src/hooks/useAsyncState.test.ts
@@ -18,8 +18,7 @@
 import pDefer from "p-defer";
 import useAsyncState from "@/hooks/useAsyncState";
 import { renderHook } from "@/pageEditor/testHelpers";
-import { act } from "@testing-library/react-hooks";
-import { waitFor } from "@testing-library/react";
+import { act, waitFor } from "@testing-library/react";
 import { waitForNextUpdate } from "@/testUtils/renderHookHelpers";
 
 describe("useAsyncState", () => {

--- a/src/hooks/useAutoFocus.test.ts
+++ b/src/hooks/useAutoFocus.test.ts
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { renderHook } from "@testing-library/react-hooks";
 import useAutoFocusConfiguration from "./useAutoFocusConfiguration";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 jest.useFakeTimers();
 

--- a/src/hooks/useDeriveAsyncState.test.ts
+++ b/src/hooks/useDeriveAsyncState.test.ts
@@ -16,10 +16,10 @@
  */
 
 import useDeriveAsyncState from "@/hooks/useDeriveAsyncState";
-import { renderHook } from "@testing-library/react-hooks";
 import pDefer from "p-defer";
 import useAsyncState from "@/hooks/useAsyncState";
-import { waitForEffect } from "@/testUtils/testHelpers";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
+import { waitFor } from "@testing-library/react";
 
 describe("useDeriveAsyncState", () => {
   it("should handle empty args", async () => {
@@ -36,17 +36,17 @@ describe("useDeriveAsyncState", () => {
       isUninitialized: true,
     });
 
-    await wrapper.waitForNextUpdate();
-
-    expect(wrapper.result.current).toEqual({
-      isFetching: false,
-      isLoading: false,
-      currentData: 42,
-      data: 42,
-      error: undefined,
-      isError: false,
-      isSuccess: true,
-      isUninitialized: false,
+    await waitFor(() => {
+      expect(wrapper.result.current).toEqual({
+        isFetching: false,
+        isLoading: false,
+        currentData: 42,
+        data: 42,
+        error: undefined,
+        isError: false,
+        isSuccess: true,
+        isUninitialized: false,
+      });
     });
   });
 
@@ -71,29 +71,29 @@ describe("useDeriveAsyncState", () => {
 
     dependency.resolve(42);
 
-    await waitForEffect();
-
-    expect(wrapper.result.current).toEqual({
-      isFetching: false,
-      isLoading: false,
-      currentData: 42,
-      data: 42,
-      error: undefined,
-      isError: false,
-      isSuccess: true,
-      isUninitialized: false,
+    await waitFor(() => {
+      expect(wrapper.result.current).toEqual({
+        isFetching: false,
+        isLoading: false,
+        currentData: 42,
+        data: 42,
+        error: undefined,
+        isError: false,
+        isSuccess: true,
+        isUninitialized: false,
+      });
     });
   });
 
   it("should handle upstream error", async () => {
     const dependency = pDefer<number>();
 
-    const wrapper = renderHook(() => {
+    const { result } = renderHook(() => {
       const state = useAsyncState(dependency.promise, []);
       return useDeriveAsyncState(state, async (x: number) => x);
     });
 
-    expect(wrapper.result.current).toEqual({
+    expect(result.current).toEqual({
       isFetching: true,
       isLoading: true,
       currentData: undefined,
@@ -106,17 +106,17 @@ describe("useDeriveAsyncState", () => {
 
     dependency.reject(new Error("Test Error"));
 
-    await waitForEffect();
-
-    expect(wrapper.result.current).toEqual({
-      isFetching: false,
-      isLoading: false,
-      currentData: undefined,
-      data: undefined,
-      error: expect.toBeObject(),
-      isError: true,
-      isSuccess: false,
-      isUninitialized: false,
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        isFetching: false,
+        isLoading: false,
+        currentData: undefined,
+        data: undefined,
+        error: expect.toBeObject(),
+        isError: true,
+        isSuccess: false,
+        isUninitialized: false,
+      });
     });
   });
 });

--- a/src/hooks/useDocumentVisibility.test.ts
+++ b/src/hooks/useDocumentVisibility.test.ts
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { renderHook } from "@testing-library/react-hooks";
 import useDocumentVisibility from "./useDocumentVisibility";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 test("useDocumentVisibility", () => {
   const addEventListenerSpy = jest.spyOn(document, "addEventListener");

--- a/src/hooks/useEventListener.test.ts
+++ b/src/hooks/useEventListener.test.ts
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { renderHook } from "@testing-library/react-hooks";
 import useEventListener from "./useEventListener";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 test("useEventListener", () => {
   const mockElement = document.createElement("div");

--- a/src/hooks/useIsMounted.test.ts
+++ b/src/hooks/useIsMounted.test.ts
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { renderHook } from "@testing-library/react-hooks";
 import useIsMounted from "./useIsMounted";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 describe("useIsMounted", () => {
   it("should return true if component is mounted", () => {

--- a/src/hooks/useMemoCompare.test.ts
+++ b/src/hooks/useMemoCompare.test.ts
@@ -15,9 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { renderHook } from "@testing-library/react-hooks";
 import useMemoCompare from "@/hooks/useMemoCompare";
 import deepEquals from "fast-deep-equal";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 describe("useMemoCompare", () => {
   it("returns same reference for deepEquals", async () => {

--- a/src/hooks/useMergeAsyncState.test.ts
+++ b/src/hooks/useMergeAsyncState.test.ts
@@ -15,13 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { act, renderHook } from "@testing-library/react-hooks";
+import { act } from "@testing-library/react";
 import useMergeAsyncState from "@/hooks/useMergeAsyncState";
 import { valueToAsyncState } from "@/utils/asyncStateUtils";
 import { identity } from "lodash";
 import pDefer from "p-defer";
 import useAsyncState from "@/hooks/useAsyncState";
 import { waitForEffect } from "@/testUtils/testHelpers";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 describe("useMergeAsyncState", () => {
   it("should handle success", async () => {

--- a/src/hooks/useOnMountOnly.test.ts
+++ b/src/hooks/useOnMountOnly.test.ts
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { renderHook } from "@testing-library/react-hooks";
 import useOnMountOnly from "./useOnMountOnly";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 test("useOnMountOnly", async () => {
   const callback = jest.fn();

--- a/src/hooks/useScrollLock.test.ts
+++ b/src/hooks/useScrollLock.test.ts
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { renderHook } from "@testing-library/react-hooks";
 import useScrollLock from "./useScrollLock";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 describe("useScrollLock", () => {
   const html = document.documentElement;

--- a/src/hooks/useTimeoutState.test.ts
+++ b/src/hooks/useTimeoutState.test.ts
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { renderHook } from "@testing-library/react-hooks";
 import useTimeoutState from "./useTimeoutState";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 jest.useFakeTimers();
 

--- a/src/hooks/useUndo.test.ts
+++ b/src/hooks/useUndo.test.ts
@@ -15,8 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { act, renderHook } from "@testing-library/react-hooks";
+import { act } from "@testing-library/react";
 import useUndo from "@/hooks/useUndo";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 describe("useUndo", () => {
   beforeAll(() => {

--- a/src/hooks/useWindowSize.test.ts
+++ b/src/hooks/useWindowSize.test.ts
@@ -15,8 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { act, renderHook } from "@testing-library/react-hooks";
+import { act } from "@testing-library/react";
 import { useWindowSize } from "@/hooks/useWindowSize";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 // Simulate window resize event: https://gist.github.com/javierarques/d95948ac7e9ddc8097612866ecc63a4b#file-jsdom-helper-js
 const resizeEvent = document.createEvent("Event");

--- a/src/pageEditor/documentBuilder/hooks/useDuplicateElement.test.ts
+++ b/src/pageEditor/documentBuilder/hooks/useDuplicateElement.test.ts
@@ -24,7 +24,7 @@ import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
 import { autoUUIDSequence } from "@/testUtils/factories/stringFactories";
 import { type BrickConfig } from "@/bricks/types";
 import { validateRegistryId } from "@/types/helpers";
-import { act } from "@testing-library/react-hooks";
+import { act } from "@testing-library/react";
 
 const staticDocumentConfig: BrickConfig = {
   id: validateRegistryId("@pixiebrix/document"),

--- a/src/pageEditor/hooks/useBuildAndValidateMod.test.ts
+++ b/src/pageEditor/hooks/useBuildAndValidateMod.test.ts
@@ -44,7 +44,7 @@ import { actions as editorActions } from "@/pageEditor/store/editor/editorSlice"
 import { normalizeModDefinition } from "@/utils/modUtils";
 import { DefinitionKinds } from "@/types/registryTypes";
 import { adapter } from "@/pageEditor/starterBricks/adapter";
-import { act } from "@testing-library/react-hooks";
+import { act } from "@testing-library/react";
 
 jest.mock("@/pageEditor/starterBricks/base", () => ({
   ...jest.requireActual("@/pageEditor/starterBricks/base"),

--- a/src/pageEditor/hooks/useCreateModFromMod.test.ts
+++ b/src/pageEditor/hooks/useCreateModFromMod.test.ts
@@ -32,7 +32,7 @@ import useCheckModStarterBrickInvariants from "@/pageEditor/hooks/useCheckModSta
 import { API_PATHS } from "@/data/service/urlPaths";
 import { timestampFactory } from "@/testUtils/factories/stringFactories";
 import { DataIntegrityError } from "@/pageEditor/hooks/useBuildAndValidateMod";
-import { act } from "@testing-library/react-hooks";
+import { act } from "@testing-library/react";
 
 const reportEventMock = jest.mocked(reportEvent);
 jest.mock("@/telemetry/trace");

--- a/src/pageEditor/hooks/useCreateModFromModComponent.test.ts
+++ b/src/pageEditor/hooks/useCreateModFromModComponent.test.ts
@@ -24,7 +24,7 @@ import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
 import { API_PATHS } from "@/data/service/urlPaths";
 import { actions as editorActions } from "@/pageEditor/store/editor/editorSlice";
-import { act } from "@testing-library/react-hooks";
+import { act } from "@testing-library/react";
 
 const reportEventMock = jest.mocked(reportEvent);
 

--- a/src/pageEditor/hooks/useDeleteDraftModComponent.test.ts
+++ b/src/pageEditor/hooks/useDeleteDraftModComponent.test.ts
@@ -24,7 +24,7 @@ import {
 import { removeDraftModComponents } from "@/contentScript/messenger/api";
 import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
 import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
-import { act } from "@testing-library/react-hooks";
+import { act } from "@testing-library/react";
 
 beforeEach(() => {
   jest.resetAllMocks();

--- a/src/pageEditor/hooks/useSaveMod.test.ts
+++ b/src/pageEditor/hooks/useSaveMod.test.ts
@@ -42,7 +42,7 @@ import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
 import { createPrivateSharing } from "@/utils/registryUtils";
 import { timestampFactory } from "@/testUtils/factories/stringFactories";
 import { propertiesToSchema } from "@/utils/schemaUtils";
-import { act } from "@testing-library/react-hooks";
+import { act } from "@testing-library/react";
 import { waitForEffect } from "@/testUtils/testHelpers";
 
 const modId = validateRegistryId("@test/mod");

--- a/src/pageEditor/tabs/editTab/useReportTraceError.test.tsx
+++ b/src/pageEditor/tabs/editTab/useReportTraceError.test.tsx
@@ -27,7 +27,6 @@ import { configureStore } from "@reduxjs/toolkit";
 import { type TraceRecord } from "@/telemetry/trace";
 import { uuidv4 } from "@/types/helpers";
 import reportEvent from "@/telemetry/reportEvent";
-import { renderHook } from "@testing-library/react-hooks";
 import useReportTraceError from "./useReportTraceError";
 import { Provider } from "react-redux";
 
@@ -36,6 +35,7 @@ import {
   traceRecordFactory,
 } from "@/testUtils/factories/traceFactories";
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
 
 // Override the manual mock to support `expect` assertions
 jest.mock("@/telemetry/reportEvent");

--- a/src/permissions/useExtensionPermissions.test.ts
+++ b/src/permissions/useExtensionPermissions.test.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { renderHook } from "@testing-library/react-hooks";
 import useExtensionPermissions from "./useExtensionPermissions";
 import { extractAdditionalPermissions } from "webext-permissions";
 import {
@@ -24,6 +23,8 @@ import {
 } from "@/utils/asyncStateUtils";
 import { setPermissions } from "@/testUtils/permissionsMock";
 import { INTERNAL_reset } from "@/hooks/useAsyncExternalStore";
+import { renderHook } from "@/testUtils/renderWithCommonStore";
+import { waitFor } from "@testing-library/react";
 
 const selectAdditionalMock = jest.mocked(extractAdditionalPermissions);
 
@@ -52,74 +53,80 @@ describe("useExtensionPermissions", () => {
 
   test("reads manifest", async () => {
     mockOrigins();
-    const { result, waitForNextUpdate } = renderHook(useExtensionPermissions);
+    const { result } = renderHook(useExtensionPermissions);
     expect(result.current).toEqual(loadingAsyncStateFactory());
-    await waitForNextUpdate();
-    expect(result.current).toEqual(
-      valueToAsyncState([
-        {
-          isAdditional: false,
-          isOrigin: true,
-          isUnique: true,
-          name: "https://p.com/*",
-        },
-      ]),
-    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        valueToAsyncState([
+          {
+            isAdditional: false,
+            isOrigin: true,
+            isUnique: true,
+            name: "https://p.com/*",
+          },
+        ]),
+      );
+    });
   });
 
   test("includes additional permissions", async () => {
     mockOrigins("https://added.example.com/*", "https://more.example.com/*");
-    const { result, waitForNextUpdate } = renderHook(useExtensionPermissions);
-    await waitForNextUpdate();
-    expect(result.current).toEqual(
-      valueToAsyncState([
-        {
-          isAdditional: true,
-          isOrigin: true,
-          isUnique: true,
-          name: "https://added.example.com/*",
-        },
-        {
-          isAdditional: true,
-          isOrigin: true,
-          isUnique: true,
-          name: "https://more.example.com/*",
-        },
-        {
-          isAdditional: false,
-          isOrigin: true,
-          isUnique: true,
-          name: "https://p.com/*",
-        },
-      ]),
-    );
+    const { result } = renderHook(useExtensionPermissions);
+
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        valueToAsyncState([
+          {
+            isAdditional: true,
+            isOrigin: true,
+            isUnique: true,
+            name: "https://added.example.com/*",
+          },
+          {
+            isAdditional: true,
+            isOrigin: true,
+            isUnique: true,
+            name: "https://more.example.com/*",
+          },
+          {
+            isAdditional: false,
+            isOrigin: true,
+            isUnique: true,
+            name: "https://p.com/*",
+          },
+        ]),
+      );
+    });
   });
 
   test("detects overlapping permissions", async () => {
     mockOrigins("https://added.example.com/*", "https://*.example.com/*");
-    const { result, waitForNextUpdate } = renderHook(useExtensionPermissions);
-    await waitForNextUpdate();
-    expect(result.current).toEqual(
-      valueToAsyncState([
-        {
-          isAdditional: true,
-          isOrigin: true,
-          isUnique: true,
-          name: "https://*.example.com/*",
-        },
-        {
-          isAdditional: true,
-          isOrigin: true,
-          isUnique: false,
-          name: "https://added.example.com/*",
-        },
-        {
-          isAdditional: false,
-          isOrigin: true,
-          isUnique: true,
-          name: "https://p.com/*",
-        },
-      ]),
-    );
+    const { result } = renderHook(useExtensionPermissions);
+
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        valueToAsyncState([
+          {
+            isAdditional: true,
+            isOrigin: true,
+            isUnique: true,
+            name: "https://*.example.com/*",
+          },
+          {
+            isAdditional: true,
+            isOrigin: true,
+            isUnique: false,
+            name: "https://added.example.com/*",
+          },
+          {
+            isAdditional: false,
+            isOrigin: true,
+            isUnique: true,
+            name: "https://p.com/*",
+          },
+        ]),
+      );
+    });
   });
 });

--- a/src/testUtils/renderHookHelpers.ts
+++ b/src/testUtils/renderHookHelpers.ts
@@ -16,6 +16,7 @@
  */
 
 import { waitFor } from "@testing-library/react";
+ 
 import type { RenderHookResult } from "@testing-library/react-hooks";
 
 /**

--- a/src/testUtils/testHelpers.tsx
+++ b/src/testUtils/testHelpers.tsx
@@ -295,7 +295,6 @@ export function createRenderHookWithWrappers(configureStore: ConfigureStore) {
       "waitFor",
       "waitForValueToChange",
       "waitForNextUpdate",
-      "error",
     );
   };
 }


### PR DESCRIPTION
## What does this PR do?

- Prep work for #3164
- FLUP to #9428
- Drops direct use of `@testing-library/react-hooks` to eliminate the use of the deprecated helpers methods

## Discussion

- There are some hooks that don't rely on the store that I migrated to use `import { renderHook } from "@/testUtils/renderWithCommonStore";` to enforce eliminating the helper methods
  - The tradeoff is it couples the test code for those generic component to the store (which I'm not sure how it will interact with monorepo.)
  - So we might switch to be `import { renderHook } from "@testing-library/react"` post React 18 upgrade
  - The alternative would be to define a helper that doesn't include the store that exports the restricted type. (Which we could drop post React 18 upgrade)

## Future Work

- There will still need to be test rewriting/fixes for hooks. Even with strict mode on the `Wrapper`, I don't think `renderHook`  in the current version is re-running the hook 2x given that it misses the bug in https://github.com/pixiebrix/pixiebrix-extension/pull/9432

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
