### PR TITLE
Fix flaky mod definitions test

### DIFF
--- a/.idea/nx-angular-config.xml
+++ b/.idea/nx-angular-config.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="NxAngularConfigService" workspaceLocation="file://$PROJECT_DIR$/nx.json" />
+  <component name="NxAngularConfigService" workspaceLocation="file://$PROJECT_DIR$/nx.json">
+    <projects>
+      <project name="@pixiebrix/extension" file="file://$PROJECT_DIR$/applications/browser-extension/project.json" />
+    </projects>
+  </component>
 </project>

--- a/applications/browser-extension/src/modDefinitions/modDefinitions.test.tsx
+++ b/applications/browser-extension/src/modDefinitions/modDefinitions.test.tsx
@@ -162,6 +162,7 @@ test("load mod definitions and save one", async () => {
     API_PATHS.REGISTRY_BRICKS,
   ]);
 
+  // Try to avoid "Mod definitions not loaded yet. Try again." race in the useSaveMod hook
   await waitFor(async () => {
     expect(screen.queryByText("Not Fetching")).not.toBeInTheDocument();
   });

--- a/applications/browser-extension/src/modDefinitions/modDefinitions.test.tsx
+++ b/applications/browser-extension/src/modDefinitions/modDefinitions.test.tsx
@@ -151,21 +151,27 @@ test("load mod definitions and save one", async () => {
     API_PATHS.REGISTRY_BRICKS,
   ]);
 
+  // Avoid race where mod definitions/editable package queries aren't loaded in the useSaveMod hook yet
+  await waitFor(async () => {
+    expect(screen.queryByText("Not Fetching")).not.toBeInTheDocument();
+  });
+
+  expect(appApiMock.history.get.map((x) => x.url)).toEqual([
+    API_PATHS.REGISTRY_BRICKS,
+    // `useSaveMod` hook fetches editable packages
+    API_PATHS.BRICKS,
+  ]);
+
   await userEvent.click(
     await screen.findByRole("button", { name: "Save Mod" }),
   );
 
   expect(appApiMock.history.get.map((x) => x.url)).toEqual([
     API_PATHS.REGISTRY_BRICKS,
-    // `useSaveMod` re-fetches definitions/editable packages
     API_PATHS.BRICKS,
+    // `useSaveMod` re-fetches definitions/editable packages
     API_PATHS.REGISTRY_BRICKS,
   ]);
-
-  // Try to avoid "Mod definitions not loaded yet. Try again." race in the useSaveMod hook
-  await waitFor(async () => {
-    expect(screen.queryByText("Not Fetching")).not.toBeInTheDocument();
-  });
 
   await userEvent.type(
     await screen.findByRole("textbox", { name: "Message" }),

--- a/applications/browser-extension/src/modDefinitions/modDefinitions.test.tsx
+++ b/applications/browser-extension/src/modDefinitions/modDefinitions.test.tsx
@@ -33,7 +33,7 @@ import { type AsyncState } from "@/types/sliceTypes";
 import { API_PATHS } from "@/data/service/urlPaths";
 import AsyncButton from "@/components/AsyncButton";
 import userEvent from "@testing-library/user-event";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import SaveModVersionModal from "@/pageEditor/modListingPanel/modals/SaveModVersionModal";
 
 beforeAll(() => {
@@ -161,6 +161,10 @@ test("load mod definitions and save one", async () => {
     API_PATHS.BRICKS,
     API_PATHS.REGISTRY_BRICKS,
   ]);
+
+  await waitFor(async () => {
+    expect(screen.queryByText("Not Fetching")).not.toBeInTheDocument();
+  });
 
   await userEvent.type(
     await screen.findByRole("textbox", { name: "Message" }),


### PR DESCRIPTION
## What does this PR do?

- Fix flaky mod definitions test to prevent "Mod definitions not loaded yet. Try again." error

## Remaining Work

- [x] Fix/confirm fix

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
