### PR TITLE
#9430: tsconfig references refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           node-version-file: applications/browser-extension/package.json
           cache: npm
       - run: npm ci
-      - run: npm run build:webpack --workspace=applications/browser-extension
+      - run: npm run build
         env:
           MV: 3
           RELEASE_CHANNEL: stable
@@ -151,7 +151,7 @@ jobs:
           node-version-file: applications/browser-extension/package.json
           cache: npm
       - run: npm ci
-      - run: npm run build:typecheck --workspaces
+      - run: npm run build:typecheck
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -68,7 +68,7 @@ jobs:
           attempt_delay: 15000
           attempt_limit: 40
       - name: Build the extension
-        run: npm run build:webpack --workspace=applications/browser-extension
+        run: npm run build
       - name: Run end to end tests
         # Xvfb is required to run the tests in headed mode. Headed mode is required to run tests for browser extensions
         # in Playwright, see https://playwright.dev/docs/ci#running-headed

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ browsers/dist
 dist
 .transpiled
 web-ext-artifacts
+*.tsbuildinfo
 
 # Other artifacts
 artifacts

--- a/applications/browser-extension/tsconfig.json
+++ b/applications/browser-extension/tsconfig.json
@@ -13,8 +13,8 @@
     "plugins": [{ "name": "typescript-plugin-css-modules" }]
   },
   "references": [
-    // UPDATED BY NX SYNC
     // All project dependencies
+    // TODO: add @nx/js plugin which will automatically update these paths
     {
       "path": "../../libraries/utils"
     }

--- a/applications/browser-extension/tsconfig.json
+++ b/applications/browser-extension/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": ".",
     "composite": false,
     "declaration": false,
+    "noEmit": true,
     "paths": {
       "@/*": ["src/*"],
       "@img/*": ["img/*"],

--- a/applications/browser-extension/tsconfig.json
+++ b/applications/browser-extension/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
+    "composite": false,
+    "declaration": false,
     "paths": {
       "@/*": ["src/*"],
       "@img/*": ["img/*"],
@@ -10,5 +12,12 @@
     },
     "plugins": [{ "name": "typescript-plugin-css-modules" }]
   },
+  "references": [
+    // UPDATED BY NX SYNC
+    // All project dependencies
+    {
+      "path": "../../libraries/utils"
+    }
+  ],
   "exclude": ["venv", "dist", "node_modules"]
 }

--- a/knip.mjs
+++ b/knip.mjs
@@ -36,7 +36,7 @@ const knipConfig = {
       ],
     },
     "libraries/*": {
-      entry: "src/*.ts",
+      entry: "src/*.ts!",
       project: "**/*.ts",
     },
     "applications/browser-extension": {

--- a/knip.mjs
+++ b/knip.mjs
@@ -35,6 +35,10 @@ const knipConfig = {
         "prettier",
       ],
     },
+    "libraries/*": {
+      entry: "src/*.ts",
+      project: "**/*.ts",
+    },
     "applications/browser-extension": {
       entry: [
         // ! suffix files are included in production mode

--- a/libraries/utils/.eslintrc.js
+++ b/libraries/utils/.eslintrc.js
@@ -1,10 +1,24 @@
 module.exports = {
   root: true,
-  extends: [
-    // Full config: https://github.com/pixiebrix/eslint-config-pixiebrix/blob/main/index.js
-    // XXX: use exact configuration for now because applications/browser-extension has a lot of local configuration.
-    // When we bring eslint-config-pixiebrix into the monorepo, we can iterate on code sharing across configs.
-    "pixiebrix",
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
+  overrides: [
+    {
+      files: ["**/*.ts", "**/*.tsx"],
+      extends: [
+        // Full config: https://github.com/pixiebrix/eslint-config-pixiebrix/blob/main/index.js
+        // XXX: use exact configuration for now because applications/browser-extension has a lot of local configuration.
+        // When we bring eslint-config-pixiebrix into the monorepo, we can iterate on code sharing across configs.
+        "pixiebrix",
+      ],
+
+      parserOptions: {
+        // Use the nearest tsconfig.json in its directory
+        // See https://typescript-eslint.io/blog/parser-options-project-true/#introducing-true
+        project: ["./tsconfig.*?.json"],
+        tsconfigRootDir: __dirname,
+      },
+    },
   ],
 };
 

--- a/libraries/utils/.eslintrc.js
+++ b/libraries/utils/.eslintrc.js
@@ -1,7 +1,5 @@
 module.exports = {
   root: true,
-  parser: "@typescript-eslint/parser",
-  plugins: ["@typescript-eslint"],
   overrides: [
     {
       files: ["**/*.ts", "**/*.tsx"],

--- a/libraries/utils/.eslintrc.js
+++ b/libraries/utils/.eslintrc.js
@@ -11,8 +11,6 @@ module.exports = {
       ],
 
       parserOptions: {
-        // Use the nearest tsconfig.json in its directory
-        // See https://typescript-eslint.io/blog/parser-options-project-true/#introducing-true
         project: ["./tsconfig.*?.json"],
         tsconfigRootDir: __dirname,
       },

--- a/libraries/utils/package.json
+++ b/libraries/utils/package.json
@@ -6,7 +6,7 @@
     "test": "TZ=UTC jest",
     "lint": "eslint src --ext js,jsx,ts,tsx --quiet --report-unused-disable-directives",
     "lint:fast": "ESLINT_NO_IMPORTS=1 eslint src --ext js,jsx,ts,tsx --quiet",
-    "build": "echo 'buildless package'",
+    "build": "tsc --build",
     "build:typecheck": "tsc --noEmit"
   },
   "license": "AGPL-3.0",

--- a/libraries/utils/package.json
+++ b/libraries/utils/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint src --ext js,jsx,ts,tsx --quiet --report-unused-disable-directives",
     "lint:fast": "ESLINT_NO_IMPORTS=1 eslint src --ext js,jsx,ts,tsx --quiet",
     "build": "tsc --build",
-    "build:typecheck": "tsc --noEmit"
+    "build:typecheck": "tsc --build"
   },
   "license": "AGPL-3.0",
   "repository": "https://github.com/pixiebrix/pixiebrix-extension",

--- a/libraries/utils/src/debugUtils.test.ts
+++ b/libraries/utils/src/debugUtils.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { getInvalidPath } from "@/debugUtils";
+import { getInvalidPath } from "./debugUtils";
 
 describe("getInvalidPath", () => {
   it("returns invalid path", () => {

--- a/libraries/utils/src/debugUtils.ts
+++ b/libraries/utils/src/debugUtils.ts
@@ -43,7 +43,7 @@ export function getInvalidPath(
     }
   }
 
-  throw new Error("Expected invalid path");
+  return { invalidPath: "", values: {} };
 }
 
 /**

--- a/libraries/utils/src/debugUtils.ts
+++ b/libraries/utils/src/debugUtils.ts
@@ -43,7 +43,7 @@ export function getInvalidPath(
     }
   }
 
-  return { invalidPath: "", values: {} };
+  throw new Error("Expected invalid path");
 }
 
 /**

--- a/libraries/utils/tsconfig.json
+++ b/libraries/utils/tsconfig.json
@@ -1,9 +1,13 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
     }
-  }
+  ]
 }

--- a/libraries/utils/tsconfig.lib.json
+++ b/libraries/utils/tsconfig.lib.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": [],
+  "exclude": [
+    "jest.config.ts",
+    "jest.config.js",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/libraries/utils/tsconfig.lib.json
+++ b/libraries/utils/tsconfig.lib.json
@@ -8,7 +8,7 @@
     "emitDeclarationOnly": false,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
   "references": [],
   "exclude": [
     "jest.config.ts",

--- a/libraries/utils/tsconfig.test.json
+++ b/libraries/utils/tsconfig.test.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc/libraries/utils",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "jest.config.js",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/nx.json
+++ b/nx.json
@@ -10,6 +10,7 @@
       "cache": true
     },
     "lint": {
+      "dependsOn": ["^build:typecheck"],
       "cache": true
     },
     "build:typecheck": {

--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,7 @@
   "targetDefaults": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["{projectRoot}/dist"],
+      "outputs": ["{workspaceRoot}/dist"],
       "cache": true
     },
     "test": {

--- a/nx.json
+++ b/nx.json
@@ -13,6 +13,7 @@
       "cache": true
     },
     "build:typecheck": {
+      "dependsOn": ["^build:typecheck"],
       "cache": true
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "concurrently": "^9.1.0",
         "knip": "^5.36.7",
         "nx": "20.1.0",
-        "prettier": "3.3.3"
+        "prettier": "3.3.3",
+        "typescript": "^5.6.3"
       },
       "engines": {
         "node": "20.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       ],
       "devDependencies": {
         "@sindresorhus/tsconfig": "^6.0.0",
+        "concurrently": "^9.1.0",
         "knip": "^5.36.7",
         "nx": "20.1.0",
         "prettier": "3.3.3"

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
   },
   "devDependencies": {
     "@sindresorhus/tsconfig": "^6.0.0",
+    "concurrently": "^9.1.0",
     "knip": "^5.36.7",
     "nx": "20.1.0",
     "prettier": "3.3.3",
-    "concurrently": "^9.1.0"
+    "typescript": "^5.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "nx run-many -t test",
     "lint": "nx run-many -t lint",
     "build": "nx build",
-    "build:typecheck": "nx build:typecheck",
+    "build:typecheck": "nx run-many -t build:typecheck",
     "dead-code": "npm run dead-code:base -- --include files,duplicates,dependencies,classMembers,binaries,enumMembers,nsTypes,exports,nsExports",
     "dead-code:base": "knip --config knip.mjs --tags=-knip",
     "dead-code:prod": "npm run dead-code -- --production",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "dead-code": "npm run dead-code:base -- --include files,duplicates,dependencies,classMembers,binaries,enumMembers,nsTypes,exports,nsExports",
     "dead-code:base": "knip --config knip.mjs --tags=-knip",
     "dead-code:prod": "npm run dead-code -- --production",
-    "watch": "npm run watch --workspaces"
+    "watch": "concurrently npm:watch:webpack npm:watch:typescript -r",
+    "watch:typescript": "tsc --build --watch --preserveWatchOutput",
+    "watch:webpack": "npm run watch:webpack --workspaces"
   },
   "author": "Todd Schiller",
   "license": "AGPL-3.0",
@@ -28,6 +30,7 @@
     "@sindresorhus/tsconfig": "^6.0.0",
     "knip": "^5.36.7",
     "nx": "20.1.0",
-    "prettier": "3.3.3"
+    "prettier": "3.3.3",
+    "concurrently": "^9.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "libraries/*"
   ],
   "scripts": {
-    "test": "nx test",
-    "lint": "nx lint",
+    "test": "nx run-many -t test",
+    "lint": "nx run-many -t lint",
     "build": "nx build",
     "build:typecheck": "nx build:typecheck",
     "dead-code": "npm run dead-code:base -- --include files,duplicates,dependencies,classMembers,binaries,enumMembers,nsTypes,exports,nsExports",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,13 +10,13 @@
     "resolveJsonModule": true,
     "baseUrl": ".",
     "outDir": null,
-    "declaration": false,
+    "declaration": true,
+    "composite": true,
 
     // TODO: Drop these lines to make TS stricter https://github.com/pixiebrix/pixiebrix-extension/issues/775
     "strictFunctionTypes": false,
     "noPropertyAccessFromIndexSignature": false,
     "noImplicitReturns": false,
     "noUnusedParameters": false
-  },
-  "exclude": ["node_modules"]
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig.base.json",
-  "compileOnSave": false, // Could this replace the need for our watch commands?
+  "compileOnSave": false,
   "files": [], // intentionally empty
   "references": [
-    // UPDATED BY PROJECT GENERATORS
     // All projects in the repository
+    // TODO: add @nx/js plugin which will automatically update these paths
     {
       "path": "./applications/browser-extension"
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compileOnSave": false, // Could this replace the need for our watch commands?
+  "files": [], // intentionally empty
+  "references": [
+    // UPDATED BY PROJECT GENERATORS
+    // All projects in the repository
+    {
+      "path": "./applications/browser-extension"
+    },
+    {
+      "path": "./libraries/utils"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

- Closes #9430
- Sets up incremental TS builds for our monorepo to speed up typescript compilation and development. See: https://www.typescriptlang.org/docs/handbook/project-references.html

## Discussion

- We could go with a "buildless" approach for our TS configuration but this over the long run will make our type checking a lot slower

## Demo

- Verified that `tsc --build --watch` recompiles only the utils directory when changes are made to it, and leaves the whole extension project untouched

## Future Work

- Add @nx/js plugin to handle ts tasks and auto updating tsconfig references
- Make our eslint config situation better

## Checklist

- [x] FIx lint issue
- [x] Fix knip issue

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
