### PR TITLE
Bugfix: Don't throw error in FormPreview if assetDatabase is not a UUID

### DIFF
--- a/applications/browser-extension/src/components/formBuilder/widgets/RichTextWidget.tsx
+++ b/applications/browser-extension/src/components/formBuilder/widgets/RichTextWidget.tsx
@@ -18,7 +18,7 @@
 import React from "react";
 import { type WidgetProps } from "@rjsf/utils";
 import RichTextEditor from "@/components/richTextEditor/RichTextEditor";
-import { validateUUID } from "@/types/helpers";
+import {isUUID} from "@/types/helpers";
 
 const RichTextWidget: React.FunctionComponent<WidgetProps> = ({
   id,
@@ -45,7 +45,7 @@ const RichTextWidget: React.FunctionComponent<WidgetProps> = ({
         onBlur(id, editor.getHTML());
       }}
       editable={!(disabled || readonly)}
-      assetDatabaseId={validateUUID(database)}
+      assetDatabaseId={typeof database === "string" && isUUID(database) ? database : null}
       content={typeof value === "string" ? value : ""}
     />
   );

--- a/applications/browser-extension/src/components/richTextEditor/RichTextEditor.tsx
+++ b/applications/browser-extension/src/components/richTextEditor/RichTextEditor.tsx
@@ -29,7 +29,7 @@ import ErrorToast from "@/components/richTextEditor/ErrorToast";
 
 type EditorProps = EditorProviderProps & {
   // A PixieBrix asset database ID to use for uploading images. If not included, the image extension will be disabled.
-  assetDatabaseId?: UUID;
+  assetDatabaseId?: UUID | null;
 };
 
 interface ImageWithAssetDatabaseOptions extends ImageOptions {


### PR DESCRIPTION
## What does this PR do?

- Fixes an issue where the FormPreview will throw if a Rich Text field specifies an asset database via mod option, but the option has not be configured (e.g. under "current inputs")

## Fixes this 👇 

<img width="1537" alt="image" src="https://github.com/user-attachments/assets/8f6244cc-bc0b-4050-948b-ee08c6ccf2e5">
