### PR TITLE
Only upload the dist directory to AWS

### DIFF
--- a/applications/browser-extension/scripts/upload-extension.sh
+++ b/applications/browser-extension/scripts/upload-extension.sh
@@ -17,6 +17,7 @@ BUILD_FILENAME="${BUILD_PATH##*/}"
 : "${AWS_SECRET_ACCESS_KEY?Need to set AWS_SECRET_ACCESS_KEY}"
 : "${AWS_DEFAULT_REGION?Need to set AWS_DEFAULT_REGION}"
 
+# Ensure we only zip up the dist dir (exclude the applications and browser-extension directories)
 cd applications/browser-extension
 zip -r "../../$BUILD_FILENAME" dist -x '*.map'
 cd -

--- a/applications/browser-extension/scripts/upload-extension.sh
+++ b/applications/browser-extension/scripts/upload-extension.sh
@@ -17,5 +17,8 @@ BUILD_FILENAME="${BUILD_PATH##*/}"
 : "${AWS_SECRET_ACCESS_KEY?Need to set AWS_SECRET_ACCESS_KEY}"
 : "${AWS_DEFAULT_REGION?Need to set AWS_DEFAULT_REGION}"
 
-zip -r "$BUILD_FILENAME" applications/browser-extension/dist -x '*.map'
+cd applications/browser-extension
+zip -r "../../$BUILD_FILENAME" dist -x '*.map'
+cd -
+
 aws s3 cp "$BUILD_FILENAME" "s3://pixiebrix-extension-builds/$BUILD_PATH" --no-progress


### PR DESCRIPTION
## What does this PR do?

-  Prevents zipping the full `/applications/browser-extension/dist` path
- Fixes [Rainforest failures](https://app.rainforestqa.com/runs/1992118)

## Discussion

- Considered `pushd` and `popd` instead of `cd`, but wasn't certain it was guaranteed to be available (sh vs bash)

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
