### PR TITLE
Fix display property on RichTextEditor error toast

### DIFF
--- a/applications/browser-extension/src/components/richTextEditor/ErrorToast.tsx
+++ b/applications/browser-extension/src/components/richTextEditor/ErrorToast.tsx
@@ -35,10 +35,12 @@ const ErrorToast: React.FC<ErrorToastProps> = ({ error, onClose }) => (
     animation={false}
     delay={5000}
   >
+    <span>
     <FontAwesomeIcon className="mr-2" icon={faExclamationCircle} /> {error}
     <Button variant="outline-danger" onClick={onClose}>
       <FontAwesomeIcon icon={faTimes} />
     </Button>
+      </span>
   </Toast>
 );
 

--- a/applications/browser-extension/src/components/richTextEditor/RichTextEditor.module.scss
+++ b/applications/browser-extension/src/components/richTextEditor/RichTextEditor.module.scss
@@ -44,14 +44,17 @@
 }
 
 .error {
-  display: flex !important;
-  align-items: center;
   color: #dc3545;
   padding: 4px 8px;
   font-size: 0.875rem;
   position: absolute;
   bottom: 4px;
   left: 4px;
+
+  span {
+    display: flex;
+    align-items: center;
+  }
 
   :global(.btn) {
     margin-left: 8px;


### PR DESCRIPTION
## What does this PR do?

- Quickfix for an issue that @Pashaminkovsky noticed were the toast notification for displaying rich text editor errors was getting the wrong display property when hidden, preventing mouse-clicking into the editor in the bottom-left corner

## Demo

### Fixes this issue 👇 
<img width="350" alt="image" src="https://github.com/user-attachments/assets/59bd57f2-4278-4103-9782-67eac5b2d6ed">
