### PR TITLE
Mark extension `dist` directory as excluded in IntelliJ

### DIFF
--- a/pixiebrix-extension.iml
+++ b/pixiebrix-extension.iml
@@ -8,6 +8,8 @@
       <excludeFolder url="file://$MODULE_DIR$/coverage" />
       <excludeFolder url="file://$MODULE_DIR$/storybook-static" />
       <excludeFolder url="file://$MODULE_DIR$/applications/browser-extension/scripts/bin" />
+      <excludeFolder url="file://$MODULE_DIR$/.playwright-report" />
+      <excludeFolder url="file://$MODULE_DIR$/applications/browser-extension/dist" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />


### PR DESCRIPTION
## What does this PR do?

- Mark extension `dist` directory as excluded from IntelliJ search/find

## Discussion

- @fungairino this would be a good step to add in our monorepo migration guide

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
