### PR TITLE
fix logic for setting alternate background in mod list items

### DIFF
--- a/applications/browser-extension/src/pageEditor/modListingPanel/ModListItem.tsx
+++ b/applications/browser-extension/src/pageEditor/modListingPanel/ModListItem.tsx
@@ -53,6 +53,7 @@ const ModListItem: React.FC<
 
   const isModComponentSelected = activeModComponentId != null;
   const isModSelected = activeModId === modId && !isModComponentSelected;
+  const hasModBackground = activeModId === modId && isModComponentSelected;
   const isExpanded = expandedModId === modId;
 
   // TODO: Fix this so it pulls from registry, after registry single-item-api-fetch is implemented
@@ -76,8 +77,8 @@ const ModListItem: React.FC<
         eventKey={modId}
         as={ListGroup.Item}
         className={cx(styles.root, "list-group-item-action", {
-          // Set the alternate background if a mod component in this mod is active
-          [styles.modBackground ?? ""]: isModSelected || isModComponentSelected,
+          // Set the alternate background for the mod if a mod component in this mod is active
+          [styles.modBackground ?? ""]: hasModBackground,
         })}
         tabIndex={0} // Avoid using `button` because this item includes more buttons #2343
         active={isModSelected}


### PR DESCRIPTION
## What does this PR do?

- Fixes bug with the logic to set the alternate background in ModListItem

## Demo

- <img width="305" alt="image" src="https://github.com/user-attachments/assets/28be3678-8126-44cd-ac42-9a51034ae2c1">

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
