### PR TITLE
Disable linting pre commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,10 +21,11 @@ repos:
     rev: v3.1.0
     hooks:
       - id: prettier
-  - repo: local
-    hooks:
-      - id: eslint
-        name: eslint
-        entry: npm run lint:staged --
-        language: node
-        files: \.js$|\.jsx$|\.ts$|\.tsx$
+  # TODO: restore in
+  # - repo: local
+  #   hooks:
+  #     - id: eslint
+  #       name: eslint
+  #       entry: npm run lint:staged --
+  #       language: node
+  #       files: \.js$|\.jsx$|\.ts$|\.tsx$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     rev: v3.1.0
     hooks:
       - id: prettier
-  # TODO: restore in
+  # TODO: restore in https://github.com/pixiebrix/pixiebrix-extension/issues/9441
   # - repo: local
   #   hooks:
   #     - id: eslint


### PR DESCRIPTION
## What does this PR do?

- Disables the linting pre-commit hook due to it taking too long to run

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
