### PR TITLE
Add default value to Rich Text field

### DIFF
--- a/applications/browser-extension/src/components/formBuilder/formBuilderHelpers.ts
+++ b/applications/browser-extension/src/components/formBuilder/formBuilderHelpers.ts
@@ -68,11 +68,6 @@ export const FIELD_TYPES_WITHOUT_DEFAULT = [
   }),
   stringifyUiType({
     propertyType: "string",
-    uiWidget: "richText",
-    propertyFormat: "html",
-  }),
-  stringifyUiType({
-    propertyType: "string",
     uiWidget: "imageCrop",
   }),
   stringifyUiType({ propertyType: "string", uiWidget: "database" }),

--- a/applications/browser-extension/src/components/formBuilder/widgets/RichTextWidget.tsx
+++ b/applications/browser-extension/src/components/formBuilder/widgets/RichTextWidget.tsx
@@ -28,6 +28,7 @@ const RichTextWidget: React.FunctionComponent<WidgetProps> = ({
   disabled,
   readonly,
   options,
+  value
 }) => {
   const { database } = options;
 
@@ -45,6 +46,7 @@ const RichTextWidget: React.FunctionComponent<WidgetProps> = ({
       }}
       editable={!(disabled || readonly)}
       assetDatabaseId={validateUUID(database)}
+      content={typeof value === "string" ? value : ""}
     />
   );
 };


### PR DESCRIPTION
## What does this PR do?

- Adds Default Value to the Rich Text field
- We had originally disabled it due to requirements for validation, but forgot to add it back in as acceptance criteria for the Image Upload feature

## Discussion

- As discussed with @Pashaminkovsky, follow-up work is to validate and properly throw errors if default value is not compatible with the Rich Text editor; we are leaving it up to the Mod Developer to make sure that they're passing html

## Demo

<img width="1912" alt="Screenshot 2024-11-14 at 5 19 27 PM" src="https://github.com/user-attachments/assets/0d9d7cc0-6c46-48f2-848e-4803a3225b71">

https://www.loom.com/share/c9af0bf99ba54c9a8f815bb4fd7a7c11
