### PR TITLE
Ignore variable expression in get variable schema

### DIFF
--- a/src/bricks/effects/pageState.test.ts
+++ b/src/bricks/effects/pageState.test.ts
@@ -21,6 +21,7 @@ import { toExpression } from "@/utils/expressionUtils";
 import { GetPageState, SetPageState } from "@/bricks/effects/pageState";
 import { TEST_resetStateController } from "@/contentScript/stateController/stateController";
 import { MergeStrategies, StateNamespaces } from "@/platform/state/stateTypes";
+import { getPlatform } from "@/platform/platformContext";
 
 beforeEach(async () => {
   await TEST_resetStateController();
@@ -28,8 +29,20 @@ beforeEach(async () => {
 
 describe("@pixiebrix/state/get", () => {
   it("defaults to mod namespace", async () => {
+    const data = { foo: 42 };
+    const options = brickOptionsFactory();
+
+    await getPlatform().state.setState({
+      namespace: StateNamespaces.MOD,
+      modComponentRef: options.meta.modComponentRef,
+      data,
+      mergeStrategy: MergeStrategies.REPLACE,
+    });
+
     const brick = new GetPageState();
-    await brick.transform(unsafeAssumeValidArg({}), brickOptionsFactory());
+    await expect(
+      brick.transform(unsafeAssumeValidArg({}), options),
+    ).resolves.toStrictEqual(data);
   });
 
   it("is page state aware", async () => {

--- a/src/bricks/effects/pageState.test.ts
+++ b/src/bricks/effects/pageState.test.ts
@@ -27,12 +27,12 @@ beforeEach(async () => {
 });
 
 describe("@pixiebrix/state/get", () => {
-  test("default to mod namespace", async () => {
+  it("defaults to mod namespace", async () => {
     const brick = new GetPageState();
     await brick.transform(unsafeAssumeValidArg({}), brickOptionsFactory());
   });
 
-  test("is page state aware", async () => {
+  it("is page state aware", async () => {
     const brick = new GetPageState();
     await expect(brick.isPageStateAware()).resolves.toBe(true);
   });
@@ -140,7 +140,7 @@ describe("@pixiebrix/state/set", () => {
 });
 
 describe("set and get", () => {
-  test("default to blueprint state", async () => {
+  it("defaults to mod state", async () => {
     const setState = new SetPageState();
     const getState = new GetPageState();
     const brickOptions = brickOptionsFactory();
@@ -169,8 +169,48 @@ describe("set and get", () => {
     expect(result).toStrictEqual({});
   });
 
-  test("is page state aware", async () => {
+  it("is page state aware", async () => {
     const brick = new SetPageState();
     await expect(brick.isPageStateAware()).resolves.toBe(true);
+  });
+});
+
+describe("getModVariableSchema", () => {
+  it("includes object literal", async () => {
+    const brick = new SetPageState();
+    await expect(
+      brick.getModVariableSchema({
+        id: SetPageState.BRICK_ID,
+        config: {
+          namespace: StateNamespaces.MOD,
+          data: {
+            foo: toExpression("var", "@hello"),
+          },
+        },
+      }),
+    ).resolves.toStrictEqual({
+      type: "object",
+      properties: {
+        foo: true,
+      },
+      required: ["foo"],
+      additionalProperties: false,
+    });
+  });
+
+  it("ignores variable data", async () => {
+    const brick = new SetPageState();
+    await expect(
+      brick.getModVariableSchema({
+        id: SetPageState.BRICK_ID,
+        config: {
+          namespace: StateNamespaces.MOD,
+          data: toExpression("var", "@hello"),
+        },
+      }),
+    ).resolves.toStrictEqual({
+      type: "object",
+      additionalProperties: true,
+    });
   });
 });

--- a/src/bricks/effects/pageState.ts
+++ b/src/bricks/effects/pageState.ts
@@ -23,7 +23,7 @@ import { validateRegistryId } from "@/types/helpers";
 import { type BrickConfig } from "@/bricks/types";
 import { isObject } from "@/utils/objectUtils";
 import { mapValues } from "lodash";
-import { castTextLiteralOrThrow } from "@/utils/expressionUtils";
+import { castTextLiteralOrThrow, isExpression } from "@/utils/expressionUtils";
 import { propertiesToSchema } from "@/utils/schemaUtils";
 import {
   MergeStrategies,
@@ -122,7 +122,7 @@ export class SetPageState extends TransformerABC {
       return;
     }
 
-    if (isObject(data)) {
+    if (isObject(data) && !isExpression(data)) {
       return {
         type: "object",
         // Only track the existence of the properties, not their values


### PR DESCRIPTION
## What does this PR do?

- Fixes bug where `__value__` and `__type__` appear as mod variables (in var popover and mod variables pane) when passing a variable to the `@pixiebrix/state/set` brick

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
