### PR TITLE
Refactor page editor state types

### DIFF
--- a/src/background/deploymentUpdater.test.ts
+++ b/src/background/deploymentUpdater.test.ts
@@ -35,10 +35,8 @@ import {
   saveSettingsState,
 } from "@/store/settings/settingsStorage";
 import { getEditorState, saveEditorState } from "@/store/editorStorage";
-import {
-  editorSlice,
-  initialState as initialEditorState,
-} from "@/pageEditor/store/editor/editorSlice";
+import { editorSlice } from "@/pageEditor/store/editor/editorSlice";
+import { initialState as initialEditorState } from "@/store/editorInitialState";
 import { type ButtonFormState } from "@/pageEditor/starterBricks/formStateTypes";
 import { parsePackage } from "@/registry/packageRegistry";
 import { registry } from "@/background/messenger/api";

--- a/src/pageEditor/modListingPanel/ModListingPanel.tsx
+++ b/src/pageEditor/modListingPanel/ModListingPanel.tsx
@@ -27,7 +27,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import cx from "classnames";
 import useFlags from "@/hooks/useFlags";
-import { selectIsEditorSidebarExpanded } from "@/pageEditor/store/editor/editorSelectors";
+import { selectIsModListingPanelExpanded } from "@/pageEditor/store/editor/editorSelectors";
 import HomeButton from "./HomeButton";
 import ReloadButton from "./ReloadButton";
 import NewModButton from "./NewModButton";
@@ -54,7 +54,7 @@ const CollapsedElement: React.FC<
 const ModListingPanel: React.VFC = () => {
   const dispatch = useDispatch();
 
-  const isExpanded = useSelector(selectIsEditorSidebarExpanded);
+  const isExpanded = useSelector(selectIsModListingPanelExpanded);
 
   const { flagOn } = useFlags();
   const showDeveloperUI =

--- a/src/pageEditor/store/editor/editorSelectors/editorModSelectors.test.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorModSelectors.test.ts
@@ -17,7 +17,7 @@
 
 import { type EditorRootState } from "@/pageEditor/store/editor/pageEditorTypes";
 import { type ModComponentsRootState } from "@/store/modComponents/modComponentTypes";
-import { initialState as editorInitialState } from "@/pageEditor/store/editor/editorSlice";
+import { initialState as editorInitialState } from "@/store/editorInitialState";
 import { type ActivatedModComponent } from "@/types/modComponentTypes";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
 import {

--- a/src/pageEditor/store/editor/editorSelectors/editorNavigationSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorNavigationSelectors.ts
@@ -49,4 +49,4 @@ export const selectEditorUpdateKey = ({ editor }: EditorRootState) =>
   editor.selectionSeq;
 
 export const selectIsEditorSidebarExpanded = ({ editor }: EditorRootState) =>
-  editor.isModListExpanded;
+  editor.isModListingPanelExpanded;

--- a/src/pageEditor/store/editor/editorSelectors/editorNavigationSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors/editorNavigationSelectors.ts
@@ -48,5 +48,5 @@ export const selectExpandedModId = ({ editor }: EditorRootState) =>
 export const selectEditorUpdateKey = ({ editor }: EditorRootState) =>
   editor.selectionSeq;
 
-export const selectIsEditorSidebarExpanded = ({ editor }: EditorRootState) =>
+export const selectIsModListingPanelExpanded = ({ editor }: EditorRootState) =>
   editor.isModListingPanelExpanded;

--- a/src/pageEditor/store/editor/editorSlice.test.ts
+++ b/src/pageEditor/store/editor/editorSlice.test.ts
@@ -18,7 +18,6 @@
 import {
   editorSlice,
   actions,
-  initialState,
   persistEditorConfig,
 } from "@/pageEditor/store/editor/editorSlice";
 import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
@@ -49,6 +48,7 @@ import {
   selectModIsDirty,
 } from "@/pageEditor/store/editor/editorSelectors";
 import { propertiesToSchema } from "@/utils/schemaUtils";
+import { initialState } from "@/store/editorInitialState";
 
 function getTabState(
   state: EditorState,

--- a/src/pageEditor/store/editor/editorSlice.ts
+++ b/src/pageEditor/store/editor/editorSlice.ts
@@ -31,7 +31,7 @@ import {
   type ModMetadataFormState,
 } from "@/pageEditor/store/editor/pageEditorTypes";
 import { uuidv4 } from "@/types/helpers";
-import { cloneDeep, compact, get, omit, pull, uniq } from "lodash";
+import { cloneDeep, compact, get, pull, uniq } from "lodash";
 import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
 import { type TreeExpandedState } from "@/components/jsonTree/JsonTree";
 import { getInvalidPath } from "@/utils/debugUtils";

--- a/src/pageEditor/store/editor/editorSlice.ts
+++ b/src/pageEditor/store/editor/editorSlice.ts
@@ -26,7 +26,6 @@ import {
   type AddBrickLocation,
   type EditorRootState,
   type EditorState,
-  type EditorStateEphemeral,
   type ModalDefinition,
   ModalKey,
   type ModMetadataFormState,
@@ -93,7 +92,6 @@ import {
   initialEphemeralState,
   initialState,
 } from "@/store/editorInitialState";
-import { type Simplify } from "type-fest";
 
 /* eslint-disable security/detect-object-injection -- lots of immer-style code here dealing with Records */
 

--- a/src/pageEditor/store/editor/editorSlice.ts
+++ b/src/pageEditor/store/editor/editorSlice.ts
@@ -90,32 +90,7 @@ import {
 } from "@/pageEditor/context/connection";
 import { assertNotNullish } from "@/utils/nullishUtils";
 import { type UnionToTuple, type Except } from "type-fest";
-
-/** @internal */
-export const initialState: EditorState = {
-  selectionSeq: 0,
-  activeModComponentId: null,
-  activeModId: null,
-  expandedModId: null,
-  error: null,
-  modComponentFormStates: [],
-  dirty: {},
-  brickPipelineUIStateById: {},
-  dirtyModMetadataById: {},
-  dirtyModOptionsDefinitionById: {},
-  dirtyModVariablesDefinitionById: {},
-  dirtyModOptionsArgsById: {},
-  visibleModal: null,
-  deletedModComponentFormStateIdsByModId: {},
-  availableActivatedModComponentIds: [],
-  isPendingAvailableActivatedModComponents: false,
-  availableDraftModComponentIds: [],
-  isPendingDraftModComponents: false,
-  isModListExpanded: true,
-  isDataPanelExpanded: true,
-  isDimensionsWarningDismissed: false,
-  isVariablePopoverVisible: false,
-};
+import { initialState } from "@/store/editorInitialState";
 
 /* eslint-disable security/detect-object-injection -- lots of immer-style code here dealing with Records */
 

--- a/src/pageEditor/store/editor/editorSlice.ts
+++ b/src/pageEditor/store/editor/editorSlice.ts
@@ -26,6 +26,7 @@ import {
   type AddBrickLocation,
   type EditorRootState,
   type EditorState,
+  type EditorStateEphemeral,
   type ModalDefinition,
   ModalKey,
   type ModMetadataFormState,
@@ -80,7 +81,7 @@ import {
   type ModMetadata,
 } from "@/types/modComponentTypes";
 import { type OptionsArgs } from "@/types/runtimeTypes";
-import { createMigrate } from "redux-persist";
+import { createMigrate, type PersistConfig } from "redux-persist";
 import { migrations } from "@/store/editorMigrations";
 import { type BaseStarterBrickState } from "@/pageEditor/store/editor/baseFormStateTypes";
 import {
@@ -88,6 +89,7 @@ import {
   inspectedTab,
 } from "@/pageEditor/context/connection";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import { type UnionToTuple, type Except } from "type-fest";
 
 /** @internal */
 export const initialState: EditorState = {
@@ -1084,14 +1086,31 @@ export const actions = {
   checkActiveModComponentAvailability,
 };
 
-export const persistEditorConfig = {
+type PageEditorPersistConfig = Except<
+  PersistConfig<EditorState>,
+  "blacklist"
+> & {
+  blacklist: UnionToTuple<keyof EditorStateEphemeral>;
+};
+
+export const persistEditorConfig: PageEditorPersistConfig = {
   key: "editor",
   // Change the type of localStorage to our overridden version so that it can be exported
   // See: @/store/StorageInterface.ts
   storage: localStorage as StorageInterface,
-  version: 11,
+  version: 12,
   migrate: createMigrate(migrations, { debug: Boolean(process.env.DEBUG) }),
-  blacklist: ["inserting", "isVarPopoverVisible", "visibleModal"],
+  blacklist: [
+    "selectionSeq",
+    "error",
+    "visibleModal",
+    "isVariablePopoverVisible",
+    "copiedBrick",
+    "availableActivatedModComponentIds",
+    "isPendingAvailableActivatedModComponents",
+    "availableDraftModComponentIds",
+    "isPendingDraftModComponents",
+  ],
 };
 
 function validateActiveModComponentId(state: Draft<EditorState>) {

--- a/src/pageEditor/store/editor/editorSlice.ts
+++ b/src/pageEditor/store/editor/editorSlice.ts
@@ -26,12 +26,13 @@ import {
   type AddBrickLocation,
   type EditorRootState,
   type EditorState,
+  type EditorStateEphemeral,
   type ModalDefinition,
   ModalKey,
   type ModMetadataFormState,
 } from "@/pageEditor/store/editor/pageEditorTypes";
 import { uuidv4 } from "@/types/helpers";
-import { cloneDeep, compact, get, pull, uniq } from "lodash";
+import { cloneDeep, compact, get, omit, pull, uniq } from "lodash";
 import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
 import { type TreeExpandedState } from "@/components/jsonTree/JsonTree";
 import { getInvalidPath } from "@/utils/debugUtils";
@@ -92,6 +93,7 @@ import {
   initialEphemeralState,
   initialState,
 } from "@/store/editorInitialState";
+import { type Simplify } from "type-fest";
 
 /* eslint-disable security/detect-object-injection -- lots of immer-style code here dealing with Records */
 

--- a/src/pageEditor/store/editor/editorSliceHelpers.test.ts
+++ b/src/pageEditor/store/editor/editorSliceHelpers.test.ts
@@ -16,10 +16,7 @@
  */
 
 import { type EditorState } from "@/pageEditor/store/editor/pageEditorTypes";
-import {
-  editorSlice,
-  initialState,
-} from "@/pageEditor/store/editor/editorSlice";
+import { editorSlice } from "@/pageEditor/store/editor/editorSlice";
 import {
   FOUNDATION_NODE_ID,
   makeInitialBrickPipelineUIState,
@@ -51,6 +48,7 @@ import {
 } from "@/pageEditor/store/editor/editorSelectors";
 import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
+import { initialState } from "@/store/editorInitialState";
 
 describe("ensureBrickPipelineUIState", () => {
   test("does not affect existing ui state", () => {

--- a/src/pageEditor/store/editor/pageEditorTypes/editorStateEphemeral.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes/editorStateEphemeral.ts
@@ -22,15 +22,17 @@ import { type UUID } from "@/types/stringTypes";
 
 /**
  * Page Editor Slice state that should not be persisted using redux-persist.
+ * Prefer `null` to `undefined` to require the keys in initialEphemeralState
  *
- * @see editorStateMigrated
- * @see editorStateSynced
+ * @see EditorStateMigratedV<N>
+ * @see EditorStateSynced
+ * @see initialEphemeralState
  */
 export type EditorStateEphemeral = {
   /**
    * A clipboard-style-copy of a brick ready to paste into a brick pipeline
    */
-  copiedBrick?: BrickConfig;
+  copiedBrick: BrickConfig | null;
 
   /**
    * A serialized error that has occurred in the page editor

--- a/src/pageEditor/store/editor/pageEditorTypes/editorStateEphemeral.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes/editorStateEphemeral.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type BrickConfig } from "@/bricks/types";
+import { type SimpleErrorObject } from "@/errors/errorHelpers";
+import { type ModalDefinition } from "@/pageEditor/store/editor/pageEditorTypes";
+import { type UUID } from "@/types/stringTypes";
+
+/**
+ * Page Editor Slice state that should not be persisted using redux-persist.
+ *
+ * @see editorStateMigrated
+ * @see editorStateSynced
+ */
+export type EditorStateEphemeral = {
+  /**
+   * A clipboard-style-copy of a brick ready to paste into a brick pipeline
+   */
+  copiedBrick?: BrickConfig;
+
+  /**
+   * A serialized error that has occurred in the page editor
+   */
+  error: SimpleErrorObject | null;
+
+  /**
+   * A sequence number that changes whenever a new element is selected.
+   *
+   * Can use as a React component key to trigger a re-render
+   */
+  selectionSeq: number;
+
+  /**
+   * Which modal are we showing, if any?
+   */
+  visibleModal: ModalDefinition | null;
+
+  /**
+   * The available activated mod components for the current tab
+   */
+  availableActivatedModComponentIds: UUID[];
+
+  /**
+   * The availableActivatedModComponentIds are being calculated
+   */
+  isPendingAvailableActivatedModComponents: boolean;
+
+  /**
+   * The available draft mod components for the current tab
+   */
+  availableDraftModComponentIds: UUID[];
+
+  /**
+   * The availableDraftModComponentIds are being calculated
+   */
+  isPendingDraftModComponents: boolean;
+  /**
+   * Is the variable popover visible?
+   * @since 1.7.34
+   */
+  isVariablePopoverVisible: boolean;
+};

--- a/src/pageEditor/store/editor/pageEditorTypes/editorStateEphemeral.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes/editorStateEphemeral.ts
@@ -23,10 +23,12 @@ import { type UUID } from "@/types/stringTypes";
 /**
  * Page Editor Slice state that should not be persisted using redux-persist.
  * Prefer `null` to `undefined` to require the keys in initialEphemeralState
+ * All keys are necessary to properly set the blacklist in persistEditorConfig
  *
  * @see EditorStateMigratedV<N>
  * @see EditorStateSynced
  * @see initialEphemeralState
+ * @see persistEditorConfig
  */
 export type EditorStateEphemeral = {
   /**

--- a/src/pageEditor/store/editor/pageEditorTypes/editorStateMigrated.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes/editorStateMigrated.ts
@@ -15,28 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type AuthRootState } from "@/auth/authTypes";
-import { type LogRootState } from "@/components/logViewer/logViewerTypes";
-import { type ModComponentsRootState } from "@/store/modComponents/modComponentTypes";
-import { type SettingsRootState } from "@/store/settings/settingsTypes";
-import { type RuntimeRootState } from "@/pageEditor/store/runtime/runtimeSliceTypes";
-import { type StarterBrickType } from "@/types/starterBrickTypes";
-import { type UUID } from "@/types/stringTypes";
-import { type RegistryId, type VersionedMetadata } from "@/types/registryTypes";
-import { type BrickConfig, type PipelineFlavor } from "@/bricks/types";
-import { type BrickPipelineUIState } from "@/pageEditor/store/editor/uiStateTypes";
-import { type AnalysisRootState } from "@/analysis/analysisTypes";
-import { type ModComponentFormState } from "../../starterBricks/formStateTypes";
-import { type TabStateRootState } from "@/pageEditor/store/tabState/tabStateTypes";
-import { type ModDefinitionsRootState } from "@/modDefinitions/modDefinitionsTypes";
+import { type BrickConfig } from "@/bricks/types";
 import { type SimpleErrorObject } from "@/errors/errorHelpers";
-import { type SessionChangesRootState } from "@/store/sessionChanges/sessionChangesTypes";
-import { type SessionRootState } from "@/pageEditor/store/session/sessionSliceTypes";
-import {
-  type ModOptionsDefinition,
-  type ModVariablesDefinition,
-} from "@/types/modDefinitionTypes";
-import { type EmptyObject, type Except } from "type-fest";
 import {
   type BaseFormStateV1,
   type BaseFormStateV2,
@@ -47,71 +27,25 @@ import {
   type BaseFormStateV7,
   type BaseFormStateV8,
 } from "@/pageEditor/store/editor/baseFormStateTypes";
+import {
+  type ModMetadataFormState,
+  type ModalDefinition,
+} from "@/pageEditor/store/editor/pageEditorTypes";
+import { type BrickPipelineUIState } from "@/pageEditor/store/editor/uiStateTypes";
+import {
+  type ModOptionsDefinition,
+  type ModVariablesDefinition,
+} from "@/types/modDefinitionTypes";
+import { type RegistryId } from "@/types/registryTypes";
 import { type OptionsArgs } from "@/types/runtimeTypes";
-
-/**
- * Mod-level editor state passed to the runtime/analysis engine
- * @since 2.1.6
- */
-export type DraftModState = {
-  /**
-   * The current option args for the draft mod
-   */
-  optionsArgs: OptionsArgs;
-  /**
-   * The current mod variables definition for the draft mod.
-   */
-  variablesDefinition: ModVariablesDefinition;
-};
-
-export type AddBrickLocation = {
-  /**
-   * The object property path to the pipeline where a block will be added by the add block modal
-   */
-  path: string;
-
-  /**
-   * The flavor of pipeline where a block will be added by the add block modal
-   * @see PipelineFlavor
-   */
-  flavor: PipelineFlavor;
-
-  /**
-   * The pipeline index where a block will be added by the add block modal
-   */
-  index: number;
-};
-
-export enum ModalKey {
-  MOVE_COPY_TO_MOD,
-  SAVE_AS_NEW_MOD,
-  CREATE_MOD,
-  ADD_BRICK,
-  SAVE_DATA_INTEGRITY_ERROR,
-}
-
-export type ModalDefinition =
-  | { type: ModalKey.ADD_BRICK; data: { addBrickLocation: AddBrickLocation } }
-  | { type: ModalKey.SAVE_AS_NEW_MOD; data: EmptyObject }
-  | {
-      type: ModalKey.CREATE_MOD;
-      data: { keepLocalCopy: boolean } & (
-        | { sourceModComponentId: UUID }
-        | { sourceModId: RegistryId }
-      );
-    }
-  | { type: ModalKey.MOVE_COPY_TO_MOD; data: { keepLocalCopy: boolean } }
-  | { type: ModalKey.SAVE_DATA_INTEGRITY_ERROR; data: EmptyObject };
-
-export type ModMetadataFormState = Pick<
-  VersionedMetadata,
-  "id" | "name" | "version" | "description"
->;
+import { type StarterBrickType } from "@/types/starterBrickTypes";
+import { type UUID } from "@/types/stringTypes";
+import { type Except } from "type-fest";
 
 /**
  * @deprecated - Do not use versioned state types directly
  */
-export type EditorStateV1 = {
+export type EditorStateMigratedV1 = {
   /**
    * A sequence number that changes whenever a new element is selected.
    *
@@ -227,8 +161,8 @@ export type EditorStateV1 = {
 /**
  * @deprecated - Do not use versioned state types directly, exported for testing
  */
-export type EditorStateV2 = Except<
-  EditorStateV1,
+export type EditorStateMigratedV2 = Except<
+  EditorStateMigratedV1,
   "elements" | "deletedElementsByRecipeId"
 > & {
   elements: BaseFormStateV2[];
@@ -238,8 +172,8 @@ export type EditorStateV2 = Except<
 /**
  * @deprecated - Do not use versioned state types directly, exported for testing
  */
-export type EditorStateV3 = Except<
-  EditorStateV2,
+export type EditorStateMigratedV3 = Except<
+  EditorStateMigratedV2,
   | "activeElementId"
   | "activeRecipeId"
   | "expandedRecipeId"
@@ -334,8 +268,8 @@ export type EditorStateV3 = Except<
 /**
  * @deprecated - Do not use versioned state types directly, exported for testing
  */
-export type EditorStateV4 = Except<
-  EditorStateV3,
+export type EditorStateMigratedV4 = Except<
+  EditorStateMigratedV3,
   "modComponentFormStates" | "deletedModComponentFormStatesByModId"
 > & {
   modComponentFormStates: BaseFormStateV3[];
@@ -345,8 +279,8 @@ export type EditorStateV4 = Except<
 /**
  * @deprecated - Do not use versioned state types directly, exported for testing
  */
-export type EditorStateV5 = Except<
-  EditorStateV4,
+export type EditorStateMigratedV5 = Except<
+  EditorStateMigratedV4,
   | "inserting"
   | "modComponentFormStates"
   | "deletedModComponentFormStatesByModId"
@@ -361,7 +295,10 @@ export type EditorStateV5 = Except<
  *
  * @deprecated - Do not use versioned state types directly, exported for testing
  */
-export type EditorStateV6 = Except<EditorStateV5, "insertingStarterBrickType">;
+export type EditorStateMigratedV6 = Except<
+  EditorStateMigratedV5,
+  "insertingStarterBrickType"
+>;
 
 /**
  * Version bump to account for changes to DataPanelTabKeys.
@@ -372,7 +309,7 @@ export type EditorStateV6 = Except<EditorStateV5, "insertingStarterBrickType">;
  * @see migrateEditorStateV6
  * @see DataPanelTabKey
  */
-export type EditorStateV7 = EditorStateV6;
+export type EditorStateMigratedV7 = EditorStateMigratedV6;
 
 /**
  * Version bump to account for adding variableDefinition property in BaseFormState
@@ -380,8 +317,8 @@ export type EditorStateV7 = EditorStateV6;
  * @deprecated - Do not use versioned state types directly, exported for testing
  * @see migrateEditorStateV7
  */
-export type EditorStateV8 = Except<
-  EditorStateV7,
+export type EditorStateMigratedV8 = Except<
+  EditorStateMigratedV7,
   "modComponentFormStates" | "deletedModComponentFormStatesByModId"
 > & {
   modComponentFormStates: BaseFormStateV5[];
@@ -394,8 +331,8 @@ export type EditorStateV8 = Except<
  * @deprecated - Do not use versioned state types directly, exported for testing
  * @see migrateEditorStateV8
  */
-export type EditorStateV9 = Except<
-  EditorStateV8,
+export type EditorStateMigratedV9 = Except<
+  EditorStateMigratedV8,
   "modComponentFormStates" | "deletedModComponentFormStatesByModId"
 > & {
   modComponentFormStates: BaseFormStateV6[];
@@ -410,8 +347,8 @@ export type EditorStateV9 = Except<
  * @deprecated - Do not use versioned state types directly, exported for testing
  * @since 2.1.6
  */
-export type EditorStateV10 = Except<
-  EditorStateV9,
+export type EditorStateMigratedV10 = Except<
+  EditorStateMigratedV9,
   | "modComponentFormStates"
   | "deletedModComponentFormStatesByModId"
   | "dirtyModOptionsById"
@@ -428,8 +365,8 @@ export type EditorStateV10 = Except<
  * @deprecated - Do not use versioned state types directly, exported for testing
  * @since 2.1.7
  */
-export type EditorStateV11 = Except<
-  EditorStateV10,
+export type EditorStateMigratedV11 = Except<
+  EditorStateMigratedV10,
   | "modComponentFormStates"
   | "deletedModComponentFormStatesByModId"
   | "dirtyModOptionsDefinitionsById"
@@ -440,29 +377,29 @@ export type EditorStateV11 = Except<
   dirtyModVariablesDefinitionById: Record<RegistryId, ModVariablesDefinition>;
 };
 
-export type EditorState = Except<
-  // On migration, re-point this type to the most recent EditorStateV<N> type name
-  EditorStateV11,
-  // Swap out any properties with versioned types for type references to the latest version.
-  // NOTE: overriding these properties is not changing the type shape/structure. It's just cleaning up the type
-  // name/reference which makes types easier to work with for testing migrations.
-  "modComponentFormStates"
-> & {
-  modComponentFormStates: ModComponentFormState[];
-};
-
-export type EditorRootState = {
-  editor: EditorState;
-};
-
-export type RootState = AuthRootState &
-  LogRootState &
-  ModComponentsRootState &
-  AnalysisRootState &
-  EditorRootState &
-  ModDefinitionsRootState &
-  TabStateRootState &
-  RuntimeRootState &
-  SettingsRootState &
-  SessionRootState &
-  SessionChangesRootState;
+/**
+ * Version bump to split state types that do not need to be migrated from the other types
+ *
+ * @see editorStateSynced
+ * @see editorStateEphemeral
+ *
+ * @deprecated - Do not use versioned state types directly, exported for testing
+ * @since 2.1.8
+ */
+export type EditorStateMigratedV12 = Except<
+  EditorStateMigratedV11,
+  | "error"
+  | "selectionSeq"
+  | "visibleModal"
+  | "availableActivatedModComponentIds"
+  | "isPendingAvailableActivatedModComponents"
+  | "availableDraftModComponentIds"
+  | "isPendingDraftModComponents"
+  | "isVariablePopoverVisible"
+  | "activeModComponentId"
+  | "activeModId"
+  | "expandedModId"
+  | "brickPipelineUIStateById"
+  | "isDataPanelExpanded"
+  | "isModListExpanded"
+>;

--- a/src/pageEditor/store/editor/pageEditorTypes/editorStateMigrated.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes/editorStateMigrated.ts
@@ -28,8 +28,6 @@ import {
   type BaseFormStateV8,
 } from "@/pageEditor/store/editor/baseFormStateTypes";
 import {
-  type EditorStateEphemeral,
-  type EditorStateSynced,
   type ModMetadataFormState,
   type ModalDefinition,
 } from "@/pageEditor/store/editor/pageEditorTypes";
@@ -382,13 +380,20 @@ export type EditorStateMigratedV11 = Except<
 /**
  * Version bump to split state types that do not need to be migrated from the other types
  *
- * @see editorStateSynced
- * @see editorStateEphemeral
+ * @see EditorStateSynced
+ * @see EditorStateEphemeral
  *
  * @deprecated - Do not use versioned state types directly, exported for testing
  * @since 2.1.8
  */
-export type EditorStateMigratedV12 = Except<
+export type EditorStateMigratedV12 = Pick<
   EditorStateMigratedV11,
-  keyof EditorStateSynced | keyof EditorStateEphemeral
+  | "dirty"
+  | "dirtyModVariablesDefinitionById"
+  | "isDimensionsWarningDismissed"
+  | "dirtyModMetadataById"
+  | "dirtyModOptionsArgsById"
+  | "modComponentFormStates"
+  | "deletedModComponentFormStateIdsByModId"
+  | "dirtyModOptionsDefinitionById"
 >;

--- a/src/pageEditor/store/editor/pageEditorTypes/editorStateMigrated.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes/editorStateMigrated.ts
@@ -28,6 +28,8 @@ import {
   type BaseFormStateV8,
 } from "@/pageEditor/store/editor/baseFormStateTypes";
 import {
+  type EditorStateEphemeral,
+  type EditorStateSynced,
   type ModMetadataFormState,
   type ModalDefinition,
 } from "@/pageEditor/store/editor/pageEditorTypes";
@@ -388,18 +390,5 @@ export type EditorStateMigratedV11 = Except<
  */
 export type EditorStateMigratedV12 = Except<
   EditorStateMigratedV11,
-  | "error"
-  | "selectionSeq"
-  | "visibleModal"
-  | "availableActivatedModComponentIds"
-  | "isPendingAvailableActivatedModComponents"
-  | "availableDraftModComponentIds"
-  | "isPendingDraftModComponents"
-  | "isVariablePopoverVisible"
-  | "activeModComponentId"
-  | "activeModId"
-  | "expandedModId"
-  | "brickPipelineUIStateById"
-  | "isDataPanelExpanded"
-  | "isModListExpanded"
+  keyof EditorStateSynced | keyof EditorStateEphemeral
 >;

--- a/src/pageEditor/store/editor/pageEditorTypes/editorStateSynced.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes/editorStateSynced.ts
@@ -25,6 +25,8 @@ import { type UUID } from "@/types/stringTypes";
  *
  * Changing the keys in the future does not require a migration.
  * Prefer `null` to `undefined` to require the keys in initialSyncedState
+ * The initialSyncedState is used to reset the synced state during
+ * EditorStateMigratedV<N> migrations
  *
  * @see EditorStateEphemeral
  * @see EditorStateMigratedV<N>

--- a/src/pageEditor/store/editor/pageEditorTypes/editorStateSynced.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes/editorStateSynced.ts
@@ -24,9 +24,11 @@ import { type UUID } from "@/types/stringTypes";
  * should be reset to initial state during a redux-persist migration.
  *
  * Changing the keys in the future does not require a migration.
+ * Prefer `null` to `undefined` to require the keys in initialSyncedState
  *
- * @see editorStateEphemeral
- * @see editorStateMigrated
+ * @see EditorStateEphemeral
+ * @see EditorStateMigratedV<N>
+ * @see initialSyncedState
  */
 export type EditorStateSynced = {
   /**
@@ -67,5 +69,5 @@ export type EditorStateSynced = {
   /**
    * Is mod listing panel expanded or collapsed
    */
-  isModListExpanded: boolean;
+  isModListingPanelExpanded: boolean;
 };

--- a/src/pageEditor/store/editor/pageEditorTypes/editorStateSynced.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes/editorStateSynced.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type BrickPipelineUIState } from "@/pageEditor/store/editor/uiStateTypes";
+import { type RegistryId } from "@/types/registryTypes";
+import { type UUID } from "@/types/stringTypes";
+
+/**
+ * Page Editor Slice state that is persisted using redux-persist, but
+ * should be reset to initial state during a redux-persist migration.
+ *
+ * Changing the keys in the future does not require a migration.
+ *
+ * @see editorStateEphemeral
+ * @see editorStateMigrated
+ */
+export type EditorStateSynced = {
+  /**
+   * The uuid of the active mod component, if a mod component is selected
+   *
+   * @see activeModId
+   * @see expandedModId
+   */
+  activeModComponentId: UUID | null;
+
+  /**
+   * The registry id of the active mod, if a mod is selected. Is null if a mod component is selected.
+   *
+   * @see expandedModId
+   * @see activeModComponentId
+   */
+  activeModId: RegistryId | null;
+
+  /**
+   * The registry id of the 'expanded' mod in the sidebar, if one is expanded. Is set if the mod is selected or a
+   * mod component within the mod component is selected.
+   *
+   * @see activeModId
+   * @see activeModComponentId
+   */
+  expandedModId: RegistryId | null;
+
+  /**
+   * The current UI state of each brick pipeline, indexed by mod component id
+   */
+  brickPipelineUIStateById: Record<UUID, BrickPipelineUIState>;
+
+  /**
+   * Is data panel expanded or collapsed
+   */
+  isDataPanelExpanded: boolean;
+
+  /**
+   * Is mod listing panel expanded or collapsed
+   */
+  isModListExpanded: boolean;
+};

--- a/src/pageEditor/store/editor/pageEditorTypes/index.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes/index.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type AuthRootState } from "@/auth/authTypes";
+import { type LogRootState } from "@/components/logViewer/logViewerTypes";
+import { type ModComponentsRootState } from "@/store/modComponents/modComponentTypes";
+import { type SettingsRootState } from "@/store/settings/settingsTypes";
+import { type RuntimeRootState } from "@/pageEditor/store/runtime/runtimeSliceTypes";
+import { type UUID } from "@/types/stringTypes";
+import { type RegistryId, type VersionedMetadata } from "@/types/registryTypes";
+import { type PipelineFlavor } from "@/bricks/types";
+import { type AnalysisRootState } from "@/analysis/analysisTypes";
+import { type TabStateRootState } from "@/pageEditor/store/tabState/tabStateTypes";
+import { type ModDefinitionsRootState } from "@/modDefinitions/modDefinitionsTypes";
+import { type SessionChangesRootState } from "@/store/sessionChanges/sessionChangesTypes";
+import { type SessionRootState } from "@/pageEditor/store/session/sessionSliceTypes";
+import { type ModVariablesDefinition } from "@/types/modDefinitionTypes";
+import { type EmptyObject, type Except } from "type-fest";
+import { type OptionsArgs } from "@/types/runtimeTypes";
+import { type EditorStateMigratedV12 } from "@/pageEditor/store/editor/pageEditorTypes/editorStateMigrated";
+import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
+import { type EditorStateSynced } from "@/pageEditor/store/editor/pageEditorTypes/editorStateSynced";
+import { type EditorStateEphemeral } from "@/pageEditor/store/editor/pageEditorTypes/editorStateEphemeral";
+
+/**
+ * Mod-level editor state passed to the runtime/analysis engine
+ * @since 2.1.6
+ */
+export type DraftModState = {
+  /**
+   * The current option args for the draft mod
+   */
+  optionsArgs: OptionsArgs;
+  /**
+   * The current mod variables definition for the draft mod.
+   */
+  variablesDefinition: ModVariablesDefinition;
+};
+
+export type AddBrickLocation = {
+  /**
+   * The object property path to the pipeline where a block will be added by the add block modal
+   */
+  path: string;
+
+  /**
+   * The flavor of pipeline where a block will be added by the add block modal
+   * @see PipelineFlavor
+   */
+  flavor: PipelineFlavor;
+
+  /**
+   * The pipeline index where a block will be added by the add block modal
+   */
+  index: number;
+};
+
+export enum ModalKey {
+  MOVE_COPY_TO_MOD,
+  SAVE_AS_NEW_MOD,
+  CREATE_MOD,
+  ADD_BRICK,
+  SAVE_DATA_INTEGRITY_ERROR,
+}
+
+export type ModalDefinition =
+  | { type: ModalKey.ADD_BRICK; data: { addBrickLocation: AddBrickLocation } }
+  | { type: ModalKey.SAVE_AS_NEW_MOD; data: EmptyObject }
+  | {
+      type: ModalKey.CREATE_MOD;
+      data: { keepLocalCopy: boolean } & (
+        | { sourceModComponentId: UUID }
+        | { sourceModId: RegistryId }
+      );
+    }
+  | { type: ModalKey.MOVE_COPY_TO_MOD; data: { keepLocalCopy: boolean } }
+  | { type: ModalKey.SAVE_DATA_INTEGRITY_ERROR; data: EmptyObject };
+
+export type ModMetadataFormState = Pick<
+  VersionedMetadata,
+  "id" | "name" | "version" | "description"
+>;
+
+export type EditorState = Except<
+  // On migration, re-point this type to the most recent EditorStateV<N> type name
+  EditorStateMigratedV12,
+  // Swap out any properties with versioned types for type references to the latest version.
+  // NOTE: overriding these properties is not changing the type shape/structure. It's just cleaning up the type
+  // name/reference which makes types easier to work with for testing migrations.
+  "modComponentFormStates"
+> & {
+  modComponentFormStates: ModComponentFormState[];
+} & EditorStateSynced &
+  EditorStateEphemeral;
+
+export type EditorRootState = {
+  editor: EditorState;
+};
+
+export type RootState = AuthRootState &
+  LogRootState &
+  ModComponentsRootState &
+  AnalysisRootState &
+  EditorRootState &
+  ModDefinitionsRootState &
+  TabStateRootState &
+  RuntimeRootState &
+  SettingsRootState &
+  SessionRootState &
+  SessionChangesRootState;
+
+export * from "./editorStateEphemeral";
+export * from "./editorStateSynced";
+export * from "./editorStateMigrated";

--- a/src/pageEditor/tabs/editTab/useReportTraceError.test.tsx
+++ b/src/pageEditor/tabs/editTab/useReportTraceError.test.tsx
@@ -17,10 +17,8 @@
  */
 
 import React from "react";
-import {
-  editorSlice,
-  initialState as editorInitialState,
-} from "@/pageEditor/store/editor/editorSlice";
+import { editorSlice } from "@/pageEditor/store/editor/editorSlice";
+import { initialState as editorInitialState } from "@/store/editorInitialState";
 import runtimeSlice from "@/pageEditor/store/runtime/runtimeSlice";
 import sessionSlice from "@/pageEditor/store/session/sessionSlice";
 import { configureStore } from "@reduxjs/toolkit";

--- a/src/store/editorInitialState.ts
+++ b/src/store/editorInitialState.ts
@@ -42,7 +42,6 @@ export const initialSyncedState: EditorStateSynced = {
   isModListingPanelExpanded: true,
 } as const;
 
-/** @internal */
 export const initialState: EditorState = {
   ...initialEphemeralState,
   ...initialSyncedState,

--- a/src/store/editorInitialState.ts
+++ b/src/store/editorInitialState.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type EditorState } from "@/pageEditor/store/editor/pageEditorTypes";
+
+/** @internal */
+export const initialState: EditorState = {
+  selectionSeq: 0,
+  activeModComponentId: null,
+  activeModId: null,
+  expandedModId: null,
+  error: null,
+  modComponentFormStates: [],
+  dirty: {},
+  brickPipelineUIStateById: {},
+  dirtyModMetadataById: {},
+  dirtyModOptionsDefinitionById: {},
+  dirtyModVariablesDefinitionById: {},
+  dirtyModOptionsArgsById: {},
+  visibleModal: null,
+  deletedModComponentFormStateIdsByModId: {},
+  availableActivatedModComponentIds: [],
+  isPendingAvailableActivatedModComponents: false,
+  availableDraftModComponentIds: [],
+  isPendingDraftModComponents: false,
+  isModListExpanded: true,
+  isDataPanelExpanded: true,
+  isDimensionsWarningDismissed: false,
+  isVariablePopoverVisible: false,
+};

--- a/src/store/editorInitialState.ts
+++ b/src/store/editorInitialState.ts
@@ -15,30 +15,42 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type EditorState } from "@/pageEditor/store/editor/pageEditorTypes";
+import {
+  type EditorStateEphemeral,
+  type EditorState,
+  type EditorStateSynced,
+} from "@/pageEditor/store/editor/pageEditorTypes";
 
-/** @internal */
-export const initialState: EditorState = {
-  selectionSeq: 0,
-  activeModComponentId: null,
-  activeModId: null,
-  expandedModId: null,
+const initialEphemeralState: EditorStateEphemeral = {
   error: null,
-  modComponentFormStates: [],
-  dirty: {},
-  brickPipelineUIStateById: {},
-  dirtyModMetadataById: {},
-  dirtyModOptionsDefinitionById: {},
-  dirtyModVariablesDefinitionById: {},
-  dirtyModOptionsArgsById: {},
+  selectionSeq: 0,
   visibleModal: null,
-  deletedModComponentFormStateIdsByModId: {},
   availableActivatedModComponentIds: [],
   isPendingAvailableActivatedModComponents: false,
   availableDraftModComponentIds: [],
   isPendingDraftModComponents: false,
-  isModListExpanded: true,
-  isDataPanelExpanded: true,
-  isDimensionsWarningDismissed: false,
   isVariablePopoverVisible: false,
+};
+
+export const initialSyncedState: EditorStateSynced = {
+  activeModComponentId: null,
+  activeModId: null,
+  expandedModId: null,
+  brickPipelineUIStateById: {},
+  isDataPanelExpanded: true,
+  isModListExpanded: true,
+};
+
+/** @internal */
+export const initialState: EditorState = {
+  ...initialEphemeralState,
+  ...initialSyncedState,
+  modComponentFormStates: [],
+  dirty: {},
+  dirtyModMetadataById: {},
+  dirtyModOptionsDefinitionById: {},
+  dirtyModVariablesDefinitionById: {},
+  dirtyModOptionsArgsById: {},
+  deletedModComponentFormStateIdsByModId: {},
+  isDimensionsWarningDismissed: false,
 };

--- a/src/store/editorInitialState.ts
+++ b/src/store/editorInitialState.ts
@@ -21,7 +21,8 @@ import {
   type EditorStateSynced,
 } from "@/pageEditor/store/editor/pageEditorTypes";
 
-const initialEphemeralState: EditorStateEphemeral = {
+export const initialEphemeralState: EditorStateEphemeral = {
+  copiedBrick: null,
   error: null,
   selectionSeq: 0,
   visibleModal: null,
@@ -30,7 +31,7 @@ const initialEphemeralState: EditorStateEphemeral = {
   availableDraftModComponentIds: [],
   isPendingDraftModComponents: false,
   isVariablePopoverVisible: false,
-};
+} as const;
 
 export const initialSyncedState: EditorStateSynced = {
   activeModComponentId: null,
@@ -38,8 +39,8 @@ export const initialSyncedState: EditorStateSynced = {
   expandedModId: null,
   brickPipelineUIStateById: {},
   isDataPanelExpanded: true,
-  isModListExpanded: true,
-};
+  isModListingPanelExpanded: true,
+} as const;
 
 /** @internal */
 export const initialState: EditorState = {
@@ -53,4 +54,4 @@ export const initialState: EditorState = {
   dirtyModOptionsArgsById: {},
   deletedModComponentFormStateIdsByModId: {},
   isDimensionsWarningDismissed: false,
-};
+} as const;

--- a/src/store/editorInitialState.ts
+++ b/src/store/editorInitialState.ts
@@ -21,7 +21,11 @@ import {
   type EditorStateSynced,
 } from "@/pageEditor/store/editor/pageEditorTypes";
 
-export const initialEphemeralState: EditorStateEphemeral = {
+/**
+ * We use `Required` to protect against accidentally making a key optional in EditorStateEphemeral
+ * All keys are necessary to properly set the blacklist in persistEditorConfig
+ */
+export const initialEphemeralState: Required<EditorStateEphemeral> = {
   copiedBrick: null,
   error: null,
   selectionSeq: 0,
@@ -33,7 +37,12 @@ export const initialEphemeralState: EditorStateEphemeral = {
   isVariablePopoverVisible: false,
 } as const;
 
-export const initialSyncedState: EditorStateSynced = {
+/**
+ * We use `Required` to protect against accidentally making a key optional in EditorStateSynced
+ * The initialSyncedState is used to reset the synced state during EditorStateMigratedV<N>
+ * migrations, so every key must have an initial value
+ */
+export const initialSyncedState: Required<EditorStateSynced> = {
   activeModComponentId: null,
   activeModId: null,
   expandedModId: null,

--- a/src/store/editorMigrations.test.ts
+++ b/src/store/editorMigrations.test.ts
@@ -17,17 +17,17 @@
 
 import {
   type DraftModState,
-  type EditorStateV1,
-  type EditorStateV10,
-  type EditorStateV11,
-  type EditorStateV2,
-  type EditorStateV3,
-  type EditorStateV4,
-  type EditorStateV5,
-  type EditorStateV6,
-  type EditorStateV7,
-  type EditorStateV8,
-  type EditorStateV9,
+  type EditorStateMigratedV1,
+  type EditorStateMigratedV10,
+  type EditorStateMigratedV11,
+  type EditorStateMigratedV2,
+  type EditorStateMigratedV3,
+  type EditorStateMigratedV4,
+  type EditorStateMigratedV5,
+  type EditorStateMigratedV6,
+  type EditorStateMigratedV7,
+  type EditorStateMigratedV8,
+  type EditorStateMigratedV9,
 } from "@/pageEditor/store/editor/pageEditorTypes";
 import { cloneDeep, mapValues, omit } from "lodash";
 import {
@@ -83,7 +83,7 @@ import {
 import { emptyModVariablesDefinitionFactory } from "@/utils/modUtils";
 import { propertiesToSchema } from "@/utils/schemaUtils";
 
-const initialStateV1: EditorStateV1 & PersistedState = {
+const initialStateV1: EditorStateMigratedV1 & PersistedState = {
   selectionSeq: 0,
   activeElementId: null,
   activeRecipeId: null,
@@ -111,7 +111,7 @@ const initialStateV1: EditorStateV1 & PersistedState = {
   },
 };
 
-const initialStateV2: EditorStateV2 & PersistedState = {
+const initialStateV2: EditorStateMigratedV2 & PersistedState = {
   ...omit(initialStateV1, "elements", "deletedElementsByRecipeId"),
   elements: [],
   deletedElementsByRecipeId: {},
@@ -122,7 +122,7 @@ const initialStateV2: EditorStateV2 & PersistedState = {
   },
 };
 
-const initialStateV3: EditorStateV3 & PersistedState = {
+const initialStateV3: EditorStateMigratedV3 & PersistedState = {
   selectionSeq: 0,
   activeModComponentId: null,
   activeModId: null,
@@ -152,7 +152,7 @@ const initialStateV3: EditorStateV3 & PersistedState = {
   },
 };
 
-const initialStateV4: EditorStateV4 & PersistedState = {
+const initialStateV4: EditorStateMigratedV4 & PersistedState = {
   selectionSeq: 0,
   activeModComponentId: null,
   activeModId: null,
@@ -182,7 +182,7 @@ const initialStateV4: EditorStateV4 & PersistedState = {
   },
 };
 
-const initialStateV5: EditorStateV5 & PersistedState = {
+const initialStateV5: EditorStateMigratedV5 & PersistedState = {
   selectionSeq: 0,
   activeModComponentId: null,
   activeModId: null,
@@ -212,7 +212,7 @@ const initialStateV5: EditorStateV5 & PersistedState = {
   },
 };
 
-const initialStateV6: EditorStateV6 & PersistedState = {
+const initialStateV6: EditorStateMigratedV6 & PersistedState = {
   selectionSeq: 0,
   activeModComponentId: null,
   activeModId: null,
@@ -241,10 +241,10 @@ const initialStateV6: EditorStateV6 & PersistedState = {
   },
 };
 
-const initialStateV7: EditorStateV7 & PersistedState =
+const initialStateV7: EditorStateMigratedV7 & PersistedState =
   cloneDeep(initialStateV6);
 
-const initialStateV8: EditorStateV8 & PersistedState = {
+const initialStateV8: EditorStateMigratedV8 & PersistedState = {
   selectionSeq: 0,
   activeModComponentId: null,
   activeModId: null,
@@ -273,19 +273,19 @@ const initialStateV8: EditorStateV8 & PersistedState = {
   },
 };
 
-const initialStateV9: EditorStateV9 & PersistedState = {
+const initialStateV9: EditorStateMigratedV9 & PersistedState = {
   ...cloneDeep(initialStateV8),
   modComponentFormStates: [],
   deletedModComponentFormStatesByModId: {},
 };
 
-const initialStateV10: EditorStateV10 & PersistedState = {
+const initialStateV10: EditorStateMigratedV10 & PersistedState = {
   ...omit(cloneDeep(initialStateV9), "dirtyModOptionsById"),
   dirtyModOptionsDefinitionsById: {},
   dirtyModOptionsArgsById: {},
 };
 
-const initialStateV11: EditorStateV11 & PersistedState = {
+const initialStateV11: EditorStateMigratedV11 & PersistedState = {
   ...omit(
     cloneDeep(initialStateV10),
     "dirtyModOptionsDefinitionsById",
@@ -326,8 +326,8 @@ function unmigrateDeletedElements(
 }
 
 function unmigrateEditorStateV2toV1(
-  state: EditorStateV2 & PersistedState,
-): EditorStateV1 & PersistedState {
+  state: EditorStateMigratedV2 & PersistedState,
+): EditorStateMigratedV1 & PersistedState {
   return {
     ...omit(state, "elements", "deletedElementsByRecipeId"),
     elements: state.elements.map((element) =>
@@ -357,8 +357,8 @@ function unmigrateFormStateV3toV2(formState: BaseFormStateV3): BaseFormStateV2 {
 }
 
 function unmigrateEditorStateV3toV2(
-  state: EditorStateV3 & PersistedState,
-): EditorStateV2 & PersistedState {
+  state: EditorStateMigratedV3 & PersistedState,
+): EditorStateMigratedV2 & PersistedState {
   return {
     ...omit(
       state,
@@ -394,8 +394,8 @@ function unmigrateEditorStateV3toV2(
 }
 
 function unmigrateEditorStateV4toV3(
-  state: EditorStateV4 & PersistedState,
-): EditorStateV3 & PersistedState {
+  state: EditorStateMigratedV4 & PersistedState,
+): EditorStateMigratedV3 & PersistedState {
   return {
     ...omit(
       state,
@@ -454,8 +454,8 @@ function unmigrateFormStateV8toV7(
 }
 
 function unmigrateEditorStateV5toV4(
-  state: EditorStateV5 & PersistedState,
-): EditorStateV4 & PersistedState {
+  state: EditorStateMigratedV5 & PersistedState,
+): EditorStateMigratedV4 & PersistedState {
   return {
     ...omit(
       state,
@@ -476,8 +476,8 @@ function unmigrateEditorStateV5toV4(
 }
 
 function unmigrateEditorStateV6toV5(
-  state: EditorStateV6 & PersistedState,
-): EditorStateV5 & PersistedState {
+  state: EditorStateMigratedV6 & PersistedState,
+): EditorStateMigratedV5 & PersistedState {
   return {
     ...state,
     insertingStarterBrickType: null,
@@ -485,8 +485,8 @@ function unmigrateEditorStateV6toV5(
 }
 
 function unmigrateEditorStateV8toV7(
-  state: EditorStateV8 & PersistedState,
-): EditorStateV7 & PersistedState {
+  state: EditorStateMigratedV8 & PersistedState,
+): EditorStateMigratedV7 & PersistedState {
   return {
     ...omit(
       state,
@@ -505,8 +505,8 @@ function unmigrateEditorStateV8toV7(
 }
 
 function unmigrateEditorStateV9toV8(
-  state: EditorStateV9 & PersistedState,
-): EditorStateV8 & PersistedState {
+  state: EditorStateMigratedV9 & PersistedState,
+): EditorStateMigratedV8 & PersistedState {
   return {
     ...state,
     modComponentFormStates: state.modComponentFormStates.map((formState) =>
@@ -516,8 +516,8 @@ function unmigrateEditorStateV9toV8(
 }
 
 function unmigrateEditorStateV10toV9(
-  state: EditorStateV10 & PersistedState,
-): EditorStateV9 & PersistedState {
+  state: EditorStateMigratedV10 & PersistedState,
+): EditorStateMigratedV9 & PersistedState {
   const unmigrateFormState = (formState: BaseFormStateV7) =>
     unmigrateFormStateV7toV6(formState, {
       optionsArgs:
@@ -542,8 +542,8 @@ function unmigrateEditorStateV10toV9(
 }
 
 function unmigrateEditorStateV11toV10(
-  state: EditorStateV11 & PersistedState,
-): EditorStateV10 & PersistedState {
+  state: EditorStateMigratedV11 & PersistedState,
+): EditorStateMigratedV10 & PersistedState {
   const unmigrateFormState = (formState: BaseFormStateV8) =>
     unmigrateFormStateV8toV7(formState, {
       variablesDefinition:
@@ -692,7 +692,7 @@ describe("editor state migrations", () => {
 
     it("migrates the form states", () => {
       const formStateV2 = formStateFactoryV2();
-      const expectedEditorStateV3: EditorStateV3 & PersistedState = {
+      const expectedEditorStateV3: EditorStateMigratedV3 & PersistedState = {
         ...initialStateV3,
         modComponentFormStates: [formStateV2],
       };
@@ -712,7 +712,7 @@ describe("editor state migrations", () => {
 
     it("migrates the form states", () => {
       const formStateV3 = formStateFactoryV3();
-      const expectedEditorStateV4: EditorStateV4 & PersistedState = {
+      const expectedEditorStateV4: EditorStateMigratedV4 & PersistedState = {
         ...initialStateV4,
         modComponentFormStates: [formStateV3],
       };
@@ -731,7 +731,7 @@ describe("editor state migrations", () => {
     });
 
     it("migrates the inserting field and the form states", () => {
-      const expectedEditorStateV5: EditorStateV5 & PersistedState = {
+      const expectedEditorStateV5: EditorStateMigratedV5 & PersistedState = {
         ...initialStateV5,
         insertingStarterBrickType: StarterBrickTypes.BUTTON,
         modComponentFormStates: [formStateFactoryV4(), formStateFactoryV4()],
@@ -752,7 +752,8 @@ describe("editor state migrations", () => {
 
     it("migrates remove insertingStarterBrickType property", () => {
       const { insertingStarterBrickType, ...rest } = initialStateV5;
-      const expectedEditorStateV6: EditorStateV6 & PersistedState = rest;
+      const expectedEditorStateV6: EditorStateMigratedV6 & PersistedState =
+        rest;
       const unmigrated = unmigrateEditorStateV6toV5(expectedEditorStateV6);
       expect(migrateEditorStateV5(unmigrated)).toStrictEqual(
         expectedEditorStateV6,
@@ -805,7 +806,7 @@ describe("editor state migrations", () => {
     });
 
     it("add variable definitions section", () => {
-      const expectedEditorStateV8: EditorStateV8 & PersistedState = {
+      const expectedEditorStateV8: EditorStateMigratedV8 & PersistedState = {
         ...initialStateV8,
         modComponentFormStates: [formStateFactoryV5()],
       };
@@ -824,7 +825,7 @@ describe("editor state migrations", () => {
     });
 
     it("adds missing modMetadata", () => {
-      const expectedEditorStateV9: EditorStateV9 & PersistedState = {
+      const expectedEditorStateV9: EditorStateMigratedV9 & PersistedState = {
         ...initialStateV9,
         modComponentFormStates: [formStateFactoryV6()],
       };
@@ -856,7 +857,7 @@ describe("editor state migrations", () => {
       const optionsArgs = { foo: 42 };
       const formState = formStateFactoryV7();
 
-      const expectedEditorStateV10: EditorStateV10 & PersistedState = {
+      const expectedEditorStateV10: EditorStateMigratedV10 & PersistedState = {
         ...initialStateV10,
         modComponentFormStates: [formState],
         dirty: { [formState.uuid]: true },
@@ -875,7 +876,7 @@ describe("editor state migrations", () => {
     it("migrates clean options args", () => {
       const formState = formStateFactoryV7();
 
-      const expectedEditorStateV10: EditorStateV10 & PersistedState = {
+      const expectedEditorStateV10: EditorStateMigratedV10 & PersistedState = {
         ...initialStateV10,
         modComponentFormStates: [formState],
         dirty: {},
@@ -903,7 +904,7 @@ describe("editor state migrations", () => {
       };
       const formState = formStateFactoryV8();
 
-      const expectedEditorStateV11: EditorStateV11 & PersistedState = {
+      const expectedEditorStateV11: EditorStateMigratedV11 & PersistedState = {
         ...initialStateV11,
         modComponentFormStates: [formState],
         dirty: { [formState.uuid]: true },

--- a/src/store/editorMigrations.test.ts
+++ b/src/store/editorMigrations.test.ts
@@ -64,6 +64,7 @@ import {
 } from "@/pageEditor/store/editor/baseFormStateTypes";
 import { type PersistedState } from "redux-persist";
 import {
+  getInitialEditorStateSynced,
   migrateEditorStateV1,
   migrateEditorStateV10,
   migrateEditorStateV11,
@@ -301,21 +302,24 @@ const initialStateV11: EditorStateMigratedV11 & PersistedState = {
   deletedModComponentFormStateIdsByModId: {},
 };
 
-const initialStateV12: EditorStateMigratedV12 & PersistedState = pick<
-  EditorStateMigratedV11 & PersistedState,
-  keyof EditorStateMigratedV11 | "_persist"
->(
-  cloneDeep(initialStateV11),
-  "dirty",
-  "isDimensionsWarningDismissed",
-  "dirtyModMetadataById",
-  "dirtyModOptionsArgsById",
-  "modComponentFormStates",
-  "deletedModComponentFormStateIdsByModId",
-  "dirtyModOptionsDefinitionById",
-  "dirtyModVariablesDefinitionById",
-  "_persist",
-);
+const initialStateV12: EditorStateMigratedV12 & PersistedState = {
+  ...pick<
+    EditorStateMigratedV11 & PersistedState,
+    keyof EditorStateMigratedV11 | "_persist"
+  >(
+    cloneDeep(initialStateV11),
+    "dirty",
+    "isDimensionsWarningDismissed",
+    "dirtyModMetadataById",
+    "dirtyModOptionsArgsById",
+    "modComponentFormStates",
+    "deletedModComponentFormStateIdsByModId",
+    "dirtyModOptionsDefinitionById",
+    "dirtyModVariablesDefinitionById",
+    "_persist",
+  ),
+  ...getInitialEditorStateSynced(),
+};
 
 function unmigrateServices(
   integrationDependencies: IntegrationDependencyV2[] = [],

--- a/src/store/editorMigrations.test.ts
+++ b/src/store/editorMigrations.test.ts
@@ -64,7 +64,6 @@ import {
 } from "@/pageEditor/store/editor/baseFormStateTypes";
 import { type PersistedState } from "redux-persist";
 import {
-  getInitialEditorStateSynced,
   migrateEditorStateV1,
   migrateEditorStateV10,
   migrateEditorStateV11,
@@ -88,6 +87,7 @@ import {
   emptyModVariablesDefinitionFactory,
 } from "@/utils/modUtils";
 import { propertiesToSchema } from "@/utils/schemaUtils";
+import { initialSyncedState } from "@/store/editorInitialState";
 
 const initialStateV1: EditorStateMigratedV1 & PersistedState = {
   selectionSeq: 0,
@@ -318,7 +318,7 @@ const initialStateV12: EditorStateMigratedV12 & PersistedState = {
     "dirtyModVariablesDefinitionById",
     "_persist",
   ),
-  ...getInitialEditorStateSynced(),
+  ...initialSyncedState,
 };
 
 function unmigrateServices(

--- a/src/store/editorMigrations.ts
+++ b/src/store/editorMigrations.ts
@@ -16,7 +16,7 @@
  */
 
 import { type MigrationManifest, type PersistedState } from "redux-persist";
-import { cloneDeep, mapValues, omit, pick } from "lodash";
+import { mapValues, omit } from "lodash";
 import {
   type BaseFormStateV1,
   type BaseFormStateV2,
@@ -56,7 +56,7 @@ import {
   emptyModVariablesDefinitionFactory,
 } from "@/utils/modUtils";
 import { type SetOptional } from "type-fest";
-import { initialState, initialSyncedState } from "@/store/editorInitialState";
+import { initialSyncedState } from "@/store/editorInitialState";
 
 export const migrations: MigrationManifest = {
   // Redux-persist defaults to version: -1; Initialize to positive-1-indexed

--- a/src/store/editorMigrations.ts
+++ b/src/store/editorMigrations.ts
@@ -385,10 +385,10 @@ export function migrateEditorStateV11(
     dirtyModVariablesDefinitionById,
     isDimensionsWarningDismissed,
     dirtyModMetadataById,
+    dirtyModOptionsDefinitionById,
     dirtyModOptionsArgsById,
     modComponentFormStates,
     deletedModComponentFormStateIdsByModId,
-    dirtyModOptionsDefinitionById,
     _persist,
   } = state;
 

--- a/src/store/editorMigrations.ts
+++ b/src/store/editorMigrations.ts
@@ -32,17 +32,18 @@ import {
   type IntegrationDependencyV2,
 } from "@/integrations/integrationTypes";
 import {
-  type EditorStateV1,
-  type EditorStateV10,
-  type EditorStateV11,
-  type EditorStateV2,
-  type EditorStateV3,
-  type EditorStateV4,
-  type EditorStateV5,
-  type EditorStateV6,
-  type EditorStateV7,
-  type EditorStateV8,
-  type EditorStateV9,
+  type EditorStateMigratedV12,
+  type EditorStateMigratedV1,
+  type EditorStateMigratedV10,
+  type EditorStateMigratedV11,
+  type EditorStateMigratedV2,
+  type EditorStateMigratedV3,
+  type EditorStateMigratedV4,
+  type EditorStateMigratedV5,
+  type EditorStateMigratedV6,
+  type EditorStateMigratedV7,
+  type EditorStateMigratedV8,
+  type EditorStateMigratedV9,
 } from "@/pageEditor/store/editor/pageEditorTypes";
 import { type Draft, produce } from "immer";
 import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
@@ -60,16 +61,28 @@ export const migrations: MigrationManifest = {
   // state version to match state type names
   0: (state) => state,
   1: (state) => state,
-  2: (state: EditorStateV1 & PersistedState) => migrateEditorStateV1(state),
-  3: (state: EditorStateV2 & PersistedState) => migrateEditorStateV2(state),
-  4: (state: EditorStateV3 & PersistedState) => migrateEditorStateV3(state),
-  5: (state: EditorStateV4 & PersistedState) => migrateEditorStateV4(state),
-  6: (state: EditorStateV5 & PersistedState) => migrateEditorStateV5(state),
-  7: (state: EditorStateV6 & PersistedState) => migrateEditorStateV6(state),
-  8: (state: EditorStateV7 & PersistedState) => migrateEditorStateV7(state),
-  9: (state: EditorStateV8 & PersistedState) => migrateEditorStateV8(state),
-  10: (state: EditorStateV9 & PersistedState) => migrateEditorStateV9(state),
-  11: (state: EditorStateV10 & PersistedState) => migrateEditorStateV10(state),
+  2: (state: EditorStateMigratedV1 & PersistedState) =>
+    migrateEditorStateV1(state),
+  3: (state: EditorStateMigratedV2 & PersistedState) =>
+    migrateEditorStateV2(state),
+  4: (state: EditorStateMigratedV3 & PersistedState) =>
+    migrateEditorStateV3(state),
+  5: (state: EditorStateMigratedV4 & PersistedState) =>
+    migrateEditorStateV4(state),
+  6: (state: EditorStateMigratedV5 & PersistedState) =>
+    migrateEditorStateV5(state),
+  7: (state: EditorStateMigratedV6 & PersistedState) =>
+    migrateEditorStateV6(state),
+  8: (state: EditorStateMigratedV7 & PersistedState) =>
+    migrateEditorStateV7(state),
+  9: (state: EditorStateMigratedV8 & PersistedState) =>
+    migrateEditorStateV8(state),
+  10: (state: EditorStateMigratedV9 & PersistedState) =>
+    migrateEditorStateV9(state),
+  11: (state: EditorStateMigratedV10 & PersistedState) =>
+    migrateEditorStateV10(state),
+  12: (state: EditorStateMigratedV11 & PersistedState) =>
+    migrateEditorStateV11(state),
 };
 
 export function migrateIntegrationDependenciesV1toV2(
@@ -99,8 +112,8 @@ function migrateFormStateV1(state: BaseFormStateV1): BaseFormStateV2 {
 
 /** @internal */
 export function migrateEditorStateV1(
-  state: EditorStateV1 & PersistedState,
-): EditorStateV2 & PersistedState {
+  state: EditorStateMigratedV1 & PersistedState,
+): EditorStateMigratedV2 & PersistedState {
   return {
     ...state,
     elements: state.elements.map((formState) => migrateFormStateV1(formState)),
@@ -128,7 +141,8 @@ export function migrateEditorStateV2({
   availableDynamicIds,
   isPendingDynamicExtensions,
   ...rest
-}: EditorStateV2 & PersistedState): EditorStateV3 & PersistedState {
+}: EditorStateMigratedV2 & PersistedState): EditorStateMigratedV3 &
+  PersistedState {
   return {
     ...rest,
     activeModComponentId: activeElementId,
@@ -169,7 +183,8 @@ export function migrateEditorStateV3({
   modComponentFormStates,
   deletedModComponentFormStatesByModId,
   ...rest
-}: EditorStateV3 & PersistedState): EditorStateV4 & PersistedState {
+}: EditorStateMigratedV3 & PersistedState): EditorStateMigratedV4 &
+  PersistedState {
   return {
     ...rest,
     modComponentFormStates: modComponentFormStates.map((element) =>
@@ -195,7 +210,8 @@ export function migrateEditorStateV4({
   modComponentFormStates,
   deletedModComponentFormStatesByModId,
   ...rest
-}: EditorStateV4 & PersistedState): EditorStateV5 & PersistedState {
+}: EditorStateMigratedV4 & PersistedState): EditorStateMigratedV5 &
+  PersistedState {
   return {
     ...rest,
     insertingStarterBrickType: inserting,
@@ -213,14 +229,15 @@ export function migrateEditorStateV4({
 export function migrateEditorStateV5({
   insertingStarterBrickType,
   ...rest
-}: EditorStateV5 & PersistedState): EditorStateV6 & PersistedState {
+}: EditorStateMigratedV5 & PersistedState): EditorStateMigratedV6 &
+  PersistedState {
   return rest;
 }
 
 /** @internal */
 export function migrateEditorStateV6(
-  state: EditorStateV6 & PersistedState,
-): EditorStateV7 & PersistedState {
+  state: EditorStateMigratedV6 & PersistedState,
+): EditorStateMigratedV7 & PersistedState {
   // Reset the Data Panel state using the current set of DataPanelTabKeys
   return produce(state, (draft) => {
     for (const uiState of Object.values(draft.brickPipelineUIStateById)) {
@@ -241,8 +258,8 @@ export function migrateEditorStateV6(
 
 /** @internal */
 export function migrateEditorStateV7(
-  state: EditorStateV7 & PersistedState,
-): EditorStateV8 & PersistedState {
+  state: EditorStateMigratedV7 & PersistedState,
+): EditorStateMigratedV8 & PersistedState {
   // Reset the Data Panel state using the current set of DataPanelTabKeys
   return produce(state, (draft) => {
     for (const formState of draft.modComponentFormStates) {
@@ -258,13 +275,13 @@ export function migrateEditorStateV7(
           emptyModVariablesDefinitionFactory();
       }
     }
-  }) as EditorStateV8 & PersistedState;
+  }) as EditorStateMigratedV8 & PersistedState;
 }
 
 /** @internal */
 export function migrateEditorStateV8(
-  state: EditorStateV8 & PersistedState,
-): EditorStateV9 & PersistedState {
+  state: EditorStateMigratedV8 & PersistedState,
+): EditorStateMigratedV9 & PersistedState {
   return produce(state, (draft) => {
     // Don't need to also loop over deletedModComponentFormStatesByModId, because there can't be any standalone
     // mod components in there. (Standalone mods when deleted are removed from the editor state entirely.)
@@ -274,19 +291,19 @@ export function migrateEditorStateV8(
           modName: formState.label,
         });
     }
-  }) as EditorStateV9 & PersistedState;
+  }) as EditorStateMigratedV9 & PersistedState;
 }
 
 /** @internal */
 export function migrateEditorStateV9(
-  state: EditorStateV9 & PersistedState,
-): EditorStateV10 & PersistedState {
+  state: EditorStateMigratedV9 & PersistedState,
+): EditorStateMigratedV10 & PersistedState {
   return produce(
-    state as unknown as EditorStateV10 & PersistedState,
+    state as unknown as EditorStateMigratedV10 & PersistedState,
     (draft) => {
       // Alias the old draft type for deleting old properties
       const oldDraft = draft as unknown as Draft<
-        SetOptional<EditorStateV9, "dirtyModOptionsById">
+        SetOptional<EditorStateMigratedV9, "dirtyModOptionsById">
       >;
 
       // Rename dirtyModOptionsById to dirtyModOptionsDefinitionById
@@ -313,15 +330,15 @@ export function migrateEditorStateV9(
 
 /** @internal */
 export function migrateEditorStateV10(
-  state: EditorStateV10 & PersistedState,
-): EditorStateV11 & PersistedState {
+  state: EditorStateMigratedV10 & PersistedState,
+): EditorStateMigratedV11 & PersistedState {
   return produce(
-    state as unknown as EditorStateV11 & PersistedState,
+    state as unknown as EditorStateMigratedV11 & PersistedState,
     (draft) => {
       // Alias the old draft type for deleting old properties
       const oldDraft = draft as unknown as Draft<
         SetOptional<
-          EditorStateV10,
+          EditorStateMigratedV10,
           | "dirtyModOptionsDefinitionsById"
           | "deletedModComponentFormStatesByModId"
         >
@@ -357,4 +374,33 @@ export function migrateEditorStateV10(
       }
     },
   );
+}
+
+/** @internal */
+export function migrateEditorStateV11(
+  state: EditorStateMigratedV11 & PersistedState,
+): EditorStateMigratedV12 & PersistedState {
+  const {
+    dirty,
+    dirtyModVariablesDefinitionById,
+    isDimensionsWarningDismissed,
+    dirtyModMetadataById,
+    dirtyModOptionsArgsById,
+    modComponentFormStates,
+    deletedModComponentFormStateIdsByModId,
+    dirtyModOptionsDefinitionById,
+    _persist,
+  } = state;
+
+  return {
+    dirty,
+    dirtyModVariablesDefinitionById,
+    isDimensionsWarningDismissed,
+    dirtyModMetadataById,
+    dirtyModOptionsArgsById,
+    modComponentFormStates,
+    deletedModComponentFormStateIdsByModId,
+    dirtyModOptionsDefinitionById,
+    _persist,
+  };
 }

--- a/src/store/editorMigrations.ts
+++ b/src/store/editorMigrations.ts
@@ -16,7 +16,7 @@
  */
 
 import { type MigrationManifest, type PersistedState } from "redux-persist";
-import { mapValues, omit } from "lodash";
+import { cloneDeep, mapValues, omit, pick } from "lodash";
 import {
   type BaseFormStateV1,
   type BaseFormStateV2,
@@ -44,6 +44,7 @@ import {
   type EditorStateMigratedV7,
   type EditorStateMigratedV8,
   type EditorStateMigratedV9,
+  type EditorStateSynced,
 } from "@/pageEditor/store/editor/pageEditorTypes";
 import { type Draft, produce } from "immer";
 import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
@@ -55,6 +56,7 @@ import {
   emptyModVariablesDefinitionFactory,
 } from "@/utils/modUtils";
 import { type SetOptional } from "type-fest";
+import { initialState } from "@/store/editorInitialState";
 
 export const migrations: MigrationManifest = {
   // Redux-persist defaults to version: -1; Initialize to positive-1-indexed
@@ -377,9 +379,22 @@ export function migrateEditorStateV10(
 }
 
 /** @internal */
+export function getInitialEditorStateSynced(): EditorStateSynced {
+  return pick(
+    cloneDeep(initialState),
+    "activeModComponentId",
+    "activeModId",
+    "expandedModId",
+    "brickPipelineUIStateById",
+    "isDataPanelExpanded",
+    "isModListExpanded",
+  );
+}
+
+/** @internal */
 export function migrateEditorStateV11(
   state: EditorStateMigratedV11 & PersistedState,
-): EditorStateMigratedV12 & PersistedState {
+): EditorStateMigratedV12 & EditorStateSynced & PersistedState {
   const {
     dirty,
     dirtyModVariablesDefinitionById,
@@ -393,6 +408,7 @@ export function migrateEditorStateV11(
   } = state;
 
   return {
+    ...getInitialEditorStateSynced(),
     dirty,
     dirtyModVariablesDefinitionById,
     isDimensionsWarningDismissed,

--- a/src/store/editorMigrations.ts
+++ b/src/store/editorMigrations.ts
@@ -56,7 +56,7 @@ import {
   emptyModVariablesDefinitionFactory,
 } from "@/utils/modUtils";
 import { type SetOptional } from "type-fest";
-import { initialState } from "@/store/editorInitialState";
+import { initialState, initialSyncedState } from "@/store/editorInitialState";
 
 export const migrations: MigrationManifest = {
   // Redux-persist defaults to version: -1; Initialize to positive-1-indexed
@@ -379,19 +379,6 @@ export function migrateEditorStateV10(
 }
 
 /** @internal */
-export function getInitialEditorStateSynced(): EditorStateSynced {
-  return pick(
-    cloneDeep(initialState),
-    "activeModComponentId",
-    "activeModId",
-    "expandedModId",
-    "brickPipelineUIStateById",
-    "isDataPanelExpanded",
-    "isModListExpanded",
-  );
-}
-
-/** @internal */
 export function migrateEditorStateV11(
   state: EditorStateMigratedV11 & PersistedState,
 ): EditorStateMigratedV12 & EditorStateSynced & PersistedState {
@@ -408,7 +395,7 @@ export function migrateEditorStateV11(
   } = state;
 
   return {
-    ...getInitialEditorStateSynced(),
+    ...initialSyncedState,
     dirty,
     dirtyModVariablesDefinitionById,
     isDimensionsWarningDismissed,


### PR DESCRIPTION
## What does this PR do?

- Part of Page Editor State low-hanging fruit 
    - See https://www.notion.so/pixiebrix/DevEx-Priorities-13543b21a253807283b4fae891dab992
- Splits Editor State into a union of three types based on usage (Migrated, Synced, Ephemeral)
- Renames `isModListExpanded` -> `isModListingPanelExpanded`
- Creates a migration to align the persisted state with the improved shape

## Future Work

- [ ] Combine and/or drop unnecessary state
- [ ] Improve naming

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
