### PR TITLE
#9430: extracting first util lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           node-version-file: applications/browser-extension/package.json
           cache: npm
       - run: npm ci
-      - run: npm run test --workspace=applications/browser-extension -- --coverage
+      - run: npm run test --workspaces -- --coverage
       - uses: actions/upload-artifact@v4
         with:
           name: extension-test-coverage
@@ -151,7 +151,7 @@ jobs:
           node-version-file: applications/browser-extension/package.json
           cache: npm
       - run: npm ci
-      - run: npm run build:typescript --workspace=applications/browser-extension
+      - run: npm run build:typecheck --workspaces
 
   lint:
     runs-on: ubuntu-latest

--- a/applications/browser-extension/package.json
+++ b/applications/browser-extension/package.json
@@ -16,9 +16,9 @@
     "watch:webpack": "ENV_FILE='.env.development' webpack ${HMR:-watch} --mode development",
     "watch:webpack-hmr": "HMR=serve npm run watch:webpack",
     "watch:typescript": "tsc --noEmit --watch",
-    "build": "concurrently npm:build:webpack npm:build:typescript -r",
+    "build": "concurrently npm:build:webpack npm:build:typecheck -r",
     "build:webpack": "NODE_OPTIONS=--max_old_space_size=8192 webpack --mode production",
-    "build:typescript": "tsc --noEmit",
+    "build:typecheck": "tsc --noEmit",
     "generate:headers": "npm run test -- src/development/headers.test.ts --no-silent",
     "storybook": "storybook dev -p 6006 -s public",
     "build-storybook": "storybook build",
@@ -26,11 +26,6 @@
     "dead-code:base_BROKEN_DUE_TO_NOT_BEING_RUN_IN_ROOT": "knip --config knip.mjs --tags=-knip",
     "dead-code:base": "echo 'skipping knip until fixed in next changeset. See: https://knip.dev/guides/handling-issues#missing-binaries'",
     "dead-code:prod": "npm run dead-code -- --production"
-  },
-  "engine-strict": true,
-  "engines": {
-    "node": "20.12.0",
-    "npm": "10.5.0"
   },
   "author": "Todd Schiller",
   "license": "AGPL-3.0",

--- a/applications/browser-extension/package.json
+++ b/applications/browser-extension/package.json
@@ -50,6 +50,7 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@mozilla/readability": "^0.5.0",
     "@pixiebrix/jq-web": "^0.5.1",
+    "@pixiebrix/utils": "*",
     "@reduxjs/toolkit": "^1.9.7",
     "@rjsf/bootstrap-4": "^5.22.3",
     "@rjsf/core": "^5.22.3",

--- a/applications/browser-extension/src/pageEditor/store/editor/editorSlice.ts
+++ b/applications/browser-extension/src/pageEditor/store/editor/editorSlice.ts
@@ -34,7 +34,7 @@ import { uuidv4 } from "@/types/helpers";
 import { cloneDeep, compact, get, pull, uniq } from "lodash";
 import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
 import { type TreeExpandedState } from "@/components/jsonTree/JsonTree";
-import { getInvalidPath } from "@/utils/debugUtils";
+import { getInvalidPath } from "@pixiebrix/utils/src/debugUtils";
 import {
   selectActiveBrickConfigurationUIState,
   selectActiveBrickPipelineUIState,

--- a/libraries/utils/jest.config.js
+++ b/libraries/utils/jest.config.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const config = {
+  silent: true,
+  modulePaths: ["/src"],
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
+  transform: {
+    "\\.[jt]sx?$": "@swc/jest",
+  },
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
+};
+
+module.exports = config;

--- a/libraries/utils/package.json
+++ b/libraries/utils/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@pixiebrix/utils",
+  "version": "1.0.0",
+  "description": "PixieBrix Utility Library",
+  "scripts": {
+    "test": "TZ=UTC jest",
+    "lint": "echo 'missing linting'",
+    "build": "tsc --noEmit"
+  },
+  "engine-strict": true,
+  "engines": {
+    "node": "20.12.0",
+    "npm": "10.5.0"
+  },
+  "license": "AGPL-3.0",
+  "repository": "https://github.com/pixiebrix/pixiebrix-extension",
+  "dependencies": {
+    "formik": "^2.4.6"
+  },
+  "devDependencies": {
+    "@swc/core": "^1.7.42",
+    "@swc/jest": "^0.2.37",
+    "eslint": "^8.57.0",
+    "typescript": "^5.6.3"
+  }
+}

--- a/libraries/utils/package.json
+++ b/libraries/utils/package.json
@@ -4,13 +4,9 @@
   "description": "PixieBrix Utility Library",
   "scripts": {
     "test": "TZ=UTC jest",
-    "lint": "echo 'missing linting'",
-    "build": "tsc --noEmit"
-  },
-  "engine-strict": true,
-  "engines": {
-    "node": "20.12.0",
-    "npm": "10.5.0"
+    "lint": "echo 'missing eslint'",
+    "build": "echo 'buildless package'",
+    "build:typecheck": "tsc --noEmit"
   },
   "license": "AGPL-3.0",
   "repository": "https://github.com/pixiebrix/pixiebrix-extension",

--- a/libraries/utils/src/debugUtils.test.ts
+++ b/libraries/utils/src/debugUtils.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { getInvalidPath } from "@/utils/debugUtils";
+import { getInvalidPath } from "@/debugUtils";
 
 describe("getInvalidPath", () => {
   it("returns invalid path", () => {

--- a/libraries/utils/src/debugUtils.ts
+++ b/libraries/utils/src/debugUtils.ts
@@ -28,7 +28,7 @@ type InvalidPathInformation = {
  * @param path period separated path
  */
 export function getInvalidPath(
-  value: UnknownObject,
+  value: Record<string, unknown>,
   path: string,
 ): InvalidPathInformation {
   const parts = path.split(".");

--- a/libraries/utils/tsconfig.json
+++ b/libraries/utils/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  // You can see the full details at https://github.com/sindresorhus/tsconfig/blob/main/tsconfig.json
+  // Note: `strict: true` enables many flags that aren’t explicitly listed in that file
+  "extends": "@sindresorhus/tsconfig",
+  "compilerOptions": {
+    "sourceMap": true,
+    "module": "esnext",
+    "target": "es2023",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "outDir": null,
+    "declaration": false,
+
+    // TODO: Drop these lines to make TS stricter https://github.com/pixiebrix/pixiebrix-extension/issues/775
+    "strictFunctionTypes": false,
+    "noPropertyAccessFromIndexSignature": false,
+    "noImplicitReturns": false,
+    "noUnusedParameters": false,
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "exclude": ["node_modules"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@mozilla/readability": "^0.5.0",
         "@pixiebrix/jq-web": "^0.5.1",
+        "@pixiebrix/utils": "*",
         "@reduxjs/toolkit": "^1.9.7",
         "@rjsf/bootstrap-4": "^5.22.3",
         "@rjsf/core": "^5.22.3",
@@ -302,6 +303,24 @@
     "eslint-plugin-pixiebrix-extension": {
       "version": "0.0.1",
       "extraneous": true
+    },
+    "libraries/utils": {
+      "name": "@pixiebrix/utils",
+      "version": "1.0.0",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "formik": "^2.4.6"
+      },
+      "devDependencies": {
+        "@swc/core": "^1.7.42",
+        "@swc/jest": "^0.2.37",
+        "eslint": "^8.57.0",
+        "typescript": "^5.6.3"
+      },
+      "engines": {
+        "node": "20.12.0",
+        "npm": "10.5.0"
+      }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -4475,6 +4494,10 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@pixiebrix/jq-web/-/jq-web-0.5.1.tgz",
       "integrity": "sha512-q99g6J8UVsS7+pNlxyl01eDnUtHuYC9GPgKUXntpfs7akuqhkes9AZjC678LxjTC5BkjFtfOQazFQoyW/9/B/w=="
+    },
+    "node_modules/@pixiebrix/utils": {
+      "resolved": "libraries/utils",
+      "link": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,17 @@
   "scripts": {
     "test": "npm run test --workspaces",
     "lint": "npm run lint --workspaces",
-    "build": "npm run build --workspaces"
+    "build": "npm run build --workspaces",
+    "build:typecheck": "npm run build:typecheck --workspaces"
   },
   "author": "Todd Schiller",
   "license": "AGPL-3.0",
   "repository": "https://github.com/pixiebrix/pixiebrix-extension",
+  "engine-strict": true,
+  "engines": {
+    "node": "20.12.0",
+    "npm": "10.5.0"
+  },
   "devDependencies": {
     "prettier": "3.1.0"
   }


### PR DESCRIPTION
## What does this PR do?

- Part of #9430
- As part of the monorepo trailblazing, this PR sets up the first extracted utils library, extracting some debugging util that isn't used anywhere else (namely `pixiebrix-app`) and doesn't have any other dependencies
  - This will make it easier for us to properly set up `nx` and catch any potential issues.
- Initial set up with some duplicated jest and tsconfig
  - Follow-up will extract common base configuration to the root, and add linting

## Discussion

- For ease of starting this out, this new utils library is build-less, but we will likely want to move towards each library project producing its compiled js so we can take advantage of `nx`'s build and caching mechanisms. I will look into this in the next set of changes alongside creating a root common ts config.
  - For reference see Nx's example npm workspace project: https://github.com/nrwl/nx-examples/tree/master/libs/shared/product/ui

## Checklist

- [X] Added jest or playwright tests and/or storybook stories

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
