### PR TITLE
#9433: mod commit message modal

### DIFF
--- a/applications/browser-extension/end-to-end-tests/pageObjects/pageEditor/pageEditorPage.ts
+++ b/applications/browser-extension/end-to-end-tests/pageObjects/pageEditor/pageEditorPage.ts
@@ -120,6 +120,16 @@ export class PageEditorPage extends BasePageObject {
     //  cleaned up after the test. Future work is adding affordance to clean up saved
     //  mods, with an option to avoid cleanup for certain mods.
     await this.modListingPanel.activeModListItem.saveButton.click();
+
+    // Since 2.2.1, Page Editor shows commit message dialog when saving an existing mod
+    const saveDialog = this.getByRole("dialog");
+    await expect(saveDialog).toBeVisible();
+    await saveDialog
+      .getByRole("textbox", { name: "Message" })
+      .fill("Commit message");
+    await saveDialog.getByRole("button", { name: "Save" }).click();
+    await expect(saveDialog).toBeHidden();
+
     await expect(
       this.page.getByRole("status").filter({ hasText: "Saved mod" }),
     ).toBeVisible();

--- a/applications/browser-extension/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts-snapshots/Add-starter-brick-to-mod/add-button-starter-brick-to-mod.yaml
+++ b/applications/browser-extension/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts-snapshots/Add-starter-brick-to-mod/add-button-starter-brick-to-mod.yaml
@@ -9,7 +9,7 @@ options:
 metadata:
   id: >-
     @extension-e2e-test-unaffiliated/new-mod-00000000-0000-0000-0000-000000000000
-  version: 1.0.0
+  version: 1.0.1
   name: New Mod
   description: Created by playwright test for adding starter bricks to a mod
 variables:

--- a/applications/browser-extension/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts-snapshots/Add-starter-brick-to-mod/add-context-menu-starter-brick-to-mod.diff
+++ b/applications/browser-extension/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts-snapshots/Add-starter-brick-to-mod/add-context-menu-starter-brick-to-mod.diff
@@ -101,7 +101,8 @@ Index: add-context-menu-starter-brick-to-mod
    id: >-
      @extension-e2e-test-unaffiliated/new-mod-00000000-0000-0000-0000-000000000000
    name: New Mod
-   version: 1.0.0
+-  version: 1.0.1
++  version: 1.0.2
  options:
    schema:
      properties: {}

--- a/applications/browser-extension/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts-snapshots/Add-starter-brick-to-mod/add-quick-bar-starter-brick-to-mod.diff
+++ b/applications/browser-extension/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts-snapshots/Add-starter-brick-to-mod/add-quick-bar-starter-brick-to-mod.diff
@@ -127,7 +127,8 @@ Index: add-quick-bar-starter-brick-to-mod
    id: >-
      @extension-e2e-test-unaffiliated/new-mod-00000000-0000-0000-0000-000000000000
    name: New Mod
-   version: 1.0.0
+-  version: 1.0.2
++  version: 1.0.3
  options:
    schema:
      properties: {}

--- a/applications/browser-extension/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts-snapshots/Add-starter-brick-to-mod/add-sidebar-panel-starter-brick-to-mod.diff
+++ b/applications/browser-extension/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts-snapshots/Add-starter-brick-to-mod/add-sidebar-panel-starter-brick-to-mod.diff
@@ -162,7 +162,8 @@ Index: add-sidebar-panel-starter-brick-to-mod
    id: >-
      @extension-e2e-test-unaffiliated/new-mod-00000000-0000-0000-0000-000000000000
    name: New Mod
-   version: 1.0.0
+-  version: 1.0.3
++  version: 1.0.4
  options:
    schema:
      properties: {}

--- a/applications/browser-extension/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts-snapshots/Add-starter-brick-to-mod/add-trigger-starter-brick-to-mod.diff
+++ b/applications/browser-extension/end-to-end-tests/tests/pageEditor/addStarterBrick.spec.ts-snapshots/Add-starter-brick-to-mod/add-trigger-starter-brick-to-mod.diff
@@ -2,7 +2,7 @@ Index: add-trigger-starter-brick-to-mod
 ===================================================================
 --- add-trigger-starter-brick-to-mod
 +++ add-trigger-starter-brick-to-mod
-@@ -91,80 +91,88 @@
+@@ -91,101 +91,109 @@
          - '@pixiebrix/document-context'
          - element: '@pixiebrix/html/element'
        reportMode: once
@@ -91,3 +91,25 @@ Index: add-trigger-starter-brick-to-mod
      id: extensionPoint4
      label: Sidebar Panel
      permissions:
+       origins: []
+       permissions: []
+     services: {}
+ kind: recipe
+ metadata:
+   description: Created by playwright test for adding starter bricks to a mod
+   id: >-
+     @extension-e2e-test-unaffiliated/new-mod-00000000-0000-0000-0000-000000000000
+   name: New Mod
+-  version: 1.0.4
++  version: 1.0.5
+ options:
+   schema:
+     properties: {}
+     type: object
+   uiSchema:
+     ui:order:
+       - '*'
+ variables:
+   schema:
+     properties: {}
+     type: object

--- a/applications/browser-extension/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/brick-added.diff
+++ b/applications/browser-extension/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/brick-added.diff
@@ -79,7 +79,8 @@ Index: brick-added
    id: >-
      @extension-e2e-test-unaffiliated/brick-actions-00000000-0000-0000-0000-000000000000
    name: Mod Actions Test
-   version: 1.0.0
+-  version: 1.0.0
++  version: 1.0.1
  options:
    schema:
      properties: {}

--- a/applications/browser-extension/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/brick-copied-to-another-mod.diff
+++ b/applications/browser-extension/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/brick-copied-to-another-mod.diff
@@ -77,7 +77,8 @@ Index: brick-copied-to-another-mod
    id: >-
      @extension-e2e-test-unaffiliated/simple-sidebar-panel-00000000-0000-0000-0000-000000000000
    name: Simple Sidebar Panel
-   version: 1.0.0
+-  version: 1.0.0
++  version: 1.0.1
  options:
    schema:
      properties: {}

--- a/applications/browser-extension/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/brick-copy-pasted.diff
+++ b/applications/browser-extension/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/brick-copy-pasted.diff
@@ -2,7 +2,7 @@ Index: brick-copy-pasted
 ===================================================================
 --- brick-copy-pasted
 +++ brick-copy-pasted
-@@ -6,80 +6,88 @@
+@@ -6,82 +6,90 @@
        containerSelector: span:has(> span:contains('Review in codespace'))
        isAvailable:
          allFrames: true
@@ -81,7 +81,8 @@ Index: brick-copy-pasted
    id: >-
      @extension-e2e-test-unaffiliated/brick-actions-00000000-0000-0000-0000-000000000000
    name: Mod Actions Test
-   version: 1.0.0
+-  version: 1.0.2
++  version: 1.0.3
  options:
    schema:
      properties: {}
@@ -91,3 +92,5 @@ Index: brick-copy-pasted
        - '*'
  variables:
    schema:
+     properties: {}
+     type: object

--- a/applications/browser-extension/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/brick-removed.diff
+++ b/applications/browser-extension/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/brick-removed.diff
@@ -2,7 +2,7 @@ Index: brick-removed
 ===================================================================
 --- brick-removed
 +++ brick-removed
-@@ -6,86 +6,80 @@
+@@ -6,88 +6,82 @@
        containerSelector: span:has(> span:contains('Review in codespace'))
        isAvailable:
          allFrames: true
@@ -79,7 +79,8 @@ Index: brick-removed
    id: >-
      @extension-e2e-test-unaffiliated/brick-actions-00000000-0000-0000-0000-000000000000
    name: Mod Actions Test
-   version: 1.0.0
+-  version: 1.0.1
++  version: 1.0.2
  options:
    schema:
      properties: {}
@@ -89,3 +90,5 @@ Index: brick-removed
        - '*'
  variables:
    schema:
+     properties: {}
+     type: object

--- a/applications/browser-extension/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/bricks-moved.diff
+++ b/applications/browser-extension/end-to-end-tests/tests/pageEditor/brickActions.spec.ts-snapshots/brick-actions-panel-behavior/bricks-moved.diff
@@ -101,7 +101,8 @@ Index: bricks-moved
    id: >-
      @extension-e2e-test-unaffiliated/brick-actions-00000000-0000-0000-0000-000000000000
    name: Mod Actions Test
-   version: 1.0.0
+-  version: 1.0.3
++  version: 1.0.4
  options:
    schema:
      properties: {}

--- a/applications/browser-extension/end-to-end-tests/tests/pageEditor/brickConfiguration.spec.ts-snapshots/brick-configuration/starter-brick-configuration-changes.diff
+++ b/applications/browser-extension/end-to-end-tests/tests/pageEditor/brickConfiguration.spec.ts-snapshots/brick-configuration/starter-brick-configuration-changes.diff
@@ -77,7 +77,8 @@ Index: starter-brick-configuration-changes
    id: >-
      @extension-e2e-test-unaffiliated/brick-configuration-00000000-0000-0000-0000-000000000000
    name: Test mod - Brick Configuration
-   version: 1.0.0
+-  version: 1.0.0
++  version: 1.0.1
  options:
    schema:
      properties: {}

--- a/applications/browser-extension/end-to-end-tests/tests/pageEditor/modEditorPane.spec.ts-snapshots/mod-editor-pane-behavior/updated-inputs.diff
+++ b/applications/browser-extension/end-to-end-tests/tests/pageEditor/modEditorPane.spec.ts-snapshots/mod-editor-pane-behavior/updated-inputs.diff
@@ -2,7 +2,10 @@ Index: updated-inputs
 ===================================================================
 --- updated-inputs
 +++ updated-inputs
-@@ -30,49 +30,60 @@
+@@ -27,52 +27,63 @@
+                   - children:
+                       - children:
+                           - config:
                                heading: h1
                                title: !nunjucks Simple Sidebar Panel
                              type: header
@@ -40,7 +43,8 @@ Index: updated-inputs
    id: >-
      @extension-e2e-test-unaffiliated/simple-sidebar-panel-00000000-0000-0000-0000-000000000000
    name: Simple Sidebar Panel (Updated)
-   version: 1.0.2
+-  version: 1.0.2
++  version: 1.0.3
  options:
    schema:
 -    properties: {}

--- a/applications/browser-extension/end-to-end-tests/tests/pageEditor/saveMod.spec.ts
+++ b/applications/browser-extension/end-to-end-tests/tests/pageEditor/saveMod.spec.ts
@@ -116,5 +116,14 @@ test("shows error notification when updating a public mod without incrementing t
     "8203 Repro Updated",
   );
   await pageEditorPage.modListingPanel.activeModListItem.saveButton.click();
+
+  const saveDialog = pageEditorPage.getByRole("dialog");
+  await expect(saveDialog).toBeVisible();
+  await saveDialog.getByRole("textbox", { name: "New Version" }).fill("1.0.0");
+  await saveDialog
+    .getByRole("textbox", { name: "Message" })
+    .fill("Commit message");
+  await saveDialog.getByRole("button", { name: "Save" }).click();
+
   await expect(pageEditorPage.getIncrementVersionErrorToast()).toBeVisible();
 });

--- a/applications/browser-extension/src/background/deploymentUpdater.test.ts
+++ b/applications/browser-extension/src/background/deploymentUpdater.test.ts
@@ -19,7 +19,7 @@ import {
   getModComponentState,
   saveModComponentState,
 } from "@/store/modComponents/modComponentStorage";
-import { uuidv4, normalizeSemVerString } from "@/types/helpers";
+import { uuidv4 } from "@/types/helpers";
 import { appApiMock } from "@/testUtils/appApiMock";
 import { omit } from "lodash";
 import {
@@ -68,6 +68,7 @@ import {
 } from "@/contentScript/messenger/api";
 import { adapter } from "@/pageEditor/starterBricks/adapter";
 import { API_PATHS } from "@/data/service/urlPaths";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 TEST_setContext("background");
 

--- a/applications/browser-extension/src/background/installer.ts
+++ b/applications/browser-extension/src/background/installer.ts
@@ -42,8 +42,8 @@ import {
 } from "@/utils/extensionUtils";
 import { oncePerSession } from "@/mv3/SessionStorage";
 import { resetFeatureFlagsCache } from "@/auth/featureFlagStorage";
-import { normalizeSemVerString } from "@/types/helpers";
 import { type SemVerString } from "@/types/registryTypes";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 /**
  * The latest version of PixieBrix available in the Chrome Web Store, or null if the version hasn't been fetched.

--- a/applications/browser-extension/src/data/service/api.ts
+++ b/applications/browser-extension/src/data/service/api.ts
@@ -47,6 +47,7 @@ import { type Me, transformMeResponse } from "@/data/model/Me";
 import { type UserMilestone } from "@/data/model/UserMilestone";
 import { API_PATHS } from "@/data/service/urlPaths";
 import { type Team, transformTeamResponse } from "@/data/model/Team";
+import { createPrivateSharing } from "@/utils/registryUtils";
 
 export const appApi = createApi({
   reducerPath: "appApi",
@@ -264,14 +265,12 @@ export const appApi = createApi({
     }),
     updateModDefinition: builder.mutation<
       PackageUpsertResponse,
-      { packageId: UUID; modDefinition: UnsavedModDefinition }
+      { packageId: UUID; modDefinition: UnsavedModDefinition; message?: string }
     >({
-      query({ packageId, modDefinition }) {
+      query({ packageId, modDefinition, message }) {
         const config = dumpBrickYaml(modDefinition);
-        const sharing = (modDefinition as ModDefinition).sharing ?? {
-          public: false,
-          organizations: [],
-        };
+        const sharing =
+          (modDefinition as ModDefinition).sharing ?? createPrivateSharing();
 
         return {
           url: API_PATHS.BRICK(packageId),
@@ -282,6 +281,7 @@ export const appApi = createApi({
             config,
             kind: DefinitionKinds.MOD,
             public: sharing.public,
+            message,
             organizations: sharing.organizations,
           },
         };

--- a/applications/browser-extension/src/extensionConsole/pages/mods/utils/buildGetModVersionStatus.test.ts
+++ b/applications/browser-extension/src/extensionConsole/pages/mods/utils/buildGetModVersionStatus.test.ts
@@ -18,10 +18,10 @@
 import buildGetModVersionStatus from "@/extensionConsole/pages/mods/utils/buildGetModVersionStatus";
 import { modDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
-import { normalizeSemVerString } from "@/types/helpers";
 import { mapModInstanceToUnavailableMod } from "@/utils/modUtils";
 import { registryIdFactory } from "@/testUtils/factories/stringFactories";
 import { modInstanceFactory } from "@/testUtils/factories/modInstanceFactories";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 describe("buildGetModVersionStatus", () => {
   it("handles no activated mod components", () => {

--- a/applications/browser-extension/src/extensionConsole/pages/packageEditor/PackageHistory.test.tsx
+++ b/applications/browser-extension/src/extensionConsole/pages/packageEditor/PackageHistory.test.tsx
@@ -27,6 +27,8 @@ import { render } from "@/extensionConsole/testHelpers";
 import { type Package, type PackageVersionDeprecated } from "@/types/contract";
 import { type Timestamp } from "@/types/stringTypes";
 import { DefinitionKinds } from "@/types/registryTypes";
+import { packageVersionDeprecatedFactory } from "@/testUtils/factories/registryFactories";
+import { validateTimestamp } from "@/utils/timeUtils";
 
 const axiosMock = new MockAdapter(axios);
 
@@ -46,22 +48,22 @@ describe("PackageHistory", () => {
 
   it("renders select components for choosing versions and displays the diff", async () => {
     const testVersions: PackageVersionDeprecated[] = [
-      {
+      packageVersionDeprecatedFactory({
         id: testPackageId,
         version: "1.0.1",
         config: {},
         raw_config: "some big yaml file",
-        created_at: "2024-01-24T20:55:41.263846Z" as Timestamp,
-        updated_at: "2024-01-26T23:58:12.270168Z" as Timestamp,
-      },
-      {
+        created_at: validateTimestamp("2024-01-24T20:55:41.263846Z"),
+        updated_at: validateTimestamp("2024-01-26T23:58:12.270168Z"),
+      }),
+      packageVersionDeprecatedFactory({
         id: testPackageId,
         version: "1.0.0",
         config: {},
         raw_config: "some big yaml file2",
-        created_at: "2024-01-20T16:55:41.263846Z" as Timestamp,
-        updated_at: "2024-01-22T18:58:12.270168Z" as Timestamp,
-      },
+        created_at: validateTimestamp("2024-01-20T16:55:41.263846Z"),
+        updated_at: validateTimestamp("2024-01-22T18:58:12.270168Z"),
+      }),
     ];
 
     const testPackage: Package = {

--- a/applications/browser-extension/src/pageEditor/hooks/useSaveMod.test.ts
+++ b/applications/browser-extension/src/pageEditor/hooks/useSaveMod.test.ts
@@ -16,284 +16,20 @@
  */
 import { renderHook } from "@/pageEditor/testHelpers";
 import useSaveMod from "@/pageEditor/hooks/useSaveMod";
-import { validateRegistryId } from "@/types/helpers";
 import { appApiMock } from "@/testUtils/appApiMock";
-import { editablePackageMetadataFactory } from "@/testUtils/factories/registryFactories";
 import notify from "@/utils/notify";
-import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
-import { type SemVerString } from "@/types/registryTypes";
-import modDefinitionRegistry from "@/modDefinitions/registry";
-import { loadBrickYaml } from "@/runtime/brickYaml";
-import { type ModDefinition } from "@/types/modDefinitionTypes";
-import type { components } from "@/types/swagger";
-import {
-  actions as editorActions,
-  editorSlice,
-} from "@/pageEditor/store/editor/editorSlice";
-import type {
-  EditablePackageMetadata,
-  PackageUpsertResponse,
-} from "@/types/contract";
-import modComponentSlice from "@/store/modComponents/modComponentSlice";
-import { API_PATHS } from "@/data/service/urlPaths";
+import { actions as editorActions } from "@/pageEditor/store/editor/editorSlice";
 import { createNewUnsavedModMetadata } from "@/utils/modUtils";
 import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
-import { createPrivateSharing } from "@/utils/registryUtils";
-import { timestampFactory } from "@/testUtils/factories/stringFactories";
-import { propertiesToSchema } from "@/utils/schemaUtils";
 import { act } from "@testing-library/react";
-import { waitForEffect } from "@/testUtils/testHelpers";
-
-const modId = validateRegistryId("@test/mod");
 
 jest.mock("@/utils/notify");
-jest.mock("@/contentScript/messenger/api");
 
 beforeEach(() => {
   jest.clearAllMocks();
 });
 
-function packageUpsertResponseFactory(
-  editablePackage: EditablePackageMetadata,
-): PackageUpsertResponse {
-  return {
-    ...editablePackage,
-    ...createPrivateSharing(),
-    updated_at: timestampFactory(),
-    // OK to pass empty string because it's not relevant to the tests
-    config: "",
-  };
-}
-
 describe("useSaveMod", () => {
-  function setupModDefinitionMocks(
-    definitionOverrides: Partial<ModDefinition> = {},
-  ) {
-    appApiMock.reset();
-
-    const editablePackage = editablePackageMetadataFactory({
-      name: modId,
-    });
-
-    const modDefinition = defaultModDefinitionFactory({
-      metadata: {
-        id: editablePackage.name,
-        name: editablePackage.verbose_name!,
-        version: editablePackage.version as SemVerString,
-      },
-      ...definitionOverrides,
-    });
-
-    // Register directly in modDefinitionRegistry because background call to sync with the bricks registry endpoint is mocked
-    modDefinitionRegistry.register([
-      {
-        id: modId,
-        ...modDefinition,
-      },
-    ]);
-
-    appApiMock.onGet(API_PATHS.BRICKS).reply(200, [editablePackage]);
-
-    appApiMock
-      .onPut(API_PATHS.BRICK(editablePackage.id))
-      .reply(200, packageUpsertResponseFactory(editablePackage));
-
-    return {
-      modDefinition,
-    };
-  }
-
-  it("saves with no dirty changes", async () => {
-    const { modDefinition } = setupModDefinitionMocks();
-
-    const { result } = renderHook(() => useSaveMod(), {
-      setupRedux(dispatch) {
-        dispatch(
-          modComponentSlice.actions.activateMod({
-            modDefinition,
-            screen: "pageEditor",
-            isReactivate: false,
-          }),
-        );
-      },
-    });
-
-    await waitForEffect();
-
-    await act(async () => {
-      await result.current(modId);
-    });
-
-    // Assert error first to assist with debugging failures
-    expect(notify.error).not.toHaveBeenCalled();
-    expect(notify.success).toHaveBeenCalledWith("Saved mod");
-  });
-
-  it("preserves original options if no dirty options", async () => {
-    const { modDefinition } = setupModDefinitionMocks({
-      options: {
-        schema: {
-          type: "object",
-          properties: {
-            test: {
-              type: "string",
-            },
-          },
-        },
-      },
-    });
-
-    const { result } = renderHook(() => useSaveMod(), {
-      setupRedux(dispatch) {
-        dispatch(
-          modComponentSlice.actions.activateMod({
-            modDefinition,
-            screen: "pageEditor",
-            isReactivate: false,
-          }),
-        );
-      },
-    });
-
-    await waitForEffect();
-
-    await act(async () => {
-      await result.current(modId);
-    });
-
-    // Assert error first to assist with debugging failures
-    expect(notify.error).not.toHaveBeenCalled();
-    expect(notify.success).toHaveBeenCalledWith("Saved mod");
-
-    const yamlConfig = (
-      JSON.parse(
-        appApiMock.history.put[0]!.data,
-      ) as components["schemas"]["Package"]
-    ).config;
-
-    expect((loadBrickYaml(yamlConfig) as ModDefinition).options).toStrictEqual({
-      schema: {
-        type: "object",
-        properties: {
-          test: {
-            type: "string",
-          },
-        },
-      },
-    });
-  });
-
-  it("saves dirty options", async () => {
-    const { modDefinition } = setupModDefinitionMocks();
-
-    const { result } = renderHook(() => useSaveMod(), {
-      setupRedux(dispatch) {
-        dispatch(
-          modComponentSlice.actions.activateMod({
-            modDefinition,
-            screen: "pageEditor",
-            isReactivate: false,
-          }),
-        );
-        dispatch(editorSlice.actions.setActiveModId(modId));
-        dispatch(
-          editorSlice.actions.editModOptionsDefinition({
-            schema: {
-              type: "object",
-              properties: {
-                test: {
-                  type: "string",
-                },
-              },
-            },
-          }),
-        );
-      },
-    });
-
-    await waitForEffect();
-
-    await act(async () => {
-      await result.current(modId);
-    });
-
-    // Assert error first to assist with debugging failures
-    expect(notify.error).not.toHaveBeenCalled();
-    expect(notify.success).toHaveBeenCalledWith("Saved mod");
-
-    const yamlConfig = (
-      JSON.parse(
-        appApiMock.history.put[0]!.data,
-      ) as components["schemas"]["Package"]
-    ).config;
-
-    expect((loadBrickYaml(yamlConfig) as ModDefinition).options).toStrictEqual({
-      schema: {
-        type: "object",
-        properties: {
-          test: {
-            type: "string",
-          },
-        },
-      },
-      uiSchema: {
-        "ui:order": ["test", "*"],
-      },
-    });
-  });
-
-  it("saves dirty mod variable definitions", async () => {
-    const { modDefinition } = setupModDefinitionMocks();
-
-    const { result } = renderHook(() => useSaveMod(), {
-      setupRedux(dispatch) {
-        dispatch(
-          modComponentSlice.actions.activateMod({
-            modDefinition,
-            screen: "pageEditor",
-            isReactivate: false,
-          }),
-        );
-        dispatch(editorSlice.actions.setActiveModId(modId));
-        dispatch(
-          editorSlice.actions.editModVariablesDefinition({
-            schema: propertiesToSchema(
-              { modVariableName: { type: "string" } },
-              [],
-            ),
-          }),
-        );
-      },
-    });
-
-    await waitForEffect();
-
-    await act(async () => {
-      await result.current(modId);
-    });
-
-    const yamlConfig = (
-      JSON.parse(
-        appApiMock.history.put[0]!.data,
-      ) as components["schemas"]["Package"]
-    ).config;
-
-    expect(
-      (loadBrickYaml(yamlConfig) as ModDefinition).variables,
-    ).toStrictEqual({
-      schema: {
-        $schema: "https://json-schema.org/draft/2019-09/schema#",
-        type: "object",
-        properties: {
-          modVariableName: {
-            type: "string",
-          },
-        },
-        required: [],
-      },
-    });
-  });
-
   it("opens the create mod modal if save is called with a temporary, internal mod", async () => {
     appApiMock.reset();
 
@@ -317,14 +53,11 @@ describe("useSaveMod", () => {
       },
     });
 
-    await waitForEffect();
-
-    const { dispatch } = getReduxStore();
-
     await act(async () => {
       await result.current(temporaryModMetadata.id);
     });
 
+    const { dispatch } = getReduxStore();
     expect(dispatch).toHaveBeenCalledWith(
       editorActions.showCreateModModal({
         keepLocalCopy: false,

--- a/applications/browser-extension/src/pageEditor/hooks/useSaveMod.test.ts
+++ b/applications/browser-extension/src/pageEditor/hooks/useSaveMod.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { renderHook } from "@/pageEditor/testHelpers";
-import useSaveMod, { isModEditable } from "@/pageEditor/hooks/useSaveMod";
+import useSaveMod from "@/pageEditor/hooks/useSaveMod";
 import { validateRegistryId } from "@/types/helpers";
 import { appApiMock } from "@/testUtils/appApiMock";
 import { editablePackageMetadataFactory } from "@/testUtils/factories/registryFactories";
@@ -43,7 +43,6 @@ import { timestampFactory } from "@/testUtils/factories/stringFactories";
 import { propertiesToSchema } from "@/utils/schemaUtils";
 import { act } from "@testing-library/react";
 import { waitForEffect } from "@/testUtils/testHelpers";
-import { array } from "cooky-cutter";
 
 const modId = validateRegistryId("@test/mod");
 
@@ -334,32 +333,5 @@ describe("useSaveMod", () => {
     );
     expect(notify.success).not.toHaveBeenCalled();
     expect(notify.error).not.toHaveBeenCalled();
-  });
-});
-
-describe("isModEditable", () => {
-  test("returns true if mod is in editable packages", () => {
-    const mod = defaultModDefinitionFactory();
-    const editablePackages = [
-      editablePackageMetadataFactory(),
-      editablePackageMetadataFactory({
-        name: mod.metadata.id,
-      }),
-    ];
-
-    expect(isModEditable(editablePackages, mod)).toBe(true);
-  });
-
-  test("returns false if mod is not in editable packages", () => {
-    const mod = defaultModDefinitionFactory();
-    const editablePackages = array(editablePackageMetadataFactory, 1)();
-
-    expect(isModEditable(editablePackages, mod)).toBe(false);
-  });
-
-  test("returns false if mod is null", () => {
-    const editablePackages = array(editablePackageMetadataFactory, 1)();
-
-    expect(isModEditable(editablePackages, null)).toBe(false);
   });
 });

--- a/applications/browser-extension/src/pageEditor/hooks/useSaveMod.ts
+++ b/applications/browser-extension/src/pageEditor/hooks/useSaveMod.ts
@@ -31,7 +31,7 @@ import { type EditablePackageMetadata } from "@/types/contract";
 
 /**
  * Returns a callback to show the appropriate save modal based on whether:
- * - The mod have been saved yet
+ * - The mod has been saved yet
  * - The user has edit permissions for the mod
  */
 function useSaveMod(): (modId: RegistryId) => Promise<void> {
@@ -81,6 +81,7 @@ function useSaveMod(): (modId: RegistryId) => Promise<void> {
         return;
       }
 
+      // Must be available because of the isSuccess check. But Typescript can't infer that.
       assertNotNullish(registryQuery.data, "Expected data");
       const { modDefinitions, editablePackages } = registryQuery.data;
 

--- a/applications/browser-extension/src/pageEditor/modListingPanel/ModListItem.test.tsx
+++ b/applications/browser-extension/src/pageEditor/modListingPanel/ModListItem.test.tsx
@@ -23,8 +23,8 @@ import { render } from "@/pageEditor/testHelpers";
 import { Accordion, ListGroup } from "react-bootstrap";
 import { appApiMock } from "@/testUtils/appApiMock";
 import { modDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
-import { normalizeSemVerString } from "@/types/helpers";
 import { API_PATHS } from "@/data/service/urlPaths";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 describe("ModListItem", () => {
   it("renders expanded", async () => {

--- a/applications/browser-extension/src/pageEditor/modListingPanel/modals/CreateModModal.tsx
+++ b/applications/browser-extension/src/pageEditor/modListingPanel/modals/CreateModModal.tsx
@@ -18,9 +18,7 @@
 import React, { useCallback, useRef } from "react";
 import {
   isInnerDefinitionRegistryId,
-  normalizeSemVerString,
   PACKAGE_REGEX,
-  testIsSemVerString,
   validateRegistryId,
 } from "@/types/helpers";
 import { useDispatch, useSelector } from "react-redux";
@@ -66,6 +64,10 @@ import useIsMounted from "@/hooks/useIsMounted";
 import useCreateModFromUnsavedMod from "@/pageEditor/hooks/useCreateModFromUnsavedMod";
 import { isSpecificError } from "@/errors/errorHelpers";
 import { DataIntegrityError } from "@/pageEditor/hooks/useBuildAndValidateMod";
+import {
+  normalizeSemVerString,
+  testIsSemVerString,
+} from "@/types/semVerHelpers";
 
 /**
  * Hook to get the initial form state for the Create Mod modal.

--- a/applications/browser-extension/src/pageEditor/modListingPanel/modals/SaveAsNewModModal.tsx
+++ b/applications/browser-extension/src/pageEditor/modListingPanel/modals/SaveAsNewModModal.tsx
@@ -59,7 +59,7 @@ const SaveAsNewModModal: React.FC = () => {
           onClick={() => {
             assertNotNullish(modId, "Expected selected mod");
             dispatch(
-              // Don't keep the old mod actived
+              // Don't keep the old mod activated
               actions.showCreateModModal({
                 keepLocalCopy: false,
                 sourceModId: modId,

--- a/applications/browser-extension/src/pageEditor/modListingPanel/modals/SaveModVersionModal.test.tsx
+++ b/applications/browser-extension/src/pageEditor/modListingPanel/modals/SaveModVersionModal.test.tsx
@@ -173,7 +173,7 @@ describe("SaveModVersionModal", () => {
     await fillMessageAndSave();
 
     expect(notify.error).not.toHaveBeenCalled();
-    expect(notify.success).toHaveBeenCalledWith("Saved mod");
+    expect(notify.success).toHaveBeenCalledWith({ message: "Saved mod" });
   });
 
   it("preserves original options if no dirty options", async () => {
@@ -207,7 +207,7 @@ describe("SaveModVersionModal", () => {
     await fillMessageAndSave();
 
     // Assert error first to assist with debugging failures
-    expect(notify.success).toHaveBeenCalledWith("Saved mod");
+    expect(notify.success).toHaveBeenCalledWith({ message: "Saved mod" });
 
     const yamlConfig = (
       JSON.parse(
@@ -259,7 +259,7 @@ describe("SaveModVersionModal", () => {
 
     // Assert error first to assist with debugging failures
     expect(notify.error).not.toHaveBeenCalled();
-    expect(notify.success).toHaveBeenCalledWith("Saved mod");
+    expect(notify.success).toHaveBeenCalledWith({ message: "Saved mod" });
 
     const yamlConfig = (
       JSON.parse(

--- a/applications/browser-extension/src/pageEditor/modListingPanel/modals/SaveModVersionModal.test.tsx
+++ b/applications/browser-extension/src/pageEditor/modListingPanel/modals/SaveModVersionModal.test.tsx
@@ -1,0 +1,332 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import useSaveMod from "@/pageEditor/hooks/useSaveMod";
+import SaveModVersionModal from "@/pageEditor/modListingPanel/modals/SaveModVersionModal";
+import AsyncButton from "@/components/AsyncButton";
+import {
+  type EditablePackageMetadata,
+  type PackageUpsertResponse,
+} from "@/types/contract";
+import {
+  registryIdFactory,
+  timestampFactory,
+} from "@/testUtils/factories/stringFactories";
+import { createPrivateSharing } from "@/utils/registryUtils";
+import { type ModDefinition } from "@/types/modDefinitionTypes";
+import { appApiMock } from "@/testUtils/appApiMock";
+import { editablePackageMetadataFactory } from "@/testUtils/factories/registryFactories";
+import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
+import modDefinitionRegistry from "@/modDefinitions/registry";
+import { API_PATHS } from "@/data/service/urlPaths";
+import { render } from "@/pageEditor/testHelpers";
+import modComponentSlice from "@/store/modComponents/modComponentSlice";
+import { actions as editorActions } from "@/pageEditor/store/editor/editorSlice";
+import userEvent from "@testing-library/user-event";
+import { screen } from "@testing-library/react";
+import notify from "@/utils/notify";
+import type { components } from "@/types/swagger";
+import { loadBrickYaml } from "@/runtime/brickYaml";
+import { propertiesToSchema } from "@/utils/schemaUtils";
+
+jest.mock("@/utils/notify");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const modId = registryIdFactory();
+
+const Wrapper: React.VFC = () => {
+  const saveMod = useSaveMod();
+  return (
+    <div>
+      <SaveModVersionModal />
+      <AsyncButton
+        onClick={async () => {
+          await saveMod(modId);
+        }}
+      >
+        Save Mod
+      </AsyncButton>
+    </div>
+  );
+};
+
+function packageUpsertResponseFactory(
+  editablePackage: EditablePackageMetadata,
+): PackageUpsertResponse {
+  return {
+    ...editablePackage,
+    ...createPrivateSharing(),
+    updated_at: timestampFactory(),
+    // OK to pass empty string because it's not relevant to the tests
+    config: "",
+  };
+}
+
+function setupModDefinitionMocks(
+  definitionOverrides: Partial<ModDefinition> = {},
+) {
+  appApiMock.reset();
+
+  const editablePackage = editablePackageMetadataFactory({
+    name: modId,
+  });
+
+  const modDefinition = defaultModDefinitionFactory({
+    metadata: {
+      id: editablePackage.name,
+      name: editablePackage.verbose_name!,
+      version: normalizeSemVerString(editablePackage.version!),
+    },
+    ...definitionOverrides,
+  });
+
+  // Register directly in modDefinitionRegistry because background call to sync with the bricks registry endpoint is mocked
+  modDefinitionRegistry.register([
+    {
+      id: modId,
+      ...modDefinition,
+    },
+  ]);
+
+  appApiMock.onGet(API_PATHS.BRICKS).reply(200, [editablePackage]);
+
+  appApiMock
+    .onPut(API_PATHS.BRICK(editablePackage.id))
+    .reply(200, packageUpsertResponseFactory(editablePackage));
+
+  return {
+    modDefinition,
+  };
+}
+
+async function fillMessageAndSave(message = "Test message") {
+  await userEvent.click(
+    await screen.findByRole("button", { name: "Save Mod" }),
+  );
+  await expect(screen.findByRole("dialog")).resolves.toBeInTheDocument();
+  await userEvent.type(
+    await screen.findByRole("textbox", { name: "Message" }),
+    message,
+  );
+  await userEvent.click(await screen.findByRole("button", { name: "Save" }));
+  expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+}
+
+describe("SaveModVersionModal", () => {
+  it("requires message", async () => {
+    const { modDefinition } = setupModDefinitionMocks();
+
+    render(<Wrapper />, {
+      setupRedux(dispatch) {
+        dispatch(
+          modComponentSlice.actions.activateMod({
+            modDefinition,
+            screen: "pageEditor",
+            isReactivate: false,
+          }),
+        );
+      },
+    });
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Save Mod" }),
+    );
+
+    await expect(screen.findByRole("dialog")).resolves.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("saves with no dirty changes", async () => {
+    const { modDefinition } = setupModDefinitionMocks();
+
+    render(<Wrapper />, {
+      setupRedux(dispatch) {
+        dispatch(
+          modComponentSlice.actions.activateMod({
+            modDefinition,
+            screen: "pageEditor",
+            isReactivate: false,
+          }),
+        );
+      },
+    });
+
+    await fillMessageAndSave();
+
+    expect(notify.error).not.toHaveBeenCalled();
+    expect(notify.success).toHaveBeenCalledWith("Saved mod");
+  });
+
+  it("preserves original options if no dirty options", async () => {
+    const { modDefinition } = setupModDefinitionMocks({
+      options: {
+        schema: {
+          type: "object",
+          properties: {
+            test: {
+              type: "string",
+            },
+          },
+        },
+      },
+    });
+
+    render(<Wrapper />, {
+      setupRedux(dispatch) {
+        dispatch(
+          modComponentSlice.actions.activateMod({
+            modDefinition,
+            screen: "pageEditor",
+            isReactivate: false,
+          }),
+        );
+
+        dispatch(editorActions.setActiveModId(modId));
+      },
+    });
+
+    await fillMessageAndSave();
+
+    // Assert error first to assist with debugging failures
+    expect(notify.success).toHaveBeenCalledWith("Saved mod");
+
+    const yamlConfig = (
+      JSON.parse(
+        appApiMock.history.put[0]!.data,
+      ) as components["schemas"]["Package"]
+    ).config;
+
+    expect((loadBrickYaml(yamlConfig) as ModDefinition).options).toStrictEqual({
+      schema: {
+        type: "object",
+        properties: {
+          test: {
+            type: "string",
+          },
+        },
+      },
+    });
+  });
+
+  it("saves dirty options", async () => {
+    const { modDefinition } = setupModDefinitionMocks();
+
+    render(<Wrapper />, {
+      setupRedux(dispatch) {
+        dispatch(
+          modComponentSlice.actions.activateMod({
+            modDefinition,
+            screen: "pageEditor",
+            isReactivate: false,
+          }),
+        );
+        dispatch(editorActions.setActiveModId(modId));
+        dispatch(
+          editorActions.editModOptionsDefinition({
+            schema: {
+              type: "object",
+              properties: {
+                test: {
+                  type: "string",
+                },
+              },
+            },
+          }),
+        );
+      },
+    });
+
+    await fillMessageAndSave();
+
+    // Assert error first to assist with debugging failures
+    expect(notify.error).not.toHaveBeenCalled();
+    expect(notify.success).toHaveBeenCalledWith("Saved mod");
+
+    const yamlConfig = (
+      JSON.parse(
+        appApiMock.history.put[0]!.data,
+      ) as components["schemas"]["Package"]
+    ).config;
+
+    expect((loadBrickYaml(yamlConfig) as ModDefinition).options).toStrictEqual({
+      schema: {
+        type: "object",
+        properties: {
+          test: {
+            type: "string",
+          },
+        },
+      },
+      uiSchema: {
+        "ui:order": ["test", "*"],
+      },
+    });
+  });
+
+  it("saves dirty mod variable definitions", async () => {
+    const { modDefinition } = setupModDefinitionMocks();
+
+    render(<Wrapper />, {
+      setupRedux(dispatch) {
+        dispatch(
+          modComponentSlice.actions.activateMod({
+            modDefinition,
+            screen: "pageEditor",
+            isReactivate: false,
+          }),
+        );
+        dispatch(editorActions.setActiveModId(modId));
+        dispatch(
+          editorActions.editModVariablesDefinition({
+            schema: propertiesToSchema(
+              { modVariableName: { type: "string" } },
+              [],
+            ),
+          }),
+        );
+      },
+    });
+
+    await fillMessageAndSave();
+
+    const yamlConfig = (
+      JSON.parse(
+        appApiMock.history.put[0]!.data,
+      ) as components["schemas"]["Package"]
+    ).config;
+
+    expect(
+      (loadBrickYaml(yamlConfig) as ModDefinition).variables,
+    ).toStrictEqual({
+      schema: {
+        $schema: "https://json-schema.org/draft/2019-09/schema#",
+        type: "object",
+        properties: {
+          modVariableName: {
+            type: "string",
+          },
+        },
+        required: [],
+      },
+    });
+  });
+});

--- a/applications/browser-extension/src/pageEditor/modListingPanel/modals/SaveModVersionModal.tsx
+++ b/applications/browser-extension/src/pageEditor/modListingPanel/modals/SaveModVersionModal.tsx
@@ -1,0 +1,286 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useCallback } from "react";
+import { testIsSemVerString } from "@/types/helpers";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  getModalDataSelector,
+  selectEditorModalVisibilities,
+  selectGetDraftModComponentsForMod,
+  selectGetModDraftStateForModId,
+} from "@/pageEditor/store/editor/editorSelectors";
+import { actions as editorActions } from "@/pageEditor/store/editor/editorSlice";
+import { Button, Modal } from "react-bootstrap";
+import Form, {
+  type OnSubmit,
+  type RenderBody,
+  type RenderSubmit,
+} from "@/components/form/Form";
+import notify from "@/utils/notify";
+import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
+import * as Yup from "yup";
+import { isSingleObjectBadRequestError } from "@/errors/networkErrorHelpers";
+import { useOptionalModDefinition } from "@/modDefinitions/modDefinitionHooks";
+import ModalLayout from "@/components/ModalLayout";
+import {
+  ModalKey,
+  type ModMetadataFormState,
+} from "@/pageEditor/store/editor/pageEditorTypes";
+import { type RegistryId, type SemVerString } from "@/types/registryTypes";
+import { assertNotNullish } from "@/utils/nullishUtils";
+import useIsMounted from "@/hooks/useIsMounted";
+import { isSpecificError } from "@/errors/errorHelpers";
+import useBuildAndValidateMod, {
+  DataIntegrityError,
+} from "@/pageEditor/hooks/useBuildAndValidateMod";
+import { gt } from "semver";
+import { ensureModComponentFormStatePermissionsFromUserGesture } from "@/pageEditor/editorPermissionsHelpers";
+import {
+  isModComponentFormState,
+  mapModDefinitionUpsertResponseToModDefinition,
+} from "@/pageEditor/utils";
+import updateReduxForSavedModDefinition from "@/pageEditor/hooks/updateReduxForSavedModDefinition";
+import reportEvent from "@/telemetry/reportEvent";
+import { Events } from "@/telemetry/events";
+import { isNullOrBlank } from "@/utils/stringUtils";
+import {
+  useGetEditablePackagesQuery,
+  useUpdateModDefinitionMutation,
+} from "@/data/service/api";
+import { type AppDispatch } from "@/pageEditor/store/store";
+
+type SaveVersionFormValues = {
+  version: SemVerString;
+  message: string;
+};
+
+function useInitialFormState(modId: RegistryId): SaveVersionFormValues {
+  const getModDraftStateForModId = useSelector(selectGetModDraftStateForModId);
+  const draftState = getModDraftStateForModId(modId);
+
+  return {
+    version: draftState.modMetadata.version,
+    message: "",
+  };
+}
+
+function useFormSchema(modId: RegistryId) {
+  const { data: modDefinition } = useOptionalModDefinition(modId);
+  const serverVersion = modDefinition?.metadata.version;
+  assertNotNullish(serverVersion, "Expected version");
+
+  return Yup.object({
+    version: Yup.string()
+      .test(
+        "semver",
+        "Version must follow the X.Y.Z semantic version format, without a leading 'v'",
+        (value: string) => testIsSemVerString(value, { allowLeadingV: false }),
+      )
+      .test(
+        "increment",
+        "You must increment the version number when providing a message.",
+        (value: string, testContext) => {
+          if (
+            // Only enforce
+            isNullOrBlank(testContext.parent.message) ||
+            // Backend also performs a check
+            serverVersion == null ||
+            // Let other rule catch for better message
+            testIsSemVerString(value, { allowLeadingV: false })
+          ) {
+            return true;
+          }
+
+          return gt(value, serverVersion);
+        },
+      )
+      .required(),
+    message: Yup.string(),
+  });
+}
+
+const SaveModVersionModalBody: React.VFC<{ onHide: () => void }> = ({
+  onHide,
+}) => {
+  const dispatch = useDispatch<AppDispatch>();
+  const isMounted = useIsMounted();
+
+  const { data: editablePackages = [] } = useGetEditablePackagesQuery();
+  const [updateModDefinitionOnServer] = useUpdateModDefinitionMutation();
+
+  const getDraftModComponentsForMod = useSelector(
+    selectGetDraftModComponentsForMod,
+  );
+  const getModDraftStateForModId = useSelector(selectGetModDraftStateForModId);
+  const { buildAndValidateMod } = useBuildAndValidateMod();
+
+  const modalData = useSelector(
+    getModalDataSelector(ModalKey.SAVE_MOD_VERSION),
+  );
+  assertNotNullish(
+    modalData,
+    "SaveModVersionModalBody rendered without modal data set",
+  );
+  const { modId, sourceModDefinition } = modalData;
+
+  const formSchema = useFormSchema(modId);
+  const initialFormState = useInitialFormState(modId);
+
+  const onSubmit: OnSubmit<ModMetadataFormState> = async (values, helpers) => {
+    try {
+      const draftModComponents = getDraftModComponentsForMod(modId);
+      const draftModState = getModDraftStateForModId(modId);
+
+      await ensureModComponentFormStatePermissionsFromUserGesture(
+        draftModComponents.filter((x) => isModComponentFormState(x)),
+      );
+
+      const unsavedModDefinition = await buildAndValidateMod({
+        sourceModDefinition,
+        draftModComponents,
+        dirtyModMetadata: {
+          ...draftModState.modMetadata,
+          version: values.version,
+        },
+        dirtyModOptionsDefinition: draftModState.dirtyModOptionsDefinition,
+        dirtyModVariablesDefinition: draftModState.variablesDefinition,
+      });
+
+      const packageId = editablePackages.find(
+        // Bricks endpoint uses "name" instead of id
+        (x) => x.name === modId,
+      )?.id;
+
+      assertNotNullish(
+        packageId,
+        "Package ID is required to upsert a mod definition",
+      );
+
+      const upsertResponse = await updateModDefinitionOnServer({
+        packageId,
+        modDefinition: unsavedModDefinition,
+      }).unwrap();
+
+      await dispatch(
+        updateReduxForSavedModDefinition({
+          modIdToReplace: modId,
+          modDefinition: mapModDefinitionUpsertResponseToModDefinition(
+            unsavedModDefinition,
+            upsertResponse,
+          ),
+          draftModComponents,
+          isReactivate: true,
+        }),
+      );
+
+      reportEvent(Events.PAGE_EDITOR_MOD_UPDATE, {
+        modId,
+      });
+
+      onHide();
+    } catch (error) {
+      if (isSpecificError(error, DataIntegrityError)) {
+        dispatch(editorActions.showSaveDataIntegrityErrorModal());
+        return;
+      }
+
+      if (isSingleObjectBadRequestError(error) && error.response.data.config) {
+        helpers.setStatus(error.response.data.config);
+        return;
+      }
+
+      notify.error({
+        message: "Error saving mod",
+        error,
+      });
+    } finally {
+      if (isMounted()) {
+        helpers.setSubmitting(false);
+      }
+    }
+  };
+
+  const renderBody: RenderBody = () => (
+    <Modal.Body>
+      <ConnectedFieldTemplate
+        name="version"
+        label="Version"
+        id="save-mod-modal-version"
+        description="The new version of the mod. Must follow the MAJOR.MINOR.PATCH semantic version format."
+        showUntouchedErrors
+      />
+      <ConnectedFieldTemplate
+        name="message"
+        label="Message"
+        id="save-mod-modal-message"
+        as="textarea"
+        description="A short description of the changes to the mod. If you provide a message, you must increment the version."
+        showUntouchedErrors
+      />
+    </Modal.Body>
+  );
+
+  const renderSubmit: RenderSubmit = ({ isSubmitting, isValid }) => (
+    <Modal.Footer>
+      <Button variant="info" onClick={onHide}>
+        Cancel
+      </Button>
+      <Button
+        variant="primary"
+        type="submit"
+        disabled={!isValid || isSubmitting}
+      >
+        Save
+      </Button>
+    </Modal.Footer>
+  );
+
+  return (
+    <Form
+      validationSchema={formSchema}
+      validateOnMount
+      initialValues={initialFormState}
+      onSubmit={onSubmit}
+      renderBody={renderBody}
+      renderSubmit={renderSubmit}
+    />
+  );
+};
+
+/**
+ * Modal for saving a new version of an existing mod.
+ */
+const SaveModVersionModal: React.VFC = () => {
+  const dispatch = useDispatch();
+
+  const { isSaveModVersionModalVisible: show } = useSelector(
+    selectEditorModalVisibilities,
+  );
+
+  const hideModal = useCallback(() => {
+    dispatch(editorActions.hideModal());
+  }, [dispatch]);
+
+  return (
+    <ModalLayout title="Save Mod" show={show} onHide={hideModal}>
+      {show && <SaveModVersionModalBody onHide={hideModal} />}
+    </ModalLayout>
+  );
+};
+
+export default SaveModVersionModal;

--- a/applications/browser-extension/src/pageEditor/modListingPanel/modals/SaveModVersionModal.tsx
+++ b/applications/browser-extension/src/pageEditor/modListingPanel/modals/SaveModVersionModal.tsx
@@ -67,7 +67,19 @@ function useInitialFormState(
 ): SaveVersionFormValues {
   const modId = sourceModDefinition.metadata.id;
   const getModDraftStateForModId = useSelector(selectGetModDraftStateForModId);
-  const draftState = getModDraftStateForModId(modId);
+
+  let draftState;
+
+  try {
+    draftState = getModDraftStateForModId(modId);
+  } catch {
+    // If the user edits the mod metadata/options/variables but has not clicked into a mod component, there's a render
+    // during the mod instance reactivate where getModDraftStateForModId will throw
+    return {
+      version: sourceModDefinition.metadata.version,
+      message: "",
+    };
+  }
 
   const serverVersion = sourceModDefinition.metadata.version;
   const draftVersion = draftState.modMetadata.version;

--- a/applications/browser-extension/src/pageEditor/modListingPanel/modals/SaveModVersionModal.tsx
+++ b/applications/browser-extension/src/pageEditor/modListingPanel/modals/SaveModVersionModal.tsx
@@ -76,7 +76,10 @@ function useInitialFormState(
   return {
     version:
       draftVersion === serverVersion
-        ? patchIncrement(serverVersion)
+        ? // In the future, could be smarter here and increment major/minor version on:
+          // - Major changes: known breaking changes (e.g., a new required mod option, a new integration configuration)
+          // - Minor changes: new features, e.g., a new mod component
+          patchIncrement(serverVersion)
         : draftVersion,
     message: "",
   };

--- a/applications/browser-extension/src/pageEditor/modals/Modals.tsx
+++ b/applications/browser-extension/src/pageEditor/modals/Modals.tsx
@@ -15,18 +15,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import AddBrickModal from "@/pageEditor/modals/addBrickModal/AddBrickModal";
 import React from "react";
+import AddBrickModal from "@/pageEditor/modals/addBrickModal/AddBrickModal";
 import CreateModModal from "@/pageEditor/modListingPanel/modals/CreateModModal";
 import MoveOrCopyToModModal from "@/pageEditor/modListingPanel/modals/MoveOrCopyToModModal";
 import SaveAsNewModModal from "@/pageEditor/modListingPanel/modals/SaveAsNewModModal";
 import SaveDataIntegrityErrorModal from "@/pageEditor/panes/save/SaveDataIntegrityErrorModal";
+import SaveModVersionModal from "@/pageEditor/modListingPanel/modals/SaveModVersionModal";
 
 const Modals: React.FunctionComponent = () => (
   <>
     <MoveOrCopyToModModal />
     <SaveAsNewModModal />
     <CreateModModal />
+    <SaveModVersionModal />
     <AddBrickModal />
     <SaveDataIntegrityErrorModal />
   </>

--- a/applications/browser-extension/src/pageEditor/panes/ModEditorPane.tsx
+++ b/applications/browser-extension/src/pageEditor/panes/ModEditorPane.tsx
@@ -81,8 +81,9 @@ const ModEditorPane: React.VFC = () => {
   ];
 
   return (
-    // Only need to remount on activeModId change because the sub-tabs mount/unmount on selection and there's
-    // no Redux actions that'd update the values while the forms are mounted
+    // Only need to remount the entire layout on activeModId change (which resets the selected tab).
+    // The sub-tabs mount/unmount on selection. Individual panels should listen for modals that might invalidate
+    // their form state. For example, the SaveModVersionModal updates the mod version
     <div className={styles.root} data-testid="modEditorPane">
       <EditorTabLayout key={activeModId} tabs={tabItems} />
     </div>

--- a/applications/browser-extension/src/pageEditor/panes/save/saveHelpers.ts
+++ b/applications/browser-extension/src/pageEditor/panes/save/saveHelpers.ts
@@ -23,7 +23,6 @@ import {
 } from "@/types/registryTypes";
 import {
   isInnerDefinitionRegistryId,
-  normalizeSemVerString,
   PACKAGE_REGEX,
   validateRegistryId,
 } from "@/types/helpers";
@@ -64,6 +63,7 @@ import {
   isModComponentFormState,
 } from "@/pageEditor/utils";
 import type { Except } from "type-fest";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 /**
  * Generate a new registry id from an existing registry id by adding/replacing the scope.

--- a/applications/browser-extension/src/pageEditor/starterBricks/base.ts
+++ b/applications/browser-extension/src/pageEditor/starterBricks/base.ts
@@ -33,11 +33,7 @@ import {
 import type React from "react";
 import { createSitePattern, SITES_PATTERN } from "@/permissions/patterns";
 import { type Except } from "type-fest";
-import {
-  normalizeSemVerString,
-  uuidv4,
-  validateRegistryId,
-} from "@/types/helpers";
+import { uuidv4, validateRegistryId } from "@/types/helpers";
 import { type BrickPipeline, type ReaderConfig } from "@/bricks/types";
 import { hasInnerStarterBrickRef } from "@/registry/hydrateInnerDefinitions";
 import { normalizePipelineForEditor } from "./pipelineMapping";
@@ -64,6 +60,7 @@ import { normalizeAvailability } from "@/bricks/available";
 import { registry } from "@/background/messenger/api";
 
 import { type DraftModState } from "@/pageEditor/store/editor/pageEditorTypes";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 export interface WizardStep {
   step: string;

--- a/applications/browser-extension/src/pageEditor/store/editor/editorSelectors/editorModalSelectors.ts
+++ b/applications/browser-extension/src/pageEditor/store/editor/editorSelectors/editorModalSelectors.ts
@@ -32,6 +32,7 @@ export const selectEditorModalVisibilities = createSelector(
       isMoveCopyToModVisible: type === ModalKey.MOVE_COPY_TO_MOD,
       isSaveAsNewModModalVisible: type === ModalKey.SAVE_AS_NEW_MOD,
       isCreateModModalVisible: type === ModalKey.CREATE_MOD,
+      isSaveModVersionModalVisible: type === ModalKey.SAVE_MOD_VERSION,
       isAddBlockModalVisible: type === ModalKey.ADD_BRICK,
       isSaveDataIntegrityErrorModalVisible:
         type === ModalKey.SAVE_DATA_INTEGRITY_ERROR,

--- a/applications/browser-extension/src/pageEditor/store/editor/editorSlice.ts
+++ b/applications/browser-extension/src/pageEditor/store/editor/editorSlice.ts
@@ -73,6 +73,7 @@ import { removeUnusedDependencies } from "@/components/fields/schemaFields/integ
 import { type UUID } from "@/types/stringTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import {
+  type ModDefinition,
   type ModOptionsDefinition,
   type ModVariablesDefinition,
 } from "@/types/modDefinitionTypes";
@@ -422,6 +423,27 @@ export const editorSlice = createSlice({
       state.visibleModal = {
         type: ModalKey.SAVE_AS_NEW_MOD,
         data: {},
+      };
+    },
+
+    showSaveModVersionModal(
+      state,
+      {
+        payload,
+      }: PayloadAction<{
+        modId: RegistryId;
+        sourceModDefinition: ModDefinition;
+      }>,
+    ) {
+      const { modId, sourceModDefinition } = payload;
+
+      state.visibleModal = {
+        type: ModalKey.SAVE_MOD_VERSION,
+        data: {
+          modId,
+          // Cast required due to draft/immutable shenanigans with RJSF uiSchema
+          sourceModDefinition: sourceModDefinition as Draft<ModDefinition>,
+        },
       };
     },
 

--- a/applications/browser-extension/src/pageEditor/store/editor/editorSlice.ts
+++ b/applications/browser-extension/src/pageEditor/store/editor/editorSlice.ts
@@ -431,16 +431,16 @@ export const editorSlice = createSlice({
       {
         payload,
       }: PayloadAction<{
-        modId: RegistryId;
+        packageId: UUID;
         sourceModDefinition: ModDefinition;
       }>,
     ) {
-      const { modId, sourceModDefinition } = payload;
+      const { packageId, sourceModDefinition } = payload;
 
       state.visibleModal = {
         type: ModalKey.SAVE_MOD_VERSION,
         data: {
-          modId,
+          packageId,
           // Cast required due to draft/immutable shenanigans with RJSF uiSchema
           sourceModDefinition: sourceModDefinition as Draft<ModDefinition>,
         },

--- a/applications/browser-extension/src/pageEditor/store/editor/pageEditorTypes/index.ts
+++ b/applications/browser-extension/src/pageEditor/store/editor/pageEditorTypes/index.ts
@@ -28,7 +28,10 @@ import { type TabStateRootState } from "@/pageEditor/store/tabState/tabStateType
 import { type ModDefinitionsRootState } from "@/modDefinitions/modDefinitionsTypes";
 import { type SessionChangesRootState } from "@/store/sessionChanges/sessionChangesTypes";
 import { type SessionRootState } from "@/pageEditor/store/session/sessionSliceTypes";
-import { type ModVariablesDefinition } from "@/types/modDefinitionTypes";
+import {
+  type ModDefinition,
+  type ModVariablesDefinition,
+} from "@/types/modDefinitionTypes";
 import { type EmptyObject, type Except } from "type-fest";
 import { type OptionsArgs } from "@/types/runtimeTypes";
 import { type EditorStateMigratedV12 } from "@/pageEditor/store/editor/pageEditorTypes/editorStateMigrated";
@@ -73,6 +76,7 @@ export enum ModalKey {
   MOVE_COPY_TO_MOD,
   SAVE_AS_NEW_MOD,
   CREATE_MOD,
+  SAVE_MOD_VERSION,
   ADD_BRICK,
   SAVE_DATA_INTEGRITY_ERROR,
 }
@@ -80,6 +84,10 @@ export enum ModalKey {
 export type ModalDefinition =
   | { type: ModalKey.ADD_BRICK; data: { addBrickLocation: AddBrickLocation } }
   | { type: ModalKey.SAVE_AS_NEW_MOD; data: EmptyObject }
+  | {
+      type: ModalKey.SAVE_MOD_VERSION;
+      data: { modId: RegistryId; sourceModDefinition: ModDefinition };
+    }
   | {
       type: ModalKey.CREATE_MOD;
       data: { keepLocalCopy: boolean } & (

--- a/applications/browser-extension/src/pageEditor/store/editor/pageEditorTypes/index.ts
+++ b/applications/browser-extension/src/pageEditor/store/editor/pageEditorTypes/index.ts
@@ -86,7 +86,7 @@ export type ModalDefinition =
   | { type: ModalKey.SAVE_AS_NEW_MOD; data: EmptyObject }
   | {
       type: ModalKey.SAVE_MOD_VERSION;
-      data: { modId: RegistryId; sourceModDefinition: ModDefinition };
+      data: { packageId: UUID; sourceModDefinition: ModDefinition };
     }
   | {
       type: ModalKey.CREATE_MOD;

--- a/applications/browser-extension/src/pageEditor/tabs/modMetadata/ModMetadataEditor.tsx
+++ b/applications/browser-extension/src/pageEditor/tabs/modMetadata/ModMetadataEditor.tsx
@@ -19,6 +19,7 @@ import React, { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   selectActiveModId,
+  selectEditorModalVisibilities,
   selectModMetadataMap,
 } from "@/pageEditor/store/editor/editorSelectors";
 import { Card, Container } from "react-bootstrap";
@@ -131,6 +132,10 @@ const ModMetadataEditor: React.VoidFunctionComponent = () => {
     [dispatch],
   );
 
+  const { isSaveModVersionModalVisible } = useSelector(
+    selectEditorModalVisibilities,
+  );
+
   const renderBody: RenderBody = ({ values }) => (
     <IntegrationsSliceModIntegrationsContextAdapter>
       <Effect values={values} onChange={updateRedux} delayMillis={100} />
@@ -190,7 +195,8 @@ const ModMetadataEditor: React.VoidFunctionComponent = () => {
     <Container className={cx(styles.root, "max-750 ml-0")}>
       <AsyncStateGate state={modDefinitionQuery}>
         {() => (
-          <ErrorBoundary>
+          // Remount on save mod version modal visibility changing, because the version can be updated from the modal
+          <ErrorBoundary key={String(isSaveModVersionModalVisible)}>
             <Form
               validationSchema={editModSchema}
               initialValues={initialFormState}

--- a/applications/browser-extension/src/pageEditor/tabs/modMetadata/ModMetadataEditor.tsx
+++ b/applications/browser-extension/src/pageEditor/tabs/modMetadata/ModMetadataEditor.tsx
@@ -28,10 +28,7 @@ import Effect from "@/components/Effect";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import styles from "./ModMetadataEditor.module.scss";
 import { object, string } from "yup";
-import {
-  isInnerDefinitionRegistryId,
-  testIsSemVerString,
-} from "@/types/helpers";
+import { isInnerDefinitionRegistryId } from "@/types/helpers";
 import Form, { type RenderBody } from "@/components/form/Form";
 import Alert from "@/components/Alert";
 import { createSelector } from "@reduxjs/toolkit";
@@ -48,6 +45,7 @@ import AsyncStateGate from "@/components/AsyncStateGate";
 import { UI_PATHS } from "@/data/service/urlPaths";
 import FieldTemplate from "@/components/form/FieldTemplate";
 import { selectModInstanceMap } from "@/store/modComponents/modInstanceSelectors";
+import { testIsSemVerString } from "@/types/semVerHelpers";
 
 // TODO: This should be yup.SchemaOf<ModMetadataFormState> but we can't set the `id` property to `RegistryId`
 // see: https://github.com/jquense/yup/issues/1183#issuecomment-749186432

--- a/applications/browser-extension/src/pageEditor/tabs/modVersionHistory/ModVersionHistory.tsx
+++ b/applications/browser-extension/src/pageEditor/tabs/modVersionHistory/ModVersionHistory.tsx
@@ -71,6 +71,31 @@ function useModPackageVersionsQuery(
   }, [modId, editablePackage, packageVersionsQuery, editablePackagesQuery]);
 }
 
+const PackageVersionRow: React.VFC<{ version: PackageVersionDeprecated }> = ({
+  version,
+}) => {
+  const email = version.updated_by?.email;
+
+  return (
+    <tr>
+      <td>{version.version}</td>
+      <td>{dateFormat.format(Date.parse(version.updated_at))}</td>
+      <td>
+        {email ? (
+          <a href={`mailto:${email}`}>{email}</a>
+        ) : (
+          <span className="text-muted">Unknown</span>
+        )}
+      </td>
+      <td>
+        {version.message ?? (
+          <span className="text-muted">No message provided</span>
+        )}
+      </td>
+    </tr>
+  );
+};
+
 const ModVersionHistory: React.FC = () => {
   const modId = useSelector(selectActiveModId);
 
@@ -90,22 +115,19 @@ const ModVersionHistory: React.FC = () => {
                   <thead>
                     <tr>
                       <th>Version</th>
-                      <th>Created At</th>
+                      <th>Timestamp</th>
+                      <th>Updated By</th>
+                      <th>Message</th>
                     </tr>
                   </thead>
                   <tbody>
                     {typeof data === "object" ? (
                       data.map((version) => (
-                        <tr key={version.id}>
-                          <td>{version.version}</td>
-                          <td>
-                            {dateFormat.format(Date.parse(version.updated_at))}
-                          </td>
-                        </tr>
+                        <PackageVersionRow key={version.id} version={version} />
                       ))
                     ) : (
                       <tr>
-                        <td colSpan={2} className="text-muted">
+                        <td colSpan={4} className="text-muted">
                           {data}
                         </td>
                       </tr>

--- a/applications/browser-extension/src/platform/platformContext.ts
+++ b/applications/browser-extension/src/platform/platformContext.ts
@@ -21,7 +21,8 @@ import {
   PlatformCapabilityNotAvailableError,
 } from "@/platform/capabilities";
 import { PlatformBase } from "@/platform/platformBase";
-import { normalizeSemVerString } from "@/types/helpers";
+
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 /**
  * A platform protocol with no available capabilities.

--- a/applications/browser-extension/src/registry/packageRegistry.test.ts
+++ b/applications/browser-extension/src/registry/packageRegistry.test.ts
@@ -26,8 +26,8 @@ import { produce } from "immer";
 import { appApiMock } from "@/testUtils/appApiMock";
 import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import pDefer from "p-defer";
-import { normalizeSemVerString } from "@/types/helpers";
 import { API_PATHS } from "@/data/service/urlPaths";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 describe("localRegistry", () => {
   beforeEach(() => {

--- a/applications/browser-extension/src/runtime/pipelineTests/component.test.ts
+++ b/applications/browser-extension/src/runtime/pipelineTests/component.test.ts
@@ -21,11 +21,11 @@ import { type BrickPipeline } from "@/bricks/types";
 import { contextBrick, echoBrick, simpleInput } from "./testHelpers";
 
 import { fromJS } from "@/bricks/transformers/brickFactory";
-import { normalizeSemVerString } from "@/types/helpers";
 import { TEST_setContext } from "webext-detect";
 import { toExpression } from "@/utils/expressionUtils";
 import { DefinitionKinds } from "@/types/registryTypes";
 import { reduceOptionsFactory } from "@/testUtils/factories/runtimeFactories";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 TEST_setContext("contentScript");
 

--- a/applications/browser-extension/src/store/modComponents/modComponentMigrations.ts
+++ b/applications/browser-extension/src/store/modComponents/modComponentMigrations.ts
@@ -38,8 +38,9 @@ import { migrateIntegrationDependenciesV1toV2 } from "@/store/editorMigrations";
 import { nowTimestamp } from "@/utils/timeUtils";
 import { type Nullishable } from "@/utils/nullishUtils";
 import { type ActivatedModComponentV2 } from "@/types/modComponentTypes";
-import { normalizeSemVerString, validateRegistryId } from "@/types/helpers";
+import { validateRegistryId } from "@/types/helpers";
 import { getUserScope } from "@/auth/authUtils";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 // eslint-disable-next-line local-rules/persistBackgroundData -- This is never mutated
 const migrations: MigrationManifest = {

--- a/applications/browser-extension/src/testUtils/factories/brickFactories.ts
+++ b/applications/browser-extension/src/testUtils/factories/brickFactories.ts
@@ -23,7 +23,6 @@ import {
   registryIdSequence,
   uuidSequence,
 } from "@/testUtils/factories/stringFactories";
-import { normalizeSemVerString } from "@/types/helpers";
 import { emptyPermissionsFactory } from "@/permissions/permissionsUtils";
 import { minimalSchemaFactory } from "@/utils/schemaUtils";
 import type { BrickDefinition } from "@/bricks/transformers/brickFactory";
@@ -32,6 +31,7 @@ import type { Reader } from "@/types/bricks/readerTypes";
 import type { PackageConfigDetail } from "@/types/contract";
 import type { ModDefinition } from "@/types/modDefinitionTypes";
 import { DefinitionKinds } from "@/types/registryTypes";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 export const brickFactory = define<Brick>({
   id: registryIdSequence,

--- a/applications/browser-extension/src/testUtils/factories/databaseFactories.ts
+++ b/applications/browser-extension/src/testUtils/factories/databaseFactories.ts
@@ -27,4 +27,6 @@ export const databaseFactory = define<Database>({
   name: (n: number) => `Test Database ${n}`,
   created_at: timestampFactory,
   last_write_at: timestampFactory,
+  // TODO: change after https://github.com/pixiebrix/pixiebrix-app/pull/5981
+  kind: "Record",
 });

--- a/applications/browser-extension/src/testUtils/factories/deploymentFactories.ts
+++ b/applications/browser-extension/src/testUtils/factories/deploymentFactories.ts
@@ -23,6 +23,7 @@ import { validateRegistryId, normalizeSemVerString } from "@/types/helpers";
 import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
 import { validateTimestamp } from "@/utils/timeUtils";
+import { userSlimFactory } from "@/testUtils/factories/registryFactories";
 
 // Deployments are returned from the API, but their shape is determined by the registry and ModDefinition type.
 
@@ -31,6 +32,7 @@ const deploymentPackageFactory = define<Deployment["package"]>({
   name: "Test Starter Brick",
   version: (n: number) => normalizeSemVerString(`1.0.${n}`),
   package_id: (n: number) => validateRegistryId(`test/starter-brick-${n}`),
+  updated_by: userSlimFactory,
 });
 
 export const deploymentFactory = define<Deployment>({

--- a/applications/browser-extension/src/testUtils/factories/deploymentFactories.ts
+++ b/applications/browser-extension/src/testUtils/factories/deploymentFactories.ts
@@ -19,11 +19,12 @@ import { define, derive, type FactoryConfig } from "cooky-cutter";
 import { type Deployment } from "@/types/contract";
 import { type ActivatableDeployment } from "@/types/deploymentTypes";
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
-import { validateRegistryId, normalizeSemVerString } from "@/types/helpers";
+import { validateRegistryId } from "@/types/helpers";
 import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
 import { validateTimestamp } from "@/utils/timeUtils";
 import { userSlimFactory } from "@/testUtils/factories/registryFactories";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 // Deployments are returned from the API, but their shape is determined by the registry and ModDefinition type.
 

--- a/applications/browser-extension/src/testUtils/factories/metadataFactory.ts
+++ b/applications/browser-extension/src/testUtils/factories/metadataFactory.ts
@@ -17,7 +17,8 @@
 
 import { define } from "cooky-cutter";
 import type { VersionedMetadata } from "@/types/registryTypes";
-import { validateRegistryId, normalizeSemVerString } from "@/types/helpers";
+import { validateRegistryId } from "@/types/helpers";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 export const metadataFactory = define<VersionedMetadata>({
   id: (n: number) => validateRegistryId(`test/mod-${n}`),

--- a/applications/browser-extension/src/testUtils/factories/modViewItemFactory.ts
+++ b/applications/browser-extension/src/testUtils/factories/modViewItemFactory.ts
@@ -17,12 +17,12 @@
 
 import { define } from "cooky-cutter";
 import { type ModActionsEnabled, type ModViewItem } from "@/types/modTypes";
-import { normalizeSemVerString } from "@/types/helpers";
 import { nowTimestamp } from "@/utils/timeUtils";
 import {
   autoUUIDSequence,
   registryIdFactory,
 } from "@/testUtils/factories/stringFactories";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 export const modViewItemFactory = define<ModViewItem>({
   activatedModVersion: normalizeSemVerString("1.0.0"),

--- a/applications/browser-extension/src/testUtils/factories/registryFactories.ts
+++ b/applications/browser-extension/src/testUtils/factories/registryFactories.ts
@@ -55,6 +55,11 @@ export const editablePackageMetadataFactory = define<EditablePackageMetadata>({
   _editableBrickBrand: undefined as never,
 });
 
+export const userSlimFactory = define<PackageVersionDeprecated["updated_by"]>({
+  id: autoUUIDSequence,
+  email: (n: number) => `user${n}@example.com`,
+});
+
 /**
  * @deprecated see https://github.com/pixiebrix/pixiebrix-extension/issues/7692
  */
@@ -72,5 +77,6 @@ export const packageVersionDeprecatedFactory = define<PackageVersionDeprecated>(
     >(({ config }) => dumpBrickYaml(config), "config"),
     created_at: timestampFactory,
     updated_at: timestampFactory,
+    updated_by: userSlimFactory,
   },
 );

--- a/applications/browser-extension/src/testUtils/platformMock.ts
+++ b/applications/browser-extension/src/testUtils/platformMock.ts
@@ -21,9 +21,9 @@ import ConsoleLogger from "@/utils/ConsoleLogger";
 import type { Logger } from "@/types/loggerTypes";
 import { SimpleEventTarget } from "@/utils/SimpleEventTarget";
 import type { RunArgs } from "@/types/runtimeTypes";
-import { normalizeSemVerString } from "@/types/helpers";
 import type { ToastProtocol } from "@/platform/platformTypes/toastProtocol";
 import type { RegistryProtocol } from "@/platform/platformTypes/registryProtocol";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 /**
  * Implementation of PlatformProtocol that mocks all methods

--- a/applications/browser-extension/src/types/helpers.ts
+++ b/applications/browser-extension/src/types/helpers.ts
@@ -15,16 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { coerce as semVerCoerce, valid as semVerValid } from "semver";
-import { startsWith } from "lodash";
-
 import { type TimedSequence, type UUID } from "@/types/stringTypes";
 import { v4, validate } from "uuid";
-import {
-  INNER_SCOPE,
-  type RegistryId,
-  type SemVerString,
-} from "@/types/registryTypes";
+import { INNER_SCOPE, type RegistryId } from "@/types/registryTypes";
 
 export const PACKAGE_REGEX =
   /^((?<scope>@[\da-z~-][\d._a-z~-]*)\/)?((?<collection>[\da-z~-][\d._a-z~-]*)\/)?(?<name>[\da-z~-][\d._a-z~-]*)$/;
@@ -123,60 +116,4 @@ export function validateRegistryId(id: string | undefined): RegistryId {
   console.debug("Invalid registry id: %s", id);
 
   throw new Error("Invalid registry id");
-}
-
-/**
- * @param value The string to normalize
- * @param allowLeadingV If `true`, a leading `v` is allowed. This results in a semver string that is not actually valid
- * @param coerce If `true`, the string will be coerced to a valid semver string. See https://www.npmjs.com/package/semver#coercion
- * @returns A normalized semver string
- */
-export function normalizeSemVerString(
-  value: string,
-  // Default to `false` to be stricter.
-  {
-    allowLeadingV = false,
-    coerce = false,
-  }: { allowLeadingV?: boolean; coerce?: boolean } = {},
-): SemVerString {
-  if (value == null) {
-    // We don't have strictNullChecks on, so null values will find there way here. We should pass them along. Eventually
-    // we can remove this check as strictNullChecks will check the call site
-    return value as SemVerString;
-  }
-
-  if (testIsSemVerString(value, { allowLeadingV, coerce })) {
-    if (coerce) {
-      const coerced = semVerValid(semVerCoerce(value));
-      if (value.startsWith("v")) {
-        return `v${coerced}` as SemVerString;
-      }
-
-      return coerced as SemVerString;
-    }
-
-    return value;
-  }
-
-  console.debug("Invalid semver %s", value);
-
-  throw new TypeError("Invalid semantic version");
-}
-
-export function testIsSemVerString(
-  value: string,
-  // FIXME: the SemVerString type wasn't intended to support a leading `v`. See documentation
-  // Default to `false` to be stricter.
-  {
-    allowLeadingV = false,
-    coerce = false,
-  }: { allowLeadingV?: boolean; coerce?: boolean } = {},
-): value is SemVerString {
-  const _value = coerce ? semVerCoerce(value) : value;
-
-  if (semVerValid(_value) != null) {
-    return allowLeadingV || !startsWith(value, "v");
-  }
-
-  return false;
 }

--- a/applications/browser-extension/src/types/semVerHelpers.test.ts
+++ b/applications/browser-extension/src/types/semVerHelpers.test.ts
@@ -15,9 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { testIsSemVerString, normalizeSemVerString } from "@/types/helpers";
+import {
+  normalizeSemVerString,
+  testIsSemVerString,
+} from "@/types/semVerHelpers";
 
-describe("types/helpers.ts", () => {
+describe("semverHelpers", () => {
   describe("testIsSemVerString", () => {
     it.each([
       {

--- a/applications/browser-extension/src/types/semVerHelpers.test.ts
+++ b/applications/browser-extension/src/types/semVerHelpers.test.ts
@@ -17,190 +17,195 @@
 
 import {
   normalizeSemVerString,
+  patchIncrement,
   testIsSemVerString,
 } from "@/types/semVerHelpers";
 
-describe("semverHelpers", () => {
-  describe("testIsSemVerString", () => {
-    it.each([
-      {
-        value: "1.2.3",
-        allowLeadingV: false,
-        coerce: false,
-        expected: true,
-      },
-      {
-        value: "1.2.3",
-        allowLeadingV: true,
-        coerce: true,
-        expected: true,
-      },
-      { value: "v1.2.3", allowLeadingV: true, coerce: false, expected: true },
-      { value: "v1.2.3", allowLeadingV: true, coerce: true, expected: true },
-      { value: "v1.2.3", allowLeadingV: false, coerce: false, expected: false },
-      {
-        value: "1.2.3.4000",
-        allowLeadingV: false,
-        coerce: false,
-        expected: false,
-      },
-      {
-        value: "1.2.3.4000",
-        allowLeadingV: false,
-        coerce: true,
-        expected: true,
-      },
-      {
-        value: "v1.2.3.4000",
-        allowLeadingV: true,
-        coerce: true,
-        expected: true,
-      },
-      {
-        value: "lorem ipsum",
-        allowLeadingV: false,
-        coerce: false,
-        expected: false,
-      },
-      {
-        value: "lorem ipsum",
-        allowLeadingV: false,
-        coerce: true,
-        expected: false,
-      },
-      {
-        value: "",
-        allowLeadingV: false,
-        coerce: false,
-        expected: false,
-      },
-      {
-        value: "",
-        allowLeadingV: false,
-        coerce: true,
-        expected: false,
-      },
-      {
-        value: "vacant",
-        allowLeadingV: true,
-        coerce: false,
-        expected: false,
-      },
-      {
-        value: "vacant",
-        allowLeadingV: true,
-        coerce: true,
-        expected: false,
-      },
-    ])(
-      "$value with allowLeadingV: $allowLeadingV and coerce: $coerce returns $expected",
-      ({ value, allowLeadingV, coerce, expected }) => {
-        expect(testIsSemVerString(value, { allowLeadingV, coerce })).toBe(
-          expected,
-        );
-      },
-    );
-  });
+describe("testIsSemVerString", () => {
+  it.each([
+    {
+      value: "1.2.3",
+      allowLeadingV: false,
+      coerce: false,
+      expected: true,
+    },
+    {
+      value: "1.2.3",
+      allowLeadingV: true,
+      coerce: true,
+      expected: true,
+    },
+    { value: "v1.2.3", allowLeadingV: true, coerce: false, expected: true },
+    { value: "v1.2.3", allowLeadingV: true, coerce: true, expected: true },
+    { value: "v1.2.3", allowLeadingV: false, coerce: false, expected: false },
+    {
+      value: "1.2.3.4000",
+      allowLeadingV: false,
+      coerce: false,
+      expected: false,
+    },
+    {
+      value: "1.2.3.4000",
+      allowLeadingV: false,
+      coerce: true,
+      expected: true,
+    },
+    {
+      value: "v1.2.3.4000",
+      allowLeadingV: true,
+      coerce: true,
+      expected: true,
+    },
+    {
+      value: "lorem ipsum",
+      allowLeadingV: false,
+      coerce: false,
+      expected: false,
+    },
+    {
+      value: "lorem ipsum",
+      allowLeadingV: false,
+      coerce: true,
+      expected: false,
+    },
+    {
+      value: "",
+      allowLeadingV: false,
+      coerce: false,
+      expected: false,
+    },
+    {
+      value: "",
+      allowLeadingV: false,
+      coerce: true,
+      expected: false,
+    },
+    {
+      value: "vacant",
+      allowLeadingV: true,
+      coerce: false,
+      expected: false,
+    },
+    {
+      value: "vacant",
+      allowLeadingV: true,
+      coerce: true,
+      expected: false,
+    },
+  ])(
+    "$value with allowLeadingV: $allowLeadingV and coerce: $coerce returns $expected",
+    ({ value, allowLeadingV, coerce, expected }) => {
+      expect(testIsSemVerString(value, { allowLeadingV, coerce })).toBe(
+        expected,
+      );
+    },
+  );
+});
 
-  describe("normalizeSemVerString", () => {
-    it.each([
-      {
-        value: "1.2.3",
-        allowLeadingV: false,
-        coerce: false,
-        expected: "1.2.3",
-      },
-      {
-        value: "v1.2.3",
-        allowLeadingV: true,
-        coerce: false,
-        expected: "v1.2.3",
-      },
-      {
-        value: "1.2.3.4000",
-        allowLeadingV: false,
-        coerce: true,
-        expected: "1.2.3",
-      },
-      {
-        value: "v1.2.3.4000",
-        allowLeadingV: true,
-        coerce: true,
-        expected: "v1.2.3",
-      },
-      {
-        value: "0.0.0",
-        allowLeadingV: false,
-        coerce: false,
-        expected: "0.0.0",
-      },
-    ])(
-      "$value with allowLeadingV: $allowLeadingV and coerce: $coerce returns $expected",
-      ({ value, allowLeadingV, coerce, expected }) => {
-        expect(normalizeSemVerString(value, { allowLeadingV, coerce })).toBe(
-          expected,
-        );
-      },
-    );
+describe("normalizeSemVerString", () => {
+  it.each([
+    {
+      value: "1.2.3",
+      allowLeadingV: false,
+      coerce: false,
+      expected: "1.2.3",
+    },
+    {
+      value: "v1.2.3",
+      allowLeadingV: true,
+      coerce: false,
+      expected: "v1.2.3",
+    },
+    {
+      value: "1.2.3.4000",
+      allowLeadingV: false,
+      coerce: true,
+      expected: "1.2.3",
+    },
+    {
+      value: "v1.2.3.4000",
+      allowLeadingV: true,
+      coerce: true,
+      expected: "v1.2.3",
+    },
+    {
+      value: "0.0.0",
+      allowLeadingV: false,
+      coerce: false,
+      expected: "0.0.0",
+    },
+  ])(
+    "$value with allowLeadingV: $allowLeadingV and coerce: $coerce returns $expected",
+    ({ value, allowLeadingV, coerce, expected }) => {
+      expect(normalizeSemVerString(value, { allowLeadingV, coerce })).toBe(
+        expected,
+      );
+    },
+  );
 
-    it.each([
-      {
-        value: "v1.2.3",
-        allowLeadingV: false,
-        coerce: false,
-      },
-      {
-        value: "1.2.3.4000",
-        allowLeadingV: false,
-        coerce: false,
-      },
-      {
-        value: "v1.2.3.4000",
-        allowLeadingV: false,
-        coerce: true,
-      },
-      {
-        value: "v1.2.3.4000",
-        allowLeadingV: true,
-        coerce: false,
-      },
-      {
-        value: "lorem ipsum",
-        allowLeadingV: false,
-        coerce: false,
-      },
-      {
-        value: "lorem ipsum",
-        allowLeadingV: false,
-        coerce: true,
-      },
-      {
-        value: "",
-        allowLeadingV: false,
-        coerce: false,
-      },
-      {
-        value: "",
-        allowLeadingV: false,
-        coerce: true,
-      },
-      {
-        value: "vacant",
-        allowLeadingV: true,
-        coerce: false,
-      },
-      {
-        value: "vacant",
-        allowLeadingV: true,
-        coerce: true,
-      },
-    ])(
-      "$value with allowLeadingV: $allowLeadingV and coerce: $coerce throws an error",
-      ({ value, allowLeadingV, coerce }) => {
-        expect(() =>
-          normalizeSemVerString(value, { allowLeadingV, coerce }),
-        ).toThrow();
-      },
-    );
+  it.each([
+    {
+      value: "v1.2.3",
+      allowLeadingV: false,
+      coerce: false,
+    },
+    {
+      value: "1.2.3.4000",
+      allowLeadingV: false,
+      coerce: false,
+    },
+    {
+      value: "v1.2.3.4000",
+      allowLeadingV: false,
+      coerce: true,
+    },
+    {
+      value: "v1.2.3.4000",
+      allowLeadingV: true,
+      coerce: false,
+    },
+    {
+      value: "lorem ipsum",
+      allowLeadingV: false,
+      coerce: false,
+    },
+    {
+      value: "lorem ipsum",
+      allowLeadingV: false,
+      coerce: true,
+    },
+    {
+      value: "",
+      allowLeadingV: false,
+      coerce: false,
+    },
+    {
+      value: "",
+      allowLeadingV: false,
+      coerce: true,
+    },
+    {
+      value: "vacant",
+      allowLeadingV: true,
+      coerce: false,
+    },
+    {
+      value: "vacant",
+      allowLeadingV: true,
+      coerce: true,
+    },
+  ])(
+    "$value with allowLeadingV: $allowLeadingV and coerce: $coerce throws an error",
+    ({ value, allowLeadingV, coerce }) => {
+      expect(() =>
+        normalizeSemVerString(value, { allowLeadingV, coerce }),
+      ).toThrow();
+    },
+  );
+});
+
+describe("patchIncrement", () => {
+  it("increments the patch segment by 1", () => {
+    expect(patchIncrement(normalizeSemVerString("1.2.3"))).toBe("1.2.4");
   });
 });

--- a/applications/browser-extension/src/types/semVerHelpers.ts
+++ b/applications/browser-extension/src/types/semVerHelpers.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { SemVerString } from "@/types/registryTypes";
+import { coerce as semVerCoerce, valid as semVerValid } from "semver";
+import { startsWith } from "lodash";
+import { assertNotNullish } from "@/utils/nullishUtils";
+
+/**
+ * @param value The string to normalize
+ * @param allowLeadingV If `true`, a leading `v` is allowed. This results in a semver string that is not actually valid
+ * @param coerce If `true`, the string will be coerced to a valid semver string. See https://www.npmjs.com/package/semver#coercion
+ * @returns A normalized semver string
+ */
+export function normalizeSemVerString(
+  value: string,
+  // Default to `false` to be stricter.
+  {
+    allowLeadingV = false,
+    coerce = false,
+  }: { allowLeadingV?: boolean; coerce?: boolean } = {},
+): SemVerString {
+  if (value == null) {
+    // We don't have strictNullChecks on, so null values will find there way here. We should pass them along. Eventually
+    // we can remove this check as strictNullChecks will check the call site
+    return value as SemVerString;
+  }
+
+  if (testIsSemVerString(value, { allowLeadingV, coerce })) {
+    if (coerce) {
+      const coerced = semVerValid(semVerCoerce(value));
+      if (value.startsWith("v")) {
+        return `v${coerced}` as SemVerString;
+      }
+
+      return coerced as SemVerString;
+    }
+
+    return value;
+  }
+
+  console.debug("Invalid semver %s", value);
+
+  throw new TypeError("Invalid semantic version");
+}
+
+export function testIsSemVerString(
+  value: string,
+  {
+    // FIXME: the SemVerString type wasn't intended to support a leading `v`. See documentation
+    // Default to `false` to be stricter.
+    allowLeadingV = false,
+    // Default to `false` to be stricter.
+    coerce = false,
+  }: { allowLeadingV?: boolean; coerce?: boolean } = {},
+): value is SemVerString {
+  const _value = coerce ? semVerCoerce(value) : value;
+
+  // FIXME: semVerValid allows pre-release and build metadata. That shouldn't supported in our SemVerString type.
+  if (semVerValid(_value) != null) {
+    return allowLeadingV || !startsWith(value, "v");
+  }
+
+  return false;
+}
+
+/**
+ * Returns a new semver string with the patch segment incremented by 1
+ */
+export function patchIncrement(semVer: SemVerString): SemVerString {
+  const [major, minor, patch] = normalizeSemVerString(semVer).split(".");
+  assertNotNullish(patch, "Invalid SemVerString");
+  return normalizeSemVerString(
+    `${major}.${minor}.${Number.parseInt(patch, 10) + 1}`,
+  );
+}

--- a/applications/browser-extension/src/types/swagger.ts
+++ b/applications/browser-extension/src/types/swagger.ts
@@ -282,6 +282,38 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/databases/{database_pk}/assets/": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["listAssets"];
+    put?: never;
+    post: operations["createAssetPreUpload"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/databases/{database_pk}/assets/{id}/": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["retrieveAsset"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch: operations["partialUpdateAsset"];
+    trace?: never;
+  };
   "/api/databases/{database_pk}/references/": {
     parameters: {
       query?: never;
@@ -970,6 +1002,38 @@ export interface paths {
     put?: never;
     post?: never;
     delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/organizations/{organization_pk}/serviceaccounts/": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["listServiceAccounts"];
+    put?: never;
+    post: operations["createServiceAccountWithToken"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/organizations/{organization_pk}/serviceaccounts/{id}/": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["retrieveServiceAccount"];
+    put?: never;
+    post?: never;
+    delete: operations["destroyServiceAccount"];
     options?: never;
     head?: never;
     patch?: never;
@@ -2003,8 +2067,13 @@ export interface components {
       actor: {
         /** Format: uuid */
         readonly id?: UUID;
+        readonly name?: string;
         /** Format: email */
         email?: string;
+        readonly service_account?: boolean;
+        readonly deployment_key_account?: boolean;
+        /** Format: date-time */
+        date_joined?: Timestamp;
       };
       target_object: {
         id: string;
@@ -2118,6 +2187,7 @@ export interface components {
       /** @default false */
       public: boolean;
       organizations?: string[];
+      message?: string;
       /** Format: date-time */
       readonly updated_at?: Timestamp;
       /** @description Human-readable name */
@@ -2133,6 +2203,14 @@ export interface components {
       readonly created_at?: Timestamp;
       /** Format: date-time */
       updated_at?: Timestamp;
+      updated_by: {
+        /** Format: uuid */
+        readonly id?: UUID;
+        /** Format: email */
+        email?: string;
+      };
+      /** @description Optional commit/changelog message for version */
+      message?: string;
     };
     Database: {
       /** Format: uuid */
@@ -2146,6 +2224,11 @@ export interface components {
       /** @description Field indicating the record owner */
       owner_field?: string | null;
       user?: string;
+      /**
+       * @default Record
+       * @enum {string}
+       */
+      kind: "Record" | "Asset";
       /** Format: date-time */
       readonly last_write_at?: Timestamp;
       readonly num_records?: number;
@@ -2178,6 +2261,20 @@ export interface components {
       /** Format: date-time */
       readonly created_at?: Timestamp;
     };
+    Asset: {
+      /** Format: uuid */
+      readonly id?: UUID;
+      /** Format: uri */
+      readonly download_url?: string;
+      /** @description The original filename. Note this is different than the cloud storage filename. */
+      filename?: string;
+      /** @description True if the file is uploaded to cloud storage */
+      is_uploaded?: boolean;
+      /** Format: date-time */
+      readonly created_at?: Timestamp;
+      /** Format: date-time */
+      readonly updated_at?: Timestamp;
+    };
     Deployment: {
       /** Format: uuid */
       readonly id?: UUID;
@@ -2197,6 +2294,14 @@ export interface components {
         readonly created_at?: Timestamp;
         /** Format: date-time */
         updated_at?: Timestamp;
+        updated_by: {
+          /** Format: uuid */
+          readonly id?: UUID;
+          /** Format: email */
+          email?: string;
+        };
+        /** @description Optional commit/changelog message for version */
+        message?: string;
       };
       package_version: string;
       user?: string;
@@ -2233,6 +2338,11 @@ export interface components {
       /** @description Field indicating the record owner */
       owner_field?: string | null;
       user?: string;
+      /**
+       * @default Record
+       * @enum {string}
+       */
+      kind: "Record" | "Asset";
       /** Format: date-time */
       readonly last_write_at?: Timestamp;
       readonly num_records?: number;
@@ -2300,6 +2410,14 @@ export interface components {
         readonly created_at?: Timestamp;
         /** Format: date-time */
         updated_at?: Timestamp;
+        updated_by: {
+          /** Format: uuid */
+          readonly id?: UUID;
+          /** Format: email */
+          email?: string;
+        };
+        /** @description Optional commit/changelog message for version */
+        message?: string;
       };
       readonly bindings?: {
         /** Format: uuid */
@@ -2402,7 +2520,11 @@ export interface components {
       last_occurrence_timestamp: Timestamp;
       message: string;
       occurrence_count: number;
-      people_count: number;
+      users: {
+        /** Format: uuid */
+        id: UUID;
+        email: string;
+      }[];
       step_label: string | null;
       user_agent_extension_version: string;
     };
@@ -2461,7 +2583,7 @@ export interface components {
         readonly updated_at?: Timestamp;
       }[];
       /** Format: date-time */
-      readonly last_active_at?: Timestamp;
+      readonly last_active_at?: Timestamp | null;
     };
     GroupPackagePermission: {
       /** Format: uuid */
@@ -2776,6 +2898,8 @@ export interface components {
         /** Format: date-time */
         readonly created_at?: Timestamp;
       }[];
+      /** Format: date-time */
+      readonly last_active_at?: Timestamp | null;
     };
     Organization: {
       /** Format: uuid */
@@ -2801,6 +2925,8 @@ export interface components {
           id: UUID;
           name: string;
         }[];
+        /** Format: date-time */
+        readonly last_active_at?: Timestamp | null;
       }[];
       scope?: string | null;
       /** @enum {integer} */
@@ -2850,6 +2976,23 @@ export interface components {
         /** @enum {integer} */
         role: 1 | 2 | 3 | 4 | 5;
       };
+    };
+    ServiceAccount: {
+      /** Format: uuid */
+      readonly id?: UUID;
+      name: string;
+      /**
+       * @default 4
+       * @enum {integer}
+       */
+      role: 1 | 2 | 3 | 4 | 5;
+      /** Format: date-time */
+      created_at?: Timestamp;
+      /**
+       * Format: date-time
+       * @description The last time the user was active. Currently only set for service accounts.
+       */
+      last_active_at?: Timestamp | null;
     };
     DeploymentKey: {
       /** Format: uuid */
@@ -3174,6 +3317,25 @@ export interface components {
         [key: string]: unknown;
       };
     };
+    AssetPreUpload: {
+      asset: {
+        /** Format: uuid */
+        readonly id?: UUID;
+        /** Format: uri */
+        readonly download_url?: string;
+        /** @description The original filename. Note this is different than the cloud storage filename. */
+        filename?: string;
+        /** @description True if the file is uploaded to cloud storage */
+        is_uploaded?: boolean;
+        /** Format: date-time */
+        readonly created_at?: Timestamp;
+        /** Format: date-time */
+        readonly updated_at?: Timestamp;
+      };
+      /** Format: uri */
+      upload_url: string;
+      fields: string;
+    };
     DeploymentMessage: {
       /** Format: email */
       recipient: string;
@@ -3205,6 +3367,24 @@ export interface components {
       } | null;
     };
     Onboarding: Record<string, never>;
+    ServiceAccountWithToken: {
+      /** Format: uuid */
+      readonly id?: UUID;
+      name: string;
+      /**
+       * @default 4
+       * @enum {integer}
+       */
+      role: 1 | 2 | 3 | 4 | 5;
+      /** Format: date-time */
+      created_at?: Timestamp;
+      /**
+       * Format: date-time
+       * @description The last time the user was active. Currently only set for service accounts.
+       */
+      last_active_at?: Timestamp | null;
+      readonly token?: string;
+    };
     ProvisionedAccount: {
       /** Format: email */
       email: string;
@@ -3276,129 +3456,14 @@ export interface components {
       readonly created_at?: Timestamp;
       /** Format: date-time */
       updated_at?: Timestamp;
-    };
-    MeV1_0: {
-      readonly flags?: string[];
-      /** Format: uuid */
-      readonly id?: UUID;
-      scope?: string | null;
-      /** Format: email */
-      email?: string;
-      readonly name?: string;
-      readonly organization?: {
+      updated_by: {
         /** Format: uuid */
         readonly id?: UUID;
-        name: string;
-        scope?: string | null;
-        readonly is_enterprise?: boolean;
-        readonly control_room?: {
-          /** Format: uuid */
-          readonly id?: UUID;
-          /**
-           * Format: uri
-           * @description The Control Room URL
-           */
-          url: string;
-        };
-        readonly theme?: {
-          show_sidebar_logo?: boolean;
-          /**
-           * Format: uri
-           * @description The image URL of a custom logo. Image format must be SVG or PNG.
-           */
-          logo?: string | null;
-          /**
-           * Format: uri
-           * @description The image URL of the icon displayed in the browser toolbar. Image format must be PNG.
-           */
-          toolbar_icon?: string | null;
-        };
+        /** Format: email */
+        email?: string;
       };
-      readonly organization_memberships?: {
-        /** Format: uuid */
-        organization: UUID;
-        organization_name: string;
-        /** @enum {integer} */
-        role: 1 | 2 | 3 | 4 | 5;
-        scope: string | null;
-        /** @description True if user is a manager of one or more team deployments */
-        readonly is_deployment_manager?: boolean;
-        control_room: {
-          /** Format: uuid */
-          readonly id?: UUID;
-          /**
-           * Format: uri
-           * @description The Control Room URL
-           */
-          url: string;
-        };
-      }[];
-      readonly group_memberships?: {
-        /** Format: uuid */
-        id: UUID;
-        name: string;
-      }[];
-      readonly partner_principals?: {
-        /**
-         * Format: int64
-         * @description AA unique identifier used to interact with the Control Room user via the AA API
-         */
-        control_room_user_id: number;
-        /** Format: uri */
-        readonly control_room_url?: string;
-      }[];
-      readonly is_onboarded?: boolean;
-      readonly milestones?: {
-        key: string;
-        /** @description Optional additional information to provide context about the Milestone. */
-        metadata?: {
-          [key: string]: unknown;
-        } | null;
-      }[];
-      /** @description True if the account is an organization API service account */
-      service_account?: boolean;
-      /** @description True if the account is an organization API deployment key account */
-      deployment_key_account?: boolean;
-      /** @description True if the account is an automated/manual test account */
-      test_account?: boolean;
-      readonly partner?: {
-        /** Format: uuid */
-        readonly id?: UUID;
-        name: string;
-        readonly theme?: string;
-        /** Format: uri */
-        documentation_url?: string | null;
-      };
-      readonly enforce_update_millis?: number;
-      readonly telemetry_organization?: {
-        /** Format: uuid */
-        readonly id?: UUID;
-        name: string;
-        scope?: string | null;
-        readonly is_enterprise?: boolean;
-        readonly control_room?: {
-          /** Format: uuid */
-          readonly id?: UUID;
-          /**
-           * Format: uri
-           * @description The Control Room URL
-           */
-          url: string;
-        };
-        readonly theme?: {
-          show_sidebar_logo?: boolean;
-          /**
-           * Format: uri
-           * @description The image URL of a custom logo. Image format must be SVG or PNG.
-           */
-          logo?: string | null;
-          /**
-           * Format: uri
-           * @description The image URL of the icon displayed in the browser toolbar. Image format must be PNG.
-           */
-          toolbar_icon?: string | null;
-        };
-      };
+      /** @description Optional commit/changelog message for version */
+      message?: string;
     };
   };
   responses: never;
@@ -4182,6 +4247,118 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+    };
+  };
+  listAssets: {
+    parameters: {
+      query?: {
+        /** @description A page number within the paginated result set. */
+        page?: number;
+        /** @description Number of results to return per page. */
+        page_size?: number;
+      };
+      header?: never;
+      path: {
+        database_pk: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          /**
+           * @description See https://datatracker.ietf.org/doc/html/rfc8288 for more information.
+           * @example &lt;https://app.pixiebrix.com/api/databases/{database_pk}/assets/&gt;; rel=&quot;first&quot;, &lt;https://app.pixiebrix.com/api/databases/{database_pk}/assets/?page=3&gt;; rel=&quot;prev&quot;, &lt;https://app.pixiebrix.com/api/databases/{database_pk}/assets/?page=5&gt;; rel=&quot;next&quot;, &lt;https://app.pixiebrix.com/api/databases/{database_pk}/assets/?page=11&gt;; rel=&quot;last&quot;
+           */
+          Link?: unknown;
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json; version=2.0": components["schemas"]["Asset"][];
+          "application/vnd.pixiebrix.api+json; version=2.0": components["schemas"]["Asset"][];
+        };
+      };
+    };
+  };
+  createAssetPreUpload: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        database_pk: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": components["schemas"]["AssetPreUpload"];
+        "application/x-www-form-urlencoded": components["schemas"]["AssetPreUpload"];
+        "multipart/form-data": components["schemas"]["AssetPreUpload"];
+      };
+    };
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json; version=2.0": components["schemas"]["AssetPreUpload"];
+          "application/vnd.pixiebrix.api+json; version=2.0": components["schemas"]["AssetPreUpload"];
+        };
+      };
+    };
+  };
+  retrieveAsset: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        database_pk: string;
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json; version=2.0": components["schemas"]["Asset"];
+          "application/vnd.pixiebrix.api+json; version=2.0": components["schemas"]["Asset"];
+        };
+      };
+    };
+  };
+  partialUpdateAsset: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        database_pk: string;
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": components["schemas"]["Asset"];
+        "application/x-www-form-urlencoded": components["schemas"]["Asset"];
+        "multipart/form-data": components["schemas"]["Asset"];
+      };
+    };
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json; version=2.0": components["schemas"]["Asset"];
+          "application/vnd.pixiebrix.api+json; version=2.0": components["schemas"]["Asset"];
+        };
       };
     };
   };
@@ -6340,6 +6517,109 @@ export interface operations {
           "application/json; version=1.0": components["schemas"]["UserDetail"];
           "application/vnd.pixiebrix.api+json; version=1.0": components["schemas"]["UserDetail"];
         };
+      };
+    };
+  };
+  listServiceAccounts: {
+    parameters: {
+      query?: {
+        /** @description A page number within the paginated result set. */
+        page?: number;
+        /** @description Number of results to return per page. */
+        page_size?: number;
+      };
+      header?: never;
+      path: {
+        organization_pk: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          /**
+           * @description See https://datatracker.ietf.org/doc/html/rfc8288 for more information.
+           * @example &lt;https://app.pixiebrix.com/api/organizations/{organization_pk}/serviceaccounts/&gt;; rel=&quot;first&quot;, &lt;https://app.pixiebrix.com/api/organizations/{organization_pk}/serviceaccounts/?page=3&gt;; rel=&quot;prev&quot;, &lt;https://app.pixiebrix.com/api/organizations/{organization_pk}/serviceaccounts/?page=5&gt;; rel=&quot;next&quot;, &lt;https://app.pixiebrix.com/api/organizations/{organization_pk}/serviceaccounts/?page=11&gt;; rel=&quot;last&quot;
+           */
+          Link?: unknown;
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json; version=2.0": components["schemas"]["ServiceAccount"][];
+          "application/vnd.pixiebrix.api+json; version=2.0": components["schemas"]["ServiceAccount"][];
+        };
+      };
+    };
+  };
+  createServiceAccountWithToken: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        organization_pk: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": components["schemas"]["ServiceAccountWithToken"];
+        "application/x-www-form-urlencoded": components["schemas"]["ServiceAccountWithToken"];
+        "multipart/form-data": components["schemas"]["ServiceAccountWithToken"];
+      };
+    };
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json; version=2.0": components["schemas"]["ServiceAccountWithToken"];
+          "application/vnd.pixiebrix.api+json; version=2.0": components["schemas"]["ServiceAccountWithToken"];
+        };
+      };
+    };
+  };
+  retrieveServiceAccount: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        organization_pk: string;
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json; version=2.0": components["schemas"]["ServiceAccount"];
+          "application/vnd.pixiebrix.api+json; version=2.0": components["schemas"]["ServiceAccount"];
+        };
+      };
+    };
+  };
+  destroyServiceAccount: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        organization_pk: string;
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };

--- a/applications/browser-extension/src/utils/deploymentUtils.test.ts
+++ b/applications/browser-extension/src/utils/deploymentUtils.test.ts
@@ -23,11 +23,7 @@ import {
   mergeDeploymentIntegrationDependencies,
   selectActivatedDeployments,
 } from "./deploymentUtils";
-import {
-  uuidv4,
-  validateRegistryId,
-  normalizeSemVerString,
-} from "@/types/helpers";
+import { uuidv4, validateRegistryId } from "@/types/helpers";
 import { type SanitizedIntegrationConfig } from "@/integrations/integrationTypes";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
 import {
@@ -52,6 +48,7 @@ import {
   teamDeploymentMetadataFactory,
 } from "@/testUtils/factories/modInstanceFactories";
 import { mapActivatedModComponentsToModInstance } from "@/store/modComponents/modInstanceUtils";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 describe("makeUpdatedFilter", () => {
   test.each([[{ restricted: true }, { restricted: false }]])(

--- a/applications/browser-extension/src/utils/deploymentUtils.ts
+++ b/applications/browser-extension/src/utils/deploymentUtils.ts
@@ -24,13 +24,14 @@ import {
   type IntegrationDependency,
   type SanitizedIntegrationConfig,
 } from "@/integrations/integrationTypes";
-import { normalizeSemVerString, validateUUID } from "@/types/helpers";
+import { validateUUID } from "@/types/helpers";
 import { type Except } from "type-fest";
 import { PIXIEBRIX_INTEGRATION_ID } from "@/integrations/constants";
 import getUnconfiguredComponentIntegrations from "@/integrations/util/getUnconfiguredComponentIntegrations";
 import type { ActivatableDeployment } from "@/types/deploymentTypes";
 import { getExtensionVersion } from "@/utils/extensionUtils";
 import type { ModInstance } from "@/types/modInstanceTypes";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 /**
  * Returns `true` if a managed deployment is active (i.e., has not been remotely paused by an admin)

--- a/applications/browser-extension/src/utils/extensionUtils.ts
+++ b/applications/browser-extension/src/utils/extensionUtils.ts
@@ -20,8 +20,8 @@ import { foreverPendingPromise } from "@/utils/promiseUtils";
 import { type Promisable } from "type-fest";
 import { isScriptableUrl } from "webext-content-scripts";
 import { type Runtime } from "webextension-polyfill";
-import { normalizeSemVerString } from "@/types/helpers";
 import { type SemVerString } from "@/types/registryTypes";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 export const SHORTCUTS_URL = "chrome://extensions/shortcuts";
 type Command = "toggle-quick-bar";

--- a/applications/browser-extension/src/utils/modUtils.ts
+++ b/applications/browser-extension/src/utils/modUtils.ts
@@ -50,14 +50,11 @@ import { isStarterBrickDefinitionLike } from "@/starterBricks/types";
 import { normalizeStarterBrickDefinitionProp } from "@/starterBricks/starterBrickUtils";
 import { type MessageContext } from "@/types/loggerTypes";
 import { type SetRequired } from "type-fest";
-import {
-  normalizeSemVerString,
-  uuidv4,
-  validateRegistryId,
-} from "@/types/helpers";
+import { uuidv4, validateRegistryId } from "@/types/helpers";
 import { nowTimestamp } from "@/utils/timeUtils";
 import { type ModInstance } from "@/types/modInstanceTypes";
 import { createPrivateSharing } from "@/utils/registryUtils";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 /**
  * Returns the ModComponentRef for a given mod component.

--- a/applications/browser-extension/src/utils/objToYaml.test.ts
+++ b/applications/browser-extension/src/utils/objToYaml.test.ts
@@ -16,8 +16,8 @@
  */
 
 import { brickToYaml } from "./objToYaml";
-import { normalizeSemVerString } from "@/types/helpers";
 import { DefinitionKinds } from "@/types/registryTypes";
+import { normalizeSemVerString } from "@/types/semVerHelpers";
 
 describe("brickToYaml", () => {
   test("serializes arbitrary object", () => {


### PR DESCRIPTION
## What does this PR do?

- Part of #9433 
- Shows mod commit message modal on save:
  - If you haven't changed the version yet, it automatically bumps patch number 
  - Otherwise, modal uses the version you changed in the mod metadata form
  - Message is now required on the front-end in the Page Editor, but not the backend
- Refactoring
  - Extract semVerHelpers to own file. If needed, I can move that to a separate PR and stack
- Playwright Updates
  - Had to update all the snapshots to account for version updates

## Discussion

- Providing a message is required in the front-end, but not the backend
- @fungairino @mnholtz is an increase in the number of versions saved a problem (e.g., for test cleanup)?

## Demo

https://www.loom.com/share/9112b6619b5e46d6b9094936928c248c?sid=a64aedf2-c9fe-4bc0-9f01-0b8f3b15aaa3

![image](https://github.com/user-attachments/assets/e2f9a931-4448-4f41-802d-778feb5ac5b6)

## Remaining Work

- [x] Fix client-side validation
- [x] Update Jest tests
- [x] Swap in RTK code endpoint code when ready
- [x] Update/fix Playwright tests
- [x] Fix bug where mod metadata form doesn't immediately reinitialize/mount on save to reflect the incremented version number: this comment is now not true: https://github.com/pixiebrix/pixiebrix-extension/blob/c2fb6c967ed12bcbf8baef24c8e1f22f3797aa78/applications/browser-extension/src/pageEditor/panes/ModEditorPane.tsx#L87-L87

## Future Work

- Migrate the Version History table to Paginated Table (cleanup in next slice): https://github.com/pixiebrix/pixiebrix-extension/pull/9527
- See note on `testIsSemVerString` allowing pre-release and build metadata. `1.2.3-beta.1+321` passes the check. (Would be rejected server-side though)
- Playwright run mode to update all snapshots. The tests with multiple snapshots are tedious to update

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
