### PR TITLE
fix uploading the complete e2e test report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Merge blob reports
         # Provide `--yes` for knip. Even though playwright will be available via @playwright/test, knip doesn't
         #   associate it with the playwright command
-        run: PLAYWRIGHT_JSON_OUTPUT_NAME=./applications/browser-extension/playwright-report/results.json npx --yes playwright merge-reports --reporter=html,json ./applications/browser-extension/blob-reports
+        run: PLAYWRIGHT_HTML_OUTPUT_DIR=./applications/browser-extension/playwright-report PLAYWRIGHT_JSON_OUTPUT_NAME=./applications/browser-extension/playwright-report/results.json npx --yes playwright merge-reports --reporter=html,json ./applications/browser-extension/blob-reports
       - name: Password protect merged Playwright report
         if: always()
         shell: bash


### PR DESCRIPTION
## What does this PR do?

- Fixes an issue where the final e2e report isn't including all the html report of all the shard runs. Ex: https://github.com/pixiebrix/pixiebrix-extension/actions/runs/11806403707/job/32891692321?pr=9490
- Verified by checking that the "Password protect merged Playwright report" step in the Create report job produces a file larger than 15kb

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
