### PR TITLE
Add eslint config for `libraries/utils`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version-file: applications/browser-extension/package.json
+          node-version-file: package.json
           cache: npm
       - run: npm ci
-      - run: npm run lint:full --workspace=applications/browser-extension
+      - run: npm run lint:full
 
   dead-code:
     runs-on: ubuntu-latest

--- a/libraries/utils/.eslintrc.js
+++ b/libraries/utils/.eslintrc.js
@@ -1,0 +1,18 @@
+module.exports = {
+  root: true,
+  extends: [
+    // Full config: https://github.com/pixiebrix/eslint-config-pixiebrix/blob/main/index.js
+    // XXX: use exact configuration for now because applications/browser-extension has a lot of local configuration.
+    // When we bring eslint-config-pixiebrix into the monorepo, we can iterate on code sharing across configs.
+    "pixiebrix",
+  ],
+};
+
+// `npm run lint:fast` will skip the (slow) import/* rules
+// Useful if you're trying to iterate fixes over other rules
+if (process.env.ESLINT_NO_IMPORTS) {
+  const importRules = Object.keys(require("eslint-plugin-import").rules);
+  for (const ruleName of importRules) {
+    module.exports.rules[`import/${ruleName}`] = "off";
+  }
+}

--- a/libraries/utils/package.json
+++ b/libraries/utils/package.json
@@ -19,6 +19,7 @@
     "@swc/core": "^1.9.2",
     "@swc/jest": "^0.2.37",
     "eslint": "^8.57.0",
+    "eslint-config-pixiebrix": "^0.41.1",
     "jest": "^29.7.0",
     "typescript": "^5.6.3"
   }

--- a/libraries/utils/src/debugUtils.ts
+++ b/libraries/utils/src/debugUtils.ts
@@ -28,7 +28,7 @@ type InvalidPathInformation = {
  * @param path period separated path
  */
 export function getInvalidPath(
-  value: Record<string, unknown>,
+  value: UnknownObject,
   path: string,
 ): InvalidPathInformation {
   const parts = path.split(".");

--- a/libraries/utils/src/globals.d.ts
+++ b/libraries/utils/src/globals.d.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* eslint-disable-next-line no-restricted-syntax --
+ * Type to be preferred over a plain `object`
+ * https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/ban-types.md */
+type UnknownObject = Record<string, unknown>;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "test": "npm run test --workspaces",
     "lint": "npm run lint --workspaces",
+    "lint:full": "npm run lint:full --workspaces",
     "build": "npm run build --workspaces",
     "build:typecheck": "npm run build:typecheck --workspaces",
     "dead-code": "npm run dead-code:base -- --include files,duplicates,dependencies,classMembers,binaries,enumMembers,nsTypes,exports,nsExports",


### PR DESCRIPTION
## What does this PR do?

- Add eslint config for `libraries/utils`
- Current enforces base `eslint-config-pixiebrix`. There are some rules (e.g., about nullish, etc. that aren't enforced)

## Future Work

- Improve lint command naming: https://pixiebrix.slack.com/archives/C080KB9R76G/p1731429258921059. E.g., `lint` should likely run all checks (instead of having to run `lint:full`)
- Move main eslint config into the monorepo so we can iterate on configuration sharing across workspaces: https://pixiebrix.slack.com/archives/C080KB9R76G/p1731429207637519

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
